### PR TITLE
TECH-336: Node signature verification

### DIFF
--- a/vms/platformvm/reward_validator_tx_test.go
+++ b/vms/platformvm/reward_validator_tx_test.go
@@ -49,9 +49,15 @@ func TestUnsignedRewardValidatorTxExecuteOnCommit(t *testing.T) {
 	toRemove := toRemoveTx.UnsignedTx.(*UnsignedAddValidatorTx)
 
 	// Case 1: Chain timestamp is wrong
-	if tx, err := vm.newRewardValidatorTx(toRemove.ID()); err != nil {
+	stx, err := vm.newRewardValidatorTx(toRemove.ID())
+	if err != nil {
 		t.Fatal(err)
-	} else if _, _, err := toRemove.Execute(vm, vm.internalState, tx); err == nil {
+	}
+	utx, ok := stx.UnsignedTx.(*UnsignedRewardValidatorTx)
+	if !ok {
+		t.Fatal("Could not cast rewardValidatorTx to an UnsignedRewardValidatorTx")
+	}
+	if _, _, err = utx.Execute(vm, vm.internalState, stx); err == nil {
 		t.Fatalf("should have failed because validator end time doesn't match chain timestamp")
 	}
 
@@ -59,9 +65,15 @@ func TestUnsignedRewardValidatorTxExecuteOnCommit(t *testing.T) {
 	vm.internalState.SetTimestamp(toRemove.EndTime())
 
 	// Case 2: Wrong validator
-	if tx, err := vm.newRewardValidatorTx(ids.GenerateTestID()); err != nil {
+	stx, err = vm.newRewardValidatorTx(ids.GenerateTestID())
+	if err != nil {
 		t.Fatal(err)
-	} else if _, _, err := toRemove.Execute(vm, vm.internalState, tx); err == nil {
+	}
+	utx, ok = stx.UnsignedTx.(*UnsignedRewardValidatorTx)
+	if !ok {
+		t.Fatal("Could not cast rewardValidatorTx to an UnsignedRewardValidatorTx")
+	}
+	if _, _, err = utx.Execute(vm, vm.internalState, stx); err == nil {
 		t.Fatalf("should have failed because validator ID is wrong")
 	}
 
@@ -128,9 +140,15 @@ func TestUnsignedRewardValidatorTxExecuteOnAbort(t *testing.T) {
 	toRemove := toRemoveTx.UnsignedTx.(*UnsignedAddValidatorTx)
 
 	// Case 1: Chain timestamp is wrong
-	if tx, err := vm.newRewardValidatorTx(toRemove.ID()); err != nil {
+	stx, err := vm.newRewardValidatorTx(toRemove.ID())
+	if err != nil {
 		t.Fatal(err)
-	} else if _, _, err := toRemove.Execute(vm, vm.internalState, tx); err == nil {
+	}
+	utx, ok := stx.UnsignedTx.(*UnsignedRewardValidatorTx)
+	if !ok {
+		t.Fatal("Could not cast rewardValidatorTx to an UnsignedRewardValidatorTx")
+	}
+	if _, _, err = utx.Execute(vm, vm.internalState, stx); err == nil {
 		t.Fatalf("should have failed because validator end time doesn't match chain timestamp")
 	}
 
@@ -138,9 +156,15 @@ func TestUnsignedRewardValidatorTxExecuteOnAbort(t *testing.T) {
 	vm.internalState.SetTimestamp(toRemove.EndTime())
 
 	// Case 2: Wrong validator
-	if tx, err := vm.newRewardValidatorTx(ids.GenerateTestID()); err != nil {
+	stx, err = vm.newRewardValidatorTx(ids.GenerateTestID())
+	if err != nil {
 		t.Fatal(err)
-	} else if _, _, err := toRemove.Execute(vm, vm.internalState, tx); err == nil {
+	}
+	utx, ok = stx.UnsignedTx.(*UnsignedRewardValidatorTx)
+	if !ok {
+		t.Fatal("Could not cast rewardValidatorTx to an UnsignedRewardValidatorTx")
+	}
+	if _, _, err = utx.Execute(vm, vm.internalState, stx); err == nil {
 		t.Fatalf("should have failed because validator ID is wrong")
 	}
 
@@ -382,7 +406,7 @@ func TestUptimeDisallowedWithRestart(t *testing.T) {
 	}
 
 	currentStakers := secondVM.internalState.CurrentStakerChainState()
-	_, err = currentStakers.GetValidator(keys[0].PublicKey().Address())
+	_, err = currentStakers.GetValidator(nodeIDs[4])
 	if err != database.ErrNotFound {
 		t.Fatal("should have removed a genesis validator")
 	}
@@ -514,7 +538,7 @@ func TestUptimeDisallowedAfterNeverConnecting(t *testing.T) {
 	}
 
 	currentStakers := vm.internalState.CurrentStakerChainState()
-	_, err = currentStakers.GetValidator(keys[0].PublicKey().Address())
+	_, err = currentStakers.GetValidator(nodeIDs[4])
 	if err != database.ErrNotFound {
 		t.Fatal("should have removed a genesis validator")
 	}

--- a/vms/platformvm/tx_heap_by_end_time_test.go
+++ b/vms/platformvm/tx_heap_by_end_time_test.go
@@ -36,9 +36,9 @@ func TestTxHeapStop(t *testing.T) {
 	validator0, err := vm.newAddValidatorTx(
 		uint64(defaultGenesisTime.Unix()+1),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+1), // endTime
-		ids.ShortID{},                           // node ID
-		ids.ShortID{1, 2, 3, 4, 5, 6, 7},        // reward address
-		[]*crypto.PrivateKeySECP256K1R{keys[0]}, // key
+		nodeIDs[0],                       // node ID
+		ids.ShortID{1, 2, 3, 4, 5, 6, 7}, // reward address
+		[]*crypto.PrivateKeySECP256K1R{keys[0], nodeKeys[0]}, // key
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -48,9 +48,9 @@ func TestTxHeapStop(t *testing.T) {
 	validator1, err := vm.newAddValidatorTx(
 		uint64(defaultGenesisTime.Unix()+1),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+2), // endTime
-		ids.ShortID{1},                          // node ID
-		ids.ShortID{1, 2, 3, 4, 5, 6, 7},        // reward address
-		[]*crypto.PrivateKeySECP256K1R{keys[0]}, // key
+		nodeIDs[1],                       // node ID
+		ids.ShortID{1, 2, 3, 4, 5, 6, 7}, // reward address
+		[]*crypto.PrivateKeySECP256K1R{keys[0], nodeKeys[1]}, // key
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -60,9 +60,9 @@ func TestTxHeapStop(t *testing.T) {
 	validator2, err := vm.newAddValidatorTx(
 		uint64(defaultGenesisTime.Unix()+1),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+3), // endTime
-		ids.ShortID{},                           // node ID
-		ids.ShortID{1, 2, 3, 4, 5, 6, 7},        // reward address
-		[]*crypto.PrivateKeySECP256K1R{keys[0]}, // key
+		nodeIDs[1],                       // node ID
+		ids.ShortID{1, 2, 3, 4, 5, 6, 7}, // reward address
+		[]*crypto.PrivateKeySECP256K1R{keys[0], nodeKeys[2]}, // key
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/vms/platformvm/tx_heap_by_start_time_test.go
+++ b/vms/platformvm/tx_heap_by_start_time_test.go
@@ -36,9 +36,9 @@ func TestTxHeapByStartTime(t *testing.T) {
 	validator0, err := vm.newAddValidatorTx(
 		uint64(defaultGenesisTime.Unix()+1),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+1), // endTime
-		ids.ShortID{},                           // node ID
-		ids.ShortID{1, 2, 3, 4, 5, 6, 7},        // reward address
-		[]*crypto.PrivateKeySECP256K1R{keys[0]}, // key
+		nodeIDs[0],                       // node ID
+		ids.ShortID{1, 2, 3, 4, 5, 6, 7}, // reward address
+		[]*crypto.PrivateKeySECP256K1R{keys[0], nodeKeys[0]}, // key
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -48,9 +48,9 @@ func TestTxHeapByStartTime(t *testing.T) {
 	validator1, err := vm.newAddValidatorTx(
 		uint64(defaultGenesisTime.Unix()+2),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+2), // endTime
-		ids.ShortID{1},                          // node ID
-		ids.ShortID{1, 2, 3, 4, 5, 6, 7},        // reward address
-		[]*crypto.PrivateKeySECP256K1R{keys[0]}, // key
+		nodeIDs[1],                       // node ID
+		ids.ShortID{1, 2, 3, 4, 5, 6, 7}, // reward address
+		[]*crypto.PrivateKeySECP256K1R{keys[0], nodeKeys[1]}, // key
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -60,9 +60,9 @@ func TestTxHeapByStartTime(t *testing.T) {
 	validator2, err := vm.newAddValidatorTx(
 		uint64(defaultGenesisTime.Unix()+3),                                // startTime
 		uint64(defaultGenesisTime.Add(defaultMinStakingDuration).Unix()+3), // endTime
-		ids.ShortID{},                           // node ID
-		ids.ShortID{1, 2, 3, 4, 5, 6, 7},        // reward address
-		[]*crypto.PrivateKeySECP256K1R{keys[0]}, // key
+		nodeIDs[2],                       // node ID
+		ids.ShortID{1, 2, 3, 4, 5, 6, 7}, // reward address
+		[]*crypto.PrivateKeySECP256K1R{keys[0], nodeKeys[2]}, // key
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/vms/platformvm/validator_test.go
+++ b/vms/platformvm/validator_test.go
@@ -15,7 +15,7 @@ func TestValidatorBoundedBy(t *testing.T) {
 	aStartTime := uint64(0)
 	aEndTIme := uint64(1)
 	a := &Validator{
-		NodeID: keys[0].PublicKey().Address(),
+		NodeID: nodeIDs[0],
 		Start:  aStartTime,
 		End:    aEndTIme,
 		Wght:   defaultWeight,
@@ -24,7 +24,7 @@ func TestValidatorBoundedBy(t *testing.T) {
 	bStartTime := uint64(2)
 	bEndTime := uint64(3)
 	b := &Validator{
-		NodeID: keys[0].PublicKey().Address(),
+		NodeID: nodeIDs[0],
 		Start:  bStartTime,
 		End:    bEndTime,
 		Wght:   defaultWeight,


### PR DESCRIPTION
## Description ##
In this PR we ensure that addValidator and addSubnetValidator transactions are being executed only from people that own the corresponding nodes. So we include node's signature in the above transactions and in the excecution we verify that the signature matches the Node's ID. (NodeID implementation is described [here](https://github.com/chain4travel/caminogo/pull/36))

## Changes ## 
- Include node's signature in `addValidatorTx` and in `addSubnetValidatorTx`
- Implement verification check
- Fix broken tests
- Add new tests covering the verification implementation

## Co-authors ##
@evlekht 