### PR TITLE
Multisignature support for P-Chain

### DIFF
--- a/genesis/config.go
+++ b/genesis/config.go
@@ -75,17 +75,37 @@ func (s Staker) Unparse(networkID uint32) (UnparsedStaker, error) {
 	}, err
 }
 
+type MultisigAlias struct {
+	Alias     ids.ShortID   `json:"alias"`
+	Addresses []ids.ShortID `json:"addresses"`
+	Threshold uint32        `json:"threshold"`
+}
+
+func (ma MultisigAlias) Unparse() (UnparsedMultisigAlias, error) {
+	addresses := make([]string, len(ma.Addresses))
+	for i, a := range ma.Addresses {
+		addresses[i] = a.String()
+	}
+
+	return UnparsedMultisigAlias{
+		Alias:     ma.Alias.String(),
+		Addresses: addresses,
+		Threshold: ma.Threshold,
+	}, nil
+}
+
 // Config contains the genesis addresses used to construct a genesis
 type Config struct {
 	NetworkID uint32 `json:"networkID"`
 
 	Allocations []Allocation `json:"allocations"`
 
-	StartTime                  uint64        `json:"startTime"`
-	InitialStakeDuration       uint64        `json:"initialStakeDuration"`
-	InitialStakeDurationOffset uint64        `json:"initialStakeDurationOffset"`
-	InitialStakedFunds         []ids.ShortID `json:"initialStakedFunds"`
-	InitialStakers             []Staker      `json:"initialStakers"`
+	StartTime                  uint64          `json:"startTime"`
+	InitialStakeDuration       uint64          `json:"initialStakeDuration"`
+	InitialStakeDurationOffset uint64          `json:"initialStakeDurationOffset"`
+	InitialStakedFunds         []ids.ShortID   `json:"initialStakedFunds"`
+	InitialStakers             []Staker        `json:"initialStakers"`
+	InitialMultisigAddresses   []MultisigAlias `json:"initialMultisigAddresses"`
 
 	CChainGenesis string `json:"cChainGenesis"`
 
@@ -101,6 +121,7 @@ func (c Config) Unparse() (UnparsedConfig, error) {
 		InitialStakeDurationOffset: c.InitialStakeDurationOffset,
 		InitialStakedFunds:         make([]string, len(c.InitialStakedFunds)),
 		InitialStakers:             make([]UnparsedStaker, len(c.InitialStakers)),
+		InitialMultisigAddresses:   make([]UnparsedMultisigAlias, len(c.InitialMultisigAddresses)),
 		CChainGenesis:              c.CChainGenesis,
 		Message:                    c.Message,
 	}
@@ -128,6 +149,13 @@ func (c Config) Unparse() (UnparsedConfig, error) {
 			return uc, err
 		}
 		uc.InitialStakers[i] = uis
+	}
+	for i, ma := range c.InitialMultisigAddresses {
+		uma, err := ma.Unparse()
+		if err != nil {
+			return uc, err
+		}
+		uc.InitialMultisigAddresses[i] = uma
 	}
 
 	return uc, nil

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -189,9 +189,9 @@ func validateConfig(networkID uint32, config *Config) error {
 // loads the network genesis data from the config at [filepath].
 //
 // FromFile returns:
-// 1) The byte representation of the genesis state of the platform chain
-//    (ie the genesis state of the network)
-// 2) The asset ID of native token
+//  1. The byte representation of the genesis state of the platform chain
+//     (ie the genesis state of the network)
+//  2. The asset ID of native token
 func FromFile(networkID uint32, filepath string) ([]byte, ids.ID, error) {
 	switch networkID {
 	case constants.MainnetID, constants.CaminoID, constants.TestnetID, constants.LocalID:
@@ -230,9 +230,9 @@ func FromFile(networkID uint32, filepath string) ([]byte, ids.ID, error) {
 // loads the network genesis data from [genesisContent].
 //
 // FromFlag returns:
-// 1) The byte representation of the genesis state of the platform chain
-//    (ie the genesis state of the network)
-// 2) The asset ID of native token
+//  1. The byte representation of the genesis state of the platform chain
+//     (ie the genesis state of the network)
+//  2. The asset ID of native token
 func FromFlag(networkID uint32, genesisContent string) ([]byte, ids.ID, error) {
 	switch networkID {
 	case constants.MainnetID, constants.CaminoID, constants.TestnetID, constants.LocalID:
@@ -256,9 +256,9 @@ func FromFlag(networkID uint32, genesisContent string) ([]byte, ids.ID, error) {
 }
 
 // FromConfig returns:
-// 1) The byte representation of the genesis state of the platform chain
-//    (ie the genesis state of the network)
-// 2) The asset ID of AVAX
+//  1. The byte representation of the genesis state of the platform chain
+//     (ie the genesis state of the network)
+//  2. The asset ID of AVAX
 func FromConfig(config *Config) ([]byte, ids.ID, error) {
 	hrp := constants.GetHRP(config.NetworkID)
 
@@ -448,6 +448,15 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 			VMID:        constants.EVMID,
 			Name:        "C-Chain",
 		},
+	}
+
+	platformvmArgs.MultisigOwners = make([]platformvm.APIMultisigOwners, len(config.InitialMultisigAddresses))
+	for i, msa := range config.InitialMultisigAddresses {
+		platformvmArgs.MultisigOwners[i] = platformvm.APIMultisigOwners{
+			Alias:     msa.Alias,
+			Addresses: msa.Addresses,
+			Threshold: msa.Threshold,
+		}
 	}
 
 	platformvmReply := platformvm.BuildGenesisReply{}

--- a/vms/platformvm/import_tx.go
+++ b/vms/platformvm/import_tx.go
@@ -155,7 +155,13 @@ func (tx *UnsignedImportTx) Execute(
 		copy(ins, tx.Ins)
 		copy(ins[len(tx.Ins):], tx.ImportedInputs)
 
-		if err := vm.semanticVerifySpendUTXOs(tx, utxos, ins, tx.Outs, stx.Creds, vm.TxFee, vm.ctx.AVAXAssetID); err != nil {
+		// Because `semanticVerifySpendUTXOs` signature has changed and accepts also `signingOwners` slice
+		// I'm just passing the same what comes in UTXO - so no `alias -> addrs` extensions is done.
+		signers := make([]verify.Verifiable, len(utxos))
+		for i, utxo := range utxos {
+			signers[i] = utxo.Out
+		}
+		if err := vm.semanticVerifySpendUTXOs(tx, utxos, ins, tx.Outs, signers, stx.Creds, vm.TxFee, vm.ctx.AVAXAssetID); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This PR provides the multisignature wallets to own and spend UTXOs on the P-Chain.

A multisignature wallet is defined as follows:
- Alias (or fake address) that is an owner of the assets on the P-Chain. Private key of this address is unknown.
- Addresses - the list of the addresses of the owners of the multisignature wallet
- Threshold - number of the signatures from the owners to consider the multisignature is valid.

In the scope of this PR we can only add definition of the multisignature wallets into the genesis config.
```genesis_columbus.go
columbusGenesisConfigJSON = `{
  ...
  "initialMultisigAddresses": [
	{
		"Alias": "NuWdjBkNsazjctduX39RRot9Z1c5q3FWv",
		"Addresses": [
			"415VVfAvZzpAN9V6PwvxmZjuJjGqaQmAV",
			"95MT2a1aZTnRr8fX49EsLcoqW3dDp1Bt2",
			"N5bBN6Pv9Kh8v4pMnnWLw1GAGnL1EMNL5"
		],
		"Threshold": 2
	}
  ],
```