### PR TITLE
Add Proposer (but not cert) to unsigned proposer blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ scripts/.build_image_gopath/
 
 tests/e2e/e2e.test
 tests/upgrade/upgrade.test
+
+launch.sh

--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -209,6 +209,7 @@ func (p *postForkCommonComponents) buildChild(
 			newTimestamp,
 			pChainHeight,
 			innerBlock.Bytes(),
+			p.vm.ctx.NodeID,
 		)
 		if err != nil {
 			return nil, err

--- a/vms/proposervm/block/block_test.go
+++ b/vms/proposervm/block/block_test.go
@@ -43,7 +43,7 @@ func TestVerifyNoCertWithSignature(t *testing.T) {
 
 	assert := assert.New(t)
 
-	builtBlockIntf, err := BuildUnsigned(parentID, timestamp, pChainHeight, innerBlockBytes)
+	builtBlockIntf, err := BuildUnsigned(parentID, timestamp, pChainHeight, innerBlockBytes, ids.ShortID{})
 	assert.NoError(err)
 
 	builtBlock := builtBlockIntf.(*statelessBlock)

--- a/vms/proposervm/block/build.go
+++ b/vms/proposervm/block/build.go
@@ -30,6 +30,7 @@ func BuildUnsigned(
 	timestamp time.Time,
 	pChainHeight uint64,
 	blockBytes []byte,
+	proposerID ids.ShortID,
 ) (SignedBlock, error) {
 	var block SignedBlock = &statelessBlock{
 		StatelessBlock: statelessUnsignedBlock{
@@ -40,6 +41,7 @@ func BuildUnsigned(
 			Block:        blockBytes,
 		},
 		timestamp: timestamp,
+		proposer:  proposerID,
 	}
 
 	bytes, err := c.Marshal(version, &block)

--- a/vms/proposervm/block/build_test.go
+++ b/vms/proposervm/block/build_test.go
@@ -71,7 +71,7 @@ func TestBuildUnsigned(t *testing.T) {
 
 	assert := assert.New(t)
 
-	builtBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, innerBlockBytes)
+	builtBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, innerBlockBytes, ids.ShortID{})
 	assert.NoError(err)
 
 	assert.Equal(parentID, builtBlock.ParentID())

--- a/vms/proposervm/block/parse_test.go
+++ b/vms/proposervm/block/parse_test.go
@@ -109,7 +109,7 @@ func TestParseUnsigned(t *testing.T) {
 	pChainHeight := uint64(2)
 	innerBlockBytes := []byte{3}
 
-	builtBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, innerBlockBytes)
+	builtBlock, err := BuildUnsigned(parentID, timestamp, pChainHeight, innerBlockBytes, ids.ShortID{})
 	assert.NoError(err)
 
 	builtBlockBytes := builtBlock.Bytes()

--- a/vms/proposervm/indexer/height_indexer_test.go
+++ b/vms/proposervm/indexer/height_indexer_test.go
@@ -57,6 +57,7 @@ func TestHeightBlockIndexPostFork(t *testing.T) {
 			dummyTS,
 			dummyPCH,
 			blockBytes[:],
+			ids.ShortID{},
 		)
 		assert.NoError(err)
 		assert.NoError(storedState.PutBlock(postForkStatelessBlk, choices.Accepted))
@@ -135,6 +136,7 @@ func TestHeightBlockIndexAcrossFork(t *testing.T) {
 			dummyTS,
 			dummyPCH,
 			blockBytes[:],
+			ids.ShortID{},
 		)
 		assert.NoError(err)
 		assert.NoError(storedState.PutBlock(postForkStatelessBlk, choices.Accepted))
@@ -217,6 +219,7 @@ func TestHeightBlockIndexResumeFromCheckPoint(t *testing.T) {
 			dummyTS,
 			dummyPCH,
 			blockBytes[:],
+			ids.ShortID{},
 		)
 		assert.NoError(err)
 		assert.NoError(storedState.PutBlock(postForkStatelessBlk, choices.Accepted))

--- a/vms/proposervm/post_fork_block_test.go
+++ b/vms/proposervm/post_fork_block_test.go
@@ -186,6 +186,7 @@ func TestBlockVerify_PostForkBlock_ParentChecks(t *testing.T) {
 		prntProBlk.Timestamp().Add(proposer.MaxDelay),
 		pChainHeight,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -364,6 +365,7 @@ func TestBlockVerify_PostForkBlock_TimestampChecks(t *testing.T) {
 		AtSubWindowEnd,
 		pChainHeight,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -490,6 +492,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 		childCoreBlk.Timestamp(),
 		prntBlkPChainHeight,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -508,6 +511,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 		childCoreBlk.Timestamp(),
 		prntBlkPChainHeight+1,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -524,6 +528,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 		childCoreBlk.Timestamp(),
 		currPChainHeight,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -539,6 +544,7 @@ func TestBlockVerify_PostForkBlock_PChainHeightChecks(t *testing.T) {
 		childCoreBlk.Timestamp(),
 		currPChainHeight*2,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -692,6 +698,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 		childCoreBlk.Timestamp(),
 		prntBlkPChainHeight,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -710,6 +717,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 		childCoreBlk.Timestamp(),
 		prntBlkPChainHeight+1,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -726,6 +734,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 		childCoreBlk.Timestamp(),
 		currPChainHeight,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -741,6 +750,7 @@ func TestBlockVerify_PostForkBlockBuiltOnOption_PChainHeightChecks(t *testing.T)
 		childCoreBlk.Timestamp(),
 		currPChainHeight*2,
 		childCoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -1126,6 +1136,7 @@ func TestBlockVerify_PostForkBlock_PChainTooLow(t *testing.T) {
 		coreGenBlk.Timestamp(),
 		4,
 		coreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("failed to build new child block")

--- a/vms/proposervm/post_fork_option_test.go
+++ b/vms/proposervm/post_fork_option_test.go
@@ -654,6 +654,7 @@ func TestOptionTimestampValidity(t *testing.T) {
 		coreGenBlk.Timestamp(),
 		0,
 		coreOracleBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/vms/proposervm/pre_fork_block.go
+++ b/vms/proposervm/pre_fork_block.go
@@ -190,6 +190,7 @@ func (b *preForkBlock) buildChild() (Block, error) {
 		newTimestamp,
 		pChainHeight,
 		innerBlock.Bytes(),
+		b.vm.ctx.NodeID,
 	)
 	if err != nil {
 		return nil, err

--- a/vms/proposervm/vm_byzantine_test.go
+++ b/vms/proposervm/vm_byzantine_test.go
@@ -289,6 +289,7 @@ func TestInvalidByzantineProposerPreForkParent(t *testing.T) {
 		yBlock.Timestamp(),
 		0,
 		yBlockBytes,
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -490,6 +491,7 @@ func TestBlockVerify_InvalidPostForkOption(t *testing.T) {
 		coreGenBlk.Timestamp(),
 		uint64(2000),
 		yBlock.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatalf("fail to manually build a block due to %s", err)

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -623,6 +623,7 @@ func TestTwoProBlocksWithSameParentCanBothVerify(t *testing.T) {
 		netcoreBlk.Timestamp(),
 		pChainHeight,
 		netcoreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal("could not build stateless block")
@@ -924,6 +925,7 @@ func TestExpiredBuildBlock(t *testing.T) {
 		coreBlk.Timestamp(),
 		0,
 		coreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1029,6 +1031,7 @@ func TestInnerBlockDeduplication(t *testing.T) {
 		coreBlk.Timestamp(),
 		0,
 		coreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1038,6 +1041,7 @@ func TestInnerBlockDeduplication(t *testing.T) {
 		coreBlk.Timestamp(),
 		1,
 		coreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1208,6 +1212,7 @@ func TestInnerVMRollback(t *testing.T) {
 		coreBlk.Timestamp(),
 		0,
 		coreBlk.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1320,6 +1325,7 @@ func TestBuildBlockDuringWindow(t *testing.T) {
 		coreBlk0.Timestamp(),
 		0,
 		coreBlk0.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1441,6 +1447,7 @@ func TestTwoForks_OneIsAccepted(t *testing.T) {
 		gBlock.Timestamp(),
 		defaultPChainHeight,
 		yBlock.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatalf("fail to manually build a block due to %s", err)
@@ -1552,6 +1559,7 @@ func TestTooFarAdvanced(t *testing.T) {
 		aBlock.Timestamp().Add(maxSkew),
 		defaultPChainHeight,
 		yBlock.Bytes(),
+		ids.ShortID{},
 	)
 	if err != nil {
 		t.Fatalf("fail to manually build a block due to %s", err)
@@ -1575,6 +1583,7 @@ func TestTooFarAdvanced(t *testing.T) {
 		aBlock.Timestamp().Add(proposer.MaxDelay),
 		defaultPChainHeight,
 		yBlock.Bytes(),
+		ids.ShortID{},
 	)
 
 	if err != nil {


### PR DESCRIPTION
During current testing phase in general unsigned proposerBlocks are built because we are out of max window time (30secs) but we have an accepted parent [more details here](https://github.com/chain4travel/caminogo/blob/chain4travel/vms/proposervm/README.md).

To get a better overview in Magellan (using index API which returns proposerBlocks for P/C chain) this PR adds the proposer (nodeId) also to unsigned proposer blocks.