### PR TITLE
Validator fixed stake

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,6 @@ var (
 	errStakingDisableOnPublicNetwork = errors.New("staking disabled on public network")
 	errAuthPasswordTooWeak           = errors.New("API auth password is not strong enough")
 	errInvalidUptimeRequirement      = errors.New("uptime requirement must be in the range [0, 1]")
-	errMinValidatorStakeAboveMax     = errors.New("minimum validator stake can't be greater than maximum validator stake")
 	errInvalidMinStakeDuration       = errors.New("min stake duration must be > 0")
 	errMinStakeDurationAboveMax      = errors.New("max stake duration can't be less than min stake duration")
 	errStakeMaxConsumptionBelowMin   = errors.New("stake max consumption can't be less than min stake consumption")
@@ -661,8 +660,6 @@ func getStakingConfig(v *viper.Viper, networkID uint32) (node.StakingConfig, err
 	}
 	if !constants.IsActiveNetwork(networkID) {
 		config.UptimeRequirement = v.GetFloat64(UptimeRequirementKey)
-		config.MinValidatorStake = v.GetUint64(MinValidatorStakeKey)
-		config.MaxValidatorStake = v.GetUint64(MaxValidatorStakeKey)
 		config.MinStakeDuration = v.GetDuration(MinStakeDurationKey)
 		config.MaxStakeDuration = v.GetDuration(MaxStakeDurationKey)
 		config.RewardConfig.MaxConsumptionRate = v.GetUint64(StakeMaxConsumptionRateKey)
@@ -672,8 +669,6 @@ func getStakingConfig(v *viper.Viper, networkID uint32) (node.StakingConfig, err
 		switch {
 		case config.UptimeRequirement < 0 || config.UptimeRequirement > 1:
 			return node.StakingConfig{}, errInvalidUptimeRequirement
-		case config.MinValidatorStake > config.MaxValidatorStake:
-			return node.StakingConfig{}, errMinValidatorStakeAboveMax
 		case config.MinStakeDuration <= 0:
 			return node.StakingConfig{}, errInvalidMinStakeDuration
 		case config.MaxStakeDuration < config.MinStakeDuration:

--- a/config/flags.go
+++ b/config/flags.go
@@ -249,10 +249,6 @@ func addNodeFlags(fs *flag.FlagSet) {
 	fs.Uint64(StakingDisabledWeightKey, 100, "Weight to provide to each peer when staking is disabled")
 	// Uptime Requirement
 	fs.Float64(UptimeRequirementKey, genesis.LocalParams.UptimeRequirement, "Fraction of time a validator must be online to receive rewards")
-	// Minimum Stake required to validate the Primary Network
-	fs.Uint64(MinValidatorStakeKey, genesis.LocalParams.MinValidatorStake, "Minimum stake, in nAVAX, required to validate the primary network")
-	// Maximum Stake that can be staked to a validator on the Primary Network
-	fs.Uint64(MaxValidatorStakeKey, genesis.LocalParams.MaxValidatorStake, "Maximum stake, in nAVAX, that can be placed on a validator on the primary network")
 	// Minimum Stake Duration
 	fs.Duration(MinStakeDurationKey, genesis.LocalParams.MinStakeDuration, "Minimum staking duration")
 	// Maximum Stake Duration

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -85,6 +85,8 @@ type Config struct {
 	InitialStakedFunds         []ids.ShortID `json:"initialStakedFunds"`
 	InitialStakers             []Staker      `json:"initialStakers"`
 
+	ValidatorBondAmount uint64 `json:"validatorBondAmount"`
+
 	CChainGenesis string `json:"cChainGenesis"`
 
 	Message string `json:"message"`

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -45,6 +45,7 @@ var (
 	errNoInitiallyStakedFunds = errors.New("initial staked funds cannot be empty")
 	errNoSupply               = errors.New("initial supply must be > 0")
 	errNoStakeDuration        = errors.New("initial stake duration must be > 0")
+	errNoValidatorBondAmount  = errors.New("validator bond amount must be > 0")
 	errNoStakers              = errors.New("initial stakers must be > 0")
 	errNoCChainGenesis        = errors.New("C-Chain genesis cannot be empty")
 	errNoTxs                  = errors.New("genesis creates no transactions")
@@ -150,6 +151,10 @@ func validateConfig(networkID uint32, config *Config) error {
 
 	if len(config.InitialStakers) == 0 {
 		return errNoStakers
+	}
+
+	if config.ValidatorBondAmount == 0 {
+		return errNoValidatorBondAmount
 	}
 
 	offsetTimeRequired := config.InitialStakeDurationOffset * uint64(len(config.InitialStakers)-1)
@@ -337,12 +342,13 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 
 	// Specify the initial state of the Platform Chain
 	platformvmArgs := platformvm.BuildGenesisArgs{
-		AvaxAssetID:   avaxAssetID,
-		NetworkID:     json.Uint32(config.NetworkID),
-		Time:          json.Uint64(config.StartTime),
-		InitialSupply: json.Uint64(initialSupply),
-		Message:       config.Message,
-		Encoding:      defaultEncoding,
+		AvaxAssetID:         avaxAssetID,
+		NetworkID:           json.Uint32(config.NetworkID),
+		Time:                json.Uint64(config.StartTime),
+		InitialSupply:       json.Uint64(initialSupply),
+		Message:             config.Message,
+		Encoding:            defaultEncoding,
+		ValidatorBondAmount: json.Uint64(config.ValidatorBondAmount),
 	}
 	for _, allocation := range config.Allocations {
 		if initiallyStaked.Contains(allocation.AVAXAddr) {

--- a/genesis/genesis_camino.go
+++ b/genesis/genesis_camino.go
@@ -20,7 +20,7 @@ var (
 				"initialAmount": 0,
 				"unlockSchedule": [
 					{
-						"amount": 2000000000000,
+						"amount": 100000000000000,
 						"locktime": 2524604400
 					}
 				]
@@ -48,6 +48,7 @@ var (
 				"rewardAddress": "X-camino1m4nr983lhd4p4nfsqk3a6a9mejugnn73f83vuy"
 			}
 		],
+		"validatorBondAmount": 100000000000000,
 		"cChainGenesis": "{\"config\":{\"chainId\":500,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0,\"apricotPhase3BlockTimestamp\":0,\"apricotPhase4BlockTimestamp\":0,\"apricotPhase5BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
 		"message": "Travel around the world!"
 	}`
@@ -62,8 +63,6 @@ var (
 		},
 		StakingConfig: StakingConfig{
 			UptimeRequirement: .8, // 80%
-			MinValidatorStake: 2 * units.KiloAvax,
-			MaxValidatorStake: 3 * units.MegaAvax,
 			MinStakeDuration:  14 * 24 * time.Hour,
 			MaxStakeDuration:  365 * 24 * time.Hour,
 			RewardConfig: reward.Config{

--- a/genesis/genesis_columbus.go
+++ b/genesis/genesis_columbus.go
@@ -20,7 +20,7 @@ var (
 				"initialAmount": 0,
 				"unlockSchedule": [
 					{
-						"amount": 2000000000000,
+						"amount": 100000000000000,
 						"locktime": 2524604400
 					}
 				]
@@ -48,6 +48,7 @@ var (
 				"rewardAddress": "X-columbus1m4nr983lhd4p4nfsqk3a6a9mejugnn73ju0gav"
 			}
 		],
+		"validatorBondAmount": 100000000000000,
 		"cChainGenesis": "{\"config\":{\"chainId\":502,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0,\"apricotPhase3BlockTimestamp\":0,\"apricotPhase4BlockTimestamp\":0,\"apricotPhase5BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
 		"message": "Have a nice trip!"
 	}`
@@ -62,8 +63,6 @@ var (
 		},
 		StakingConfig: StakingConfig{
 			UptimeRequirement: .8, // 80%
-			MinValidatorStake: 2 * units.KiloAvax,
-			MaxValidatorStake: 3 * units.MegaAvax,
 			MinStakeDuration:  24 * time.Hour,
 			MaxStakeDuration:  365 * 24 * time.Hour,
 			RewardConfig: reward.Config{

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -109,6 +109,7 @@ var (
 				"rewardAddress": "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
 			}
 		],
+		"validatorBondAmount": 2000000000000000,
 		"cChainGenesis": "{\"config\":{\"chainId\":43112,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC\":{\"balance\":\"0x295BE96E64066972000000\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
 		"message": "{{ fun_quote }}"
 	}`
@@ -123,8 +124,6 @@ var (
 		},
 		StakingConfig: StakingConfig{
 			UptimeRequirement: .8, // 80%
-			MinValidatorStake: 2 * units.KiloAvax,
-			MaxValidatorStake: 3 * units.MegaAvax,
 			MinStakeDuration:  24 * time.Hour,
 			MaxStakeDuration:  365 * 24 * time.Hour,
 			RewardConfig: reward.Config{

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -228,6 +228,7 @@ var (
 				"rewardAddress": "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
 			}
 		],
+		"validatorBondAmount": 2000000000000000,
 		"cChainGenesis": "{\"config\":{\"chainId\":43112,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
 		"message": "{{ fun_quote }}"
 	}`
@@ -272,7 +273,7 @@ func TestGenesisFromFile(t *testing.T) {
 		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
-			expected:     "a516ca17d58001f754e2d21af4936cc8f5208dcc1c4180fdf13cb69c478f1964",
+			expected:     "08d0173d7cade86c5168def8f39a72a1b7b4c1791dd8605d373a4a152e3ee369",
 		},
 		"custom (networkID mismatch)": {
 			networkID:    9999,
@@ -351,7 +352,7 @@ func TestGenesisFromFlag(t *testing.T) {
 		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
-			expected:     "a516ca17d58001f754e2d21af4936cc8f5208dcc1c4180fdf13cb69c478f1964",
+			expected:     "08d0173d7cade86c5168def8f39a72a1b7b4c1791dd8605d373a4a152e3ee369",
 		},
 		"custom (networkID mismatch)": {
 			networkID:    9999,

--- a/genesis/params.go
+++ b/genesis/params.go
@@ -24,11 +24,6 @@ import (
 type StakingConfig struct {
 	// Staking uptime requirements
 	UptimeRequirement float64 `json:"uptimeRequirement"`
-	// Minimum stake, in nAVAX, required to validate the primary network
-	MinValidatorStake uint64 `json:"minValidatorStake"`
-	// Maximum stake, in nAVAX, allowed to be placed on a single validator in
-	// the primary network
-	MaxValidatorStake uint64 `json:"maxValidatorStake"`
 	// MinStakeDuration is the minimum amount of time a validator can validate
 	// for in a single period.
 	MinStakeDuration time.Duration `json:"minStakeDuration"`

--- a/genesis/unparsed_config.go
+++ b/genesis/unparsed_config.go
@@ -103,6 +103,8 @@ type UnparsedConfig struct {
 	InitialStakedFunds         []string         `json:"initialStakedFunds"`
 	InitialStakers             []UnparsedStaker `json:"initialStakers"`
 
+	ValidatorBondAmount uint64 `json:"validatorBondAmount"`
+
 	CChainGenesis string `json:"cChainGenesis"`
 
 	Message string `json:"message"`
@@ -117,6 +119,7 @@ func (uc UnparsedConfig) Parse() (Config, error) {
 		InitialStakeDurationOffset: uc.InitialStakeDurationOffset,
 		InitialStakedFunds:         make([]ids.ShortID, len(uc.InitialStakedFunds)),
 		InitialStakers:             make([]Staker, len(uc.InitialStakers)),
+		ValidatorBondAmount:        uc.ValidatorBondAmount,
 		CChainGenesis:              uc.CChainGenesis,
 		Message:                    uc.Message,
 	}

--- a/nat/upnp.go
+++ b/nat/upnp.go
@@ -118,7 +118,8 @@ func (r *upnpRouter) ExternalIP() (net.IP, error) {
 }
 
 func (r *upnpRouter) MapPort(protocol string, intPort, extPort uint16,
-	desc string, duration time.Duration) error {
+	desc string, duration time.Duration,
+) error {
 	ip, err := r.localIP()
 	if err != nil {
 		return nil

--- a/vms/platformvm/add_subnet_validator_tx_test.go
+++ b/vms/platformvm/add_subnet_validator_tx_test.go
@@ -198,7 +198,6 @@ func TestAddSubnetValidatorTxExecute(t *testing.T) {
 	DSEndTime := DSStartTime.Add(5 * defaultMinStakingDuration)
 
 	addDSTx, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,                    // stake amount
 		uint64(DSStartTime.Unix()),              // start time
 		uint64(DSEndTime.Unix()),                // end time
 		pendingDSValidatorID,                    // node ID

--- a/vms/platformvm/add_validator_tx.go
+++ b/vms/platformvm/add_validator_tx.go
@@ -34,9 +34,9 @@ import (
 var (
 	errNilTx           = errors.New("tx is nil")
 	errWeightTooSmall  = errors.New("weight of this validator is too low")
-	errWeightTooLarge  = errors.New("weight of this validator is too large")
 	errStakeTooShort   = errors.New("staking period is too short")
 	errStakeTooLong    = errors.New("staking period is too long")
+	errWrongBondAmount = errors.New("wrong bond amount for this validator")
 	errFutureStakeTime = fmt.Errorf("staker is attempting to start staking more than %s ahead of the current chain time", maxFutureStartTime)
 
 	_ UnsignedProposalTx = &UnsignedAddValidatorTx{}
@@ -154,11 +154,8 @@ func (tx *UnsignedAddValidatorTx) Execute(
 		return nil, nil, err
 	}
 
-	switch {
-	case tx.Validator.Wght < vm.MinValidatorStake: // Ensure validator is staking at least the minimum amount
-		return nil, nil, errWeightTooSmall
-	case tx.Validator.Wght > vm.MaxValidatorStake: // Ensure validator isn't staking too much
-		return nil, nil, errWeightTooLarge
+	if tx.Validator.Wght != parentState.GetValidatorBondAmount() {
+		return nil, nil, errWrongBondAmount
 	}
 
 	duration := tx.Validator.Duration()
@@ -262,7 +259,6 @@ func (tx *UnsignedAddValidatorTx) InitiallyPrefersCommit(vm *VM) bool {
 
 // NewAddValidatorTx returns a new NewAddValidatorTx
 func (vm *VM) newAddValidatorTx(
-	stakeAmt, // Amount the validator stakes
 	startTime, // Unix time they start validating
 	endTime uint64, // Unix time they stop validating
 	nodeID ids.ShortID, // ID of the node we want to validate with
@@ -270,7 +266,8 @@ func (vm *VM) newAddValidatorTx(
 	keys []*crypto.PrivateKeySECP256K1R, // Keys providing the staked tokens
 	changeAddr ids.ShortID, // Address to send change to, if there is any
 ) (*Tx, error) {
-	ins, unlockedOuts, lockedOuts, signers, err := vm.stake(keys, stakeAmt, vm.AddStakerTxFee, changeAddr)
+	bondAmount := vm.internalState.GetValidatorBondAmount()
+	ins, unlockedOuts, lockedOuts, signers, err := vm.stake(keys, bondAmount, vm.AddStakerTxFee, changeAddr)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
 	}
@@ -286,7 +283,7 @@ func (vm *VM) newAddValidatorTx(
 			NodeID: nodeID,
 			Start:  startTime,
 			End:    endTime,
-			Wght:   stakeAmt,
+			Wght:   bondAmount,
 		},
 		Stake: lockedOuts,
 		RewardsOwner: &secp256k1fx.OutputOwners{

--- a/vms/platformvm/add_validator_tx_test.go
+++ b/vms/platformvm/add_validator_tx_test.go
@@ -50,7 +50,6 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 
 	// Case 3: Wrong Network ID
 	tx, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,
 		uint64(defaultValidateStartTime.Unix()),
 		uint64(defaultValidateEndTime.Unix()),
 		nodeID,
@@ -71,7 +70,6 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 
 	// Case: Stake owner has no addresses
 	tx, err = vm.newAddValidatorTx(
-		vm.MinValidatorStake,
 		uint64(defaultValidateStartTime.Unix()),
 		uint64(defaultValidateEndTime.Unix()),
 		nodeID,
@@ -86,7 +84,7 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 	tx.UnsignedTx.(*UnsignedAddValidatorTx).Stake = []*avax.TransferableOutput{{
 		Asset: avax.Asset{ID: avaxAssetID},
 		Out: &secp256k1fx.TransferOutput{
-			Amt: vm.MinValidatorStake,
+			Amt: vm.internalState.GetValidatorBondAmount(),
 			OutputOwners: secp256k1fx.OutputOwners{
 				Locktime:  0,
 				Threshold: 1,
@@ -102,7 +100,6 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 
 	// Case: Rewards owner has no addresses
 	tx, err = vm.newAddValidatorTx(
-		vm.MinValidatorStake,
 		uint64(defaultValidateStartTime.Unix()),
 		uint64(defaultValidateEndTime.Unix()),
 		nodeID,
@@ -127,7 +124,6 @@ func TestAddValidatorTxSyntacticVerify(t *testing.T) {
 
 	// Case: Valid
 	if tx, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,
 		uint64(defaultValidateStartTime.Unix()),
 		uint64(defaultValidateEndTime.Unix()),
 		nodeID,
@@ -161,7 +157,6 @@ func TestAddValidatorTxExecute(t *testing.T) {
 
 	// Case: Validator's start time too early
 	if tx, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,
 		uint64(defaultValidateStartTime.Unix())-1,
 		uint64(defaultValidateEndTime.Unix()),
 		nodeID,
@@ -176,7 +171,6 @@ func TestAddValidatorTxExecute(t *testing.T) {
 
 	// Case: Validator's start time too far in the future
 	if tx, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,
 		uint64(defaultValidateStartTime.Add(maxFutureStartTime).Unix()+1),
 		uint64(defaultValidateStartTime.Add(maxFutureStartTime).Add(defaultMinStakingDuration).Unix()+1),
 		nodeID,
@@ -191,7 +185,6 @@ func TestAddValidatorTxExecute(t *testing.T) {
 
 	// Case: Validator already validating primary network
 	if tx, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,
 		uint64(defaultValidateStartTime.Unix()),
 		uint64(defaultValidateEndTime.Unix()),
 		nodeID, // node ID
@@ -211,8 +204,7 @@ func TestAddValidatorTxExecute(t *testing.T) {
 	}
 	startTime := defaultGenesisTime.Add(1 * time.Second)
 	tx, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,     // stake amount
-		uint64(startTime.Unix()), // start time
+		uint64(startTime.Unix()),                                // start time
 		uint64(startTime.Add(defaultMinStakingDuration).Unix()), // end time
 		nodeID,                     // node ID
 		key2.PublicKey().Address(), // reward address
@@ -238,7 +230,6 @@ func TestAddValidatorTxExecute(t *testing.T) {
 
 	// Case: Validator doesn't have enough tokens to cover stake amount
 	if _, err := vm.newAddValidatorTx( // create the tx
-		vm.MinValidatorStake,
 		uint64(defaultValidateStartTime.Unix()),
 		uint64(defaultValidateEndTime.Unix()),
 		nodeID,

--- a/vms/platformvm/advance_time_tx_test.go
+++ b/vms/platformvm/advance_time_tx_test.go
@@ -594,7 +594,6 @@ func TestAdvanceTimeTxUnmarshal(t *testing.T) {
 
 func addPendingValidator(vm *VM, startTime time.Time, endTime time.Time, nodeID ids.ShortID, keys []*crypto.PrivateKeySECP256K1R) (*Tx, error) {
 	addPendingValidatorTx, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,
 		uint64(startTime.Unix()),
 		uint64(endTime.Unix()),
 		nodeID,

--- a/vms/platformvm/cache_versioned_state.go
+++ b/vms/platformvm/cache_versioned_state.go
@@ -56,6 +56,9 @@ type MutableState interface {
 	GetCurrentSupply() uint64
 	SetCurrentSupply(uint64)
 
+	SetValidatorBondAmount(currentSupply uint64)
+	GetValidatorBondAmount() uint64
+
 	GetSubnets() ([]*Tx, error)
 	AddSubnet(createSubnetTx *Tx)
 
@@ -81,7 +84,8 @@ type versionedStateImpl struct {
 
 	timestamp time.Time
 
-	currentSupply uint64
+	currentSupply       uint64
+	validatorBondAmount uint64
 
 	addedSubnets  []*Tx
 	cachedSubnets []*Tx
@@ -120,6 +124,7 @@ func newVersionedState(
 		pendingStakerChainState: pending,
 		timestamp:               ps.GetTimestamp(),
 		currentSupply:           ps.GetCurrentSupply(),
+		validatorBondAmount:     ps.GetValidatorBondAmount(),
 	}
 }
 
@@ -137,6 +142,14 @@ func (vs *versionedStateImpl) GetCurrentSupply() uint64 {
 
 func (vs *versionedStateImpl) SetCurrentSupply(currentSupply uint64) {
 	vs.currentSupply = currentSupply
+}
+
+func (vs *versionedStateImpl) GetValidatorBondAmount() uint64 {
+	return vs.validatorBondAmount
+}
+
+func (vs *versionedStateImpl) SetValidatorBondAmount(currentSupply uint64) {
+	vs.validatorBondAmount = currentSupply
 }
 
 func (vs *versionedStateImpl) GetSubnets() ([]*Tx, error) {
@@ -311,6 +324,7 @@ func (vs *versionedStateImpl) SetBase(parentState MutableState) {
 func (vs *versionedStateImpl) Apply(is InternalState) {
 	is.SetTimestamp(vs.timestamp)
 	is.SetCurrentSupply(vs.currentSupply)
+	is.SetValidatorBondAmount(vs.validatorBondAmount)
 	for _, subnet := range vs.addedSubnets {
 		is.AddSubnet(subnet)
 	}

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -631,7 +631,7 @@ func (c *client) GetStake(ctx context.Context, addrs []string, options ...rpc.Op
 func (c *client) GetMinStake(ctx context.Context, options ...rpc.Option) (uint64, error) {
 	res := new(GetMinStakeReply)
 	err := c.requester.SendRequest(ctx, "getMinStake", struct{}{}, res, options...)
-	return uint64(res.MinValidatorStake), err
+	return uint64(res.ValidatorBondAmount), err
 }
 
 func (c *client) GetTotalStake(ctx context.Context, options ...rpc.Option) (uint64, error) {

--- a/vms/platformvm/factory.go
+++ b/vms/platformvm/factory.go
@@ -57,12 +57,6 @@ type Factory struct {
 	// Fee that must be burned by every blockchain creating transaction after AP3
 	CreateBlockchainTxFee uint64
 
-	// The minimum amount of tokens one must bond to be a validator
-	MinValidatorStake uint64
-
-	// The maximum amount of tokens that can be bonded on a validator
-	MaxValidatorStake uint64
-
 	// UptimePercentage is the minimum uptime required to be rewarded for staking
 	UptimePercentage float64
 

--- a/vms/platformvm/mock_cache_internal_state.go
+++ b/vms/platformvm/mock_cache_internal_state.go
@@ -403,6 +403,20 @@ func (mr *MockInternalStateMockRecorder) GetUptime(nodeID interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUptime", reflect.TypeOf((*MockInternalState)(nil).GetUptime), nodeID)
 }
 
+// GetValidatorBondAmount mocks base method.
+func (m *MockInternalState) GetValidatorBondAmount() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetValidatorBondAmount")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// GetValidatorBondAmount indicates an expected call of GetValidatorBondAmount.
+func (mr *MockInternalStateMockRecorder) GetValidatorBondAmount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorBondAmount", reflect.TypeOf((*MockInternalState)(nil).GetValidatorBondAmount))
+}
+
 // GetValidatorWeightDiffs mocks base method.
 func (m *MockInternalState) GetValidatorWeightDiffs(height uint64, subnetID ids.ID) (map[ids.ShortID]*ValidatorWeightDiff, error) {
 	m.ctrl.T.Helper()
@@ -516,6 +530,18 @@ func (m *MockInternalState) SetUptime(nodeID ids.ShortID, upDuration time.Durati
 func (mr *MockInternalStateMockRecorder) SetUptime(nodeID, upDuration, lastUpdated interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUptime", reflect.TypeOf((*MockInternalState)(nil).SetUptime), nodeID, upDuration, lastUpdated)
+}
+
+// SetValidatorBondAmount mocks base method.
+func (m *MockInternalState) SetValidatorBondAmount(currentSupply uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetValidatorBondAmount", currentSupply)
+}
+
+// SetValidatorBondAmount indicates an expected call of SetValidatorBondAmount.
+func (mr *MockInternalStateMockRecorder) SetValidatorBondAmount(currentSupply interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidatorBondAmount", reflect.TypeOf((*MockInternalState)(nil).SetValidatorBondAmount), currentSupply)
 }
 
 // UTXOIDs mocks base method.

--- a/vms/platformvm/reward_validator_tx_test.go
+++ b/vms/platformvm/reward_validator_tx_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/chain4travel/caminogo/chains"
+	"github.com/chain4travel/caminogo/database"
 	"github.com/chain4travel/caminogo/database/manager"
 	"github.com/chain4travel/caminogo/ids"
 	"github.com/chain4travel/caminogo/snow"
@@ -103,9 +104,9 @@ func TestUnsignedRewardValidatorTxExecuteOnCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if onCommitBalance != oldBalance+toRemove.Validator.Weight()+27 {
+	if onCommitBalance != oldBalance+toRemove.Validator.Weight()+13773 {
 		t.Fatalf("on commit, should have old balance (%d) + staked amount (%d) + reward (%d) but have %d",
-			oldBalance, toRemove.Validator.Weight(), 27, onCommitBalance)
+			oldBalance, toRemove.Validator.Weight(), 13773, onCommitBalance)
 	}
 }
 
@@ -381,8 +382,8 @@ func TestUptimeDisallowedWithRestart(t *testing.T) {
 	}
 
 	currentStakers := secondVM.internalState.CurrentStakerChainState()
-	_, err = currentStakers.GetValidator(keys[1].PublicKey().Address())
-	if err == nil {
+	_, err = currentStakers.GetValidator(keys[0].PublicKey().Address())
+	if err != database.ErrNotFound {
 		t.Fatal("should have removed a genesis validator")
 	}
 }
@@ -513,8 +514,8 @@ func TestUptimeDisallowedAfterNeverConnecting(t *testing.T) {
 	}
 
 	currentStakers := vm.internalState.CurrentStakerChainState()
-	_, err = currentStakers.GetValidator(keys[1].PublicKey().Address())
-	if err == nil {
+	_, err = currentStakers.GetValidator(keys[0].PublicKey().Address())
+	if err != database.ErrNotFound {
 		t.Fatal("should have removed a genesis validator")
 	}
 }

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -995,7 +995,6 @@ func (service *Service) AddValidator(_ *http.Request, args *AddValidatorArgs, re
 
 	// Create the transaction
 	tx, err := service.vm.newAddValidatorTx(
-		args.weight(),          // Stake amount
 		uint64(args.StartTime), // Start time
 		uint64(args.EndTime),   // End time
 		nodeID,                 // Node ID
@@ -2011,13 +2010,13 @@ func (service *Service) GetStake(_ *http.Request, args *GetStakeArgs, response *
 
 // GetMinStakeReply is the response from calling GetMinStake.
 type GetMinStakeReply struct {
-	//  The minimum amount of tokens one must bond to be a validator
-	MinValidatorStake json.Uint64 `json:"minValidatorStake"`
+	//  The amount of tokens one must bond to be a validator
+	ValidatorBondAmount json.Uint64 `json:"minValidatorStake"`
 }
 
 // GetMinStake returns the minimum staking amount in nAVAX.
 func (service *Service) GetMinStake(_ *http.Request, _ *struct{}, reply *GetMinStakeReply) error {
-	reply.MinValidatorStake = json.Uint64(service.vm.MinValidatorStake)
+	reply.ValidatorBondAmount = json.Uint64(service.vm.internalState.GetValidatorBondAmount())
 	return nil
 }
 
@@ -2192,10 +2191,6 @@ type GetConfigurationReply struct {
 	MinStakeDuration json.Uint64 `json:"minStakeDuration"`
 	// The maximum duration a validator can stake
 	MaxStakeDuration json.Uint64 `json:"maxStakeDuration"`
-	// The minimum amount of tokens one must bond to be a validator
-	MinValidatorStake json.Uint64 `json:"minValidatorStake"`
-	// The maximum amount of tokens bondable to a validator
-	MaxValidatorStake json.Uint64 `json:"maxValidatorStake"`
 	// The minimum consumption rate
 	MinConsumptionRate json.Uint64 `json:"minConsumptionRate"`
 	// The maximum consumption rate
@@ -2224,9 +2219,6 @@ func (service *Service) GetConfiguration(_ *http.Request, _ *struct{}, reply *Ge
 	// Staking information
 	reply.MinStakeDuration = json.Uint64(service.vm.MinStakeDuration)
 	reply.MaxStakeDuration = json.Uint64(service.vm.MaxStakeDuration)
-
-	reply.MaxValidatorStake = json.Uint64(service.vm.MaxValidatorStake)
-	reply.MinValidatorStake = json.Uint64(service.vm.MinValidatorStake)
 
 	reply.MinConsumptionRate = json.Uint64(service.vm.RewardConfig.MinConsumptionRate)
 	reply.MaxConsumptionRate = json.Uint64(service.vm.RewardConfig.MaxConsumptionRate)

--- a/vms/platformvm/static_service.go
+++ b/vms/platformvm/static_service.go
@@ -38,9 +38,10 @@ import (
 // state of the network.
 
 var (
-	errUTXOHasNoValue       = errors.New("genesis UTXO has no value")
-	errValidatorAddsNoValue = errors.New("validator would have already unstaked")
-	errStakeOverflow        = errors.New("too many funds staked on single validator")
+	errUTXOHasNoValue                  = errors.New("genesis UTXO has no value")
+	errValidatorZeroStake              = errors.New("validator hase no stake")
+	errValidatorEndsBeforeGenesisStart = errors.New("validator would have already unstaked")
+	errStakeOverflow                   = errors.New("too many funds staked on single validator")
 )
 
 // StaticService defines the static API methods exposed by the platform VM
@@ -121,15 +122,16 @@ type APIChain struct {
 // [Chains] are the chains that exist at genesis.
 // [Time] is the Platform Chain's time at network genesis.
 type BuildGenesisArgs struct {
-	AvaxAssetID   ids.ID                `json:"avaxAssetID"`
-	NetworkID     json.Uint32           `json:"networkID"`
-	UTXOs         []APIUTXO             `json:"utxos"`
-	Validators    []APIPrimaryValidator `json:"validators"`
-	Chains        []APIChain            `json:"chains"`
-	Time          json.Uint64           `json:"time"`
-	InitialSupply json.Uint64           `json:"initialSupply"`
-	Message       string                `json:"message"`
-	Encoding      formatting.Encoding   `json:"encoding"`
+	AvaxAssetID         ids.ID                `json:"avaxAssetID"`
+	NetworkID           json.Uint32           `json:"networkID"`
+	UTXOs               []APIUTXO             `json:"utxos"`
+	Validators          []APIPrimaryValidator `json:"validators"`
+	Chains              []APIChain            `json:"chains"`
+	Time                json.Uint64           `json:"time"`
+	InitialSupply       json.Uint64           `json:"initialSupply"`
+	ValidatorBondAmount json.Uint64           `json:"validatorBondAmount"`
+	Message             string                `json:"message"`
+	Encoding            formatting.Encoding   `json:"encoding"`
 }
 
 // BuildGenesisReply is the reply from BuildGenesis
@@ -146,12 +148,13 @@ type GenesisUTXO struct {
 
 // Genesis represents a genesis state of the platform chain
 type Genesis struct {
-	UTXOs         []*GenesisUTXO `serialize:"true"`
-	Validators    []*Tx          `serialize:"true"`
-	Chains        []*Tx          `serialize:"true"`
-	Timestamp     uint64         `serialize:"true"`
-	InitialSupply uint64         `serialize:"true"`
-	Message       string         `serialize:"true"`
+	UTXOs               []*GenesisUTXO `serialize:"true"`
+	Validators          []*Tx          `serialize:"true"`
+	Chains              []*Tx          `serialize:"true"`
+	Timestamp           uint64         `serialize:"true"`
+	InitialSupply       uint64         `serialize:"true"`
+	ValidatorBondAmount uint64         `serialize:"true"`
+	Message             string         `serialize:"true"`
 }
 
 func (g *Genesis) Initialize() error {
@@ -259,11 +262,14 @@ func (ss *StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, r
 			weight = newWeight
 		}
 
-		if weight == 0 {
-			return errValidatorAddsNoValue
+		switch {
+		case weight == 0:
+			return errValidatorZeroStake
+		case weight != uint64(args.ValidatorBondAmount):
+			return errWrongBondAmount
 		}
 		if uint64(validator.EndTime) <= uint64(args.Time) {
-			return errValidatorAddsNoValue
+			return errValidatorEndsBeforeGenesisStart
 		}
 		nodeID, err := ids.ShortFromPrefixedString(validator.NodeID, constants.NodeIDPrefix)
 		if err != nil {
@@ -337,12 +343,13 @@ func (ss *StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, r
 
 	// genesis holds the genesis state
 	genesis := Genesis{
-		UTXOs:         utxos,
-		Validators:    validatorTxs,
-		Chains:        chains,
-		Timestamp:     uint64(args.Time),
-		InitialSupply: uint64(args.InitialSupply),
-		Message:       args.Message,
+		UTXOs:               utxos,
+		Validators:          validatorTxs,
+		Chains:              chains,
+		Timestamp:           uint64(args.Time),
+		InitialSupply:       uint64(args.InitialSupply),
+		Message:             args.Message,
+		ValidatorBondAmount: uint64(args.ValidatorBondAmount),
 	}
 
 	// Marshal genesis to bytes

--- a/vms/platformvm/tx_heap_by_end_time_test.go
+++ b/vms/platformvm/tx_heap_by_end_time_test.go
@@ -34,7 +34,6 @@ func TestTxHeapStop(t *testing.T) {
 	txHeap := newTxHeapByEndTime()
 
 	validator0, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,                                               // stake amount
 		uint64(defaultGenesisTime.Unix()+1),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+1), // endTime
 		ids.ShortID{},                           // node ID
@@ -48,7 +47,6 @@ func TestTxHeapStop(t *testing.T) {
 	vdr0Tx := validator0.UnsignedTx.(*UnsignedAddValidatorTx)
 
 	validator1, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,                                               // stake amount
 		uint64(defaultGenesisTime.Unix()+1),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+2), // endTime
 		ids.ShortID{1},                          // node ID
@@ -62,7 +60,6 @@ func TestTxHeapStop(t *testing.T) {
 	vdr1Tx := validator1.UnsignedTx.(*UnsignedAddValidatorTx)
 
 	validator2, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,                                               // stake amount
 		uint64(defaultGenesisTime.Unix()+1),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+3), // endTime
 		ids.ShortID{},                           // node ID

--- a/vms/platformvm/tx_heap_by_start_time_test.go
+++ b/vms/platformvm/tx_heap_by_start_time_test.go
@@ -34,7 +34,6 @@ func TestTxHeapByStartTime(t *testing.T) {
 	txHeap := NewTxHeapByStartTime()
 
 	validator0, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,                                               // stake amount
 		uint64(defaultGenesisTime.Unix()+1),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+1), // endTime
 		ids.ShortID{},                           // node ID
@@ -48,7 +47,6 @@ func TestTxHeapByStartTime(t *testing.T) {
 	vdr0Tx := validator0.UnsignedTx.(*UnsignedAddValidatorTx)
 
 	validator1, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,                                               // stake amount
 		uint64(defaultGenesisTime.Unix()+2),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+2), // endTime
 		ids.ShortID{1},                          // node ID
@@ -62,7 +60,6 @@ func TestTxHeapByStartTime(t *testing.T) {
 	vdr1Tx := validator1.UnsignedTx.(*UnsignedAddValidatorTx)
 
 	validator2, err := vm.newAddValidatorTx(
-		vm.MinValidatorStake,                                               // stake amount
 		uint64(defaultGenesisTime.Unix()+3),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+3), // endTime
 		ids.ShortID{},                           // node ID

--- a/vms/proposervm/batched_vm_test.go
+++ b/vms/proposervm/batched_vm_test.go
@@ -128,7 +128,8 @@ func TestGetAncestorsPreForkOnly(t *testing.T) {
 	// Simply return an empty result
 	coreVM.GetAncestorsF = func(blkID ids.ID,
 		maxBlocksNum, maxBlocksSize int,
-		maxBlocksRetrivalTime time.Duration) ([][]byte, error) {
+		maxBlocksRetrivalTime time.Duration,
+	) ([][]byte, error) {
 		res := make([][]byte, 0, 3)
 		switch blkID {
 		case coreBlk3.ID():
@@ -240,7 +241,8 @@ func TestGetAncestorsPostForkOnly(t *testing.T) {
 	// Simply return an empty result
 	coreVM.GetAncestorsF = func(blkID ids.ID,
 		maxBlocksNum, maxBlocksSize int,
-		maxBlocksRetrivalTime time.Duration) ([][]byte, error) {
+		maxBlocksRetrivalTime time.Duration,
+	) ([][]byte, error) {
 		res := make([][]byte, 0, 3)
 		switch blkID {
 		case coreBlk3.ID():
@@ -412,7 +414,8 @@ func TestGetAncestorsAtSnomanPlusPlusFork(t *testing.T) {
 	// Simply return an empty result
 	coreVM.GetAncestorsF = func(blkID ids.ID,
 		maxBlocksNum, maxBlocksSize int,
-		maxBlocksRetrivalTime time.Duration) ([][]byte, error) {
+		maxBlocksRetrivalTime time.Duration,
+	) ([][]byte, error) {
 		res := make([][]byte, 0, 3)
 		switch blkID {
 		case coreBlk4.ID():
@@ -866,7 +869,8 @@ func initTestRemoteProposerVM(
 
 	coreVM.InitializeF = func(*snow.Context, manager.Manager,
 		[]byte, []byte, []byte, chan<- common.Message,
-		[]*common.Fx, common.AppSender) error {
+		[]*common.Fx, common.AppSender,
+	) error {
 		return nil
 	}
 	coreVM.LastAcceptedF = func() (ids.ID, error) { return coreGenBlk.ID(), nil }

--- a/vms/proposervm/post_fork_option_test.go
+++ b/vms/proposervm/post_fork_option_test.go
@@ -742,7 +742,8 @@ func TestOptionTimestampValidity(t *testing.T) {
 
 	coreVM.InitializeF = func(*snow.Context, manager.Manager,
 		[]byte, []byte, []byte, chan<- common.Message,
-		[]*common.Fx, common.AppSender) error {
+		[]*common.Fx, common.AppSender,
+	) error {
 		return nil
 	}
 	coreVM.LastAcceptedF = func() (ids.ID, error) { return coreOracleBlk.opts[0].ID(), nil }

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -92,7 +92,8 @@ func initTestProposerVM(
 
 	coreVM.InitializeF = func(*snow.Context, manager.Manager,
 		[]byte, []byte, []byte, chan<- common.Message,
-		[]*common.Fx, common.AppSender) error {
+		[]*common.Fx, common.AppSender,
+	) error {
 		return nil
 	}
 	coreVM.LastAcceptedF = func() (ids.ID, error) { return coreGenBlk.ID(), nil }


### PR DESCRIPTION
### Summary
Make `addValidator` transaction to use fixed validator bond amount instead of arbitrary values from rpc request.
The value is 100_000_000_000_000 nCAM = 100_000 CAM
### Purpose of change
We expect validators on Camino to have the same fixed stake, so they'll be equal. That was stated, but not implemented. This PR covers that and also adds possibility to change this fixed stake in future (for example, with voting) by adding this value to genesis.
### Solution
Added `validatorBondAmount` value to genesis. Updated internal and versioned chain states, so it will be possible to get and set `validatorBondAmount` value.
Updated `newAddValidator` func to use `validatorBondAmount` from internal state instead of one passed from rpc request. Updated `addValidator` transaction semantic verification to check stake amount against `validatorBondAmount` from parent state. 
I also updated some old fail-tests so they will look for specific error instead of just any (went its ment to be not just any error)

### Co-Authors
- @charalarg  