### PR TITLE
[API] Return Platform CodecVersion from GetInformation

### DIFF
--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -2131,8 +2131,10 @@ type GetConfigurationReply struct {
 	MinConsumptionRate json.Uint64 `json:"minConsumptionRate"`
 	// The maximum consumption rate
 	MaxConsumptionRate json.Uint64 `json:"maxConsumptionRate"`
-	// The supply cap for the native tolen (AVAX)
+	// The supply cap for the native token (AVAX)
 	SupplyCap json.Uint64 `json:"supplyCap"`
+	// The codec version used for serializing
+	CodecVersion json.Uint16 `json:"codecVersion"`
 }
 
 // GetMinStake returns the minimum staking amount in nAVAX.
@@ -2160,6 +2162,9 @@ func (service *Service) GetConfiguration(_ *http.Request, _ *struct{}, reply *Ge
 	reply.MaxConsumptionRate = json.Uint64(service.vm.RewardConfig.MaxConsumptionRate)
 
 	reply.SupplyCap = json.Uint64(service.vm.RewardConfig.SupplyCap)
+
+	// Codec information
+	reply.CodecVersion = json.Uint16(CodecVersion)
 
 	return nil
 }


### PR DESCRIPTION
# Return Platform CodecVersion from GetInformation
For external services (e.g. caminojs) we need the codec version to serialize types and transactions.
This PR returns PlatformVM CodecVersion in GetInformationCall which is already used in caminojs to setup node preferences.
