### PR TITLE
Camino Genesis / Flags

### DIFF
--- a/config/camino.go
+++ b/config/camino.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package config
+
+import (
+	"flag"
+
+	"github.com/ava-labs/avalanchego/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
+	"github.com/spf13/viper"
+)
+
+const (
+	ValidatorBondAmountKey   = "validator-bond-amount"
+	DaoProposalBondAmountKey = "dao-proposal-bond-amount"
+)
+
+func addCaminoFlags(fs *flag.FlagSet) {
+	// Bond amount required to validate the Primary Network
+	fs.Uint64(ValidatorBondAmountKey, genesis.LocalParams.CaminoConfig.ValidatorBondAmount, "Amount, in nAVAX, required to validate the primary network")
+	// Bond amount required to place a DAO proposal on the Primary Network
+	fs.Uint64(DaoProposalBondAmountKey, genesis.LocalParams.CaminoConfig.DaoProposalBondAmount, "Amount, in nAVAX, required to place a DAO proposal")
+}
+
+func getCaminoPlatformConfig(v *viper.Viper) config.CaminoConfig {
+	conf := config.CaminoConfig{
+		ValidatorBondAmount:   v.GetUint64(ValidatorBondAmountKey),
+		DaoProposalBondAmount: v.GetUint64(DaoProposalBondAmountKey),
+	}
+	return conf
+}

--- a/config/config.go
+++ b/config/config.go
@@ -818,6 +818,7 @@ func getStakingConfig(v *viper.Viper, networkID uint32) (node.StakingConfig, err
 		config.RewardConfig.MintingPeriod = v.GetDuration(StakeMintingPeriodKey)
 		config.RewardConfig.SupplyCap = v.GetUint64(StakeSupplyCapKey)
 		config.MinDelegationFee = v.GetUint32(MinDelegatorFeeKey)
+		config.CaminoConfig = getCaminoPlatformConfig(v)
 		switch {
 		case config.UptimeRequirement < 0 || config.UptimeRequirement > 1:
 			return node.StakingConfig{}, errInvalidUptimeRequirement

--- a/config/flags.go
+++ b/config/flags.go
@@ -383,6 +383,7 @@ func BuildFlagSet() *flag.FlagSet {
 	fs := flag.NewFlagSet(constants.AppName, flag.ContinueOnError)
 	addProcessFlags(fs)
 	addNodeFlags(fs)
+	addCaminoFlags(fs)
 	return fs
 }
 

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 
 	safemath "github.com/ava-labs/avalanchego/utils/math"
 )
@@ -81,11 +82,12 @@ type Config struct {
 
 	Allocations []Allocation `json:"allocations"`
 
-	StartTime                  uint64        `json:"startTime"`
-	InitialStakeDuration       uint64        `json:"initialStakeDuration"`
-	InitialStakeDurationOffset uint64        `json:"initialStakeDurationOffset"`
-	InitialStakedFunds         []ids.ShortID `json:"initialStakedFunds"`
-	InitialStakers             []Staker      `json:"initialStakers"`
+	StartTime                  uint64         `json:"startTime"`
+	InitialStakeDuration       uint64         `json:"initialStakeDuration"`
+	InitialStakeDurationOffset uint64         `json:"initialStakeDurationOffset"`
+	InitialStakedFunds         []ids.ShortID  `json:"initialStakedFunds"`
+	InitialStakers             []Staker       `json:"initialStakers"`
+	Camino                     genesis.Camino `json:"camino"`
 
 	CChainGenesis string `json:"cChainGenesis"`
 

--- a/genesis/genesis_camino.go
+++ b/genesis/genesis_camino.go
@@ -9,6 +9,7 @@ import (
 	_ "embed"
 
 	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
@@ -37,6 +38,10 @@ var (
 				MinConsumptionRate: .10 * reward.PercentDenominator,
 				MintingPeriod:      365 * 24 * time.Hour,
 				SupplyCap:          1000 * units.MegaAvax,
+			},
+			CaminoConfig: config.CaminoConfig{
+				ValidatorBondAmount:   100 * units.KiloAvax,
+				DaoProposalBondAmount: 1 * units.KiloAvax,
 			},
 		},
 	}

--- a/genesis/genesis_camino.json
+++ b/genesis/genesis_camino.json
@@ -23,6 +23,10 @@
             ]
         }
     ],
+    "camino": {
+        "verifyNodeSignature": true,
+        "lockModeBondDeposit": true
+    },
     "startTime": 1647388800,
     "initialStakeDuration": 31536000,
     "initialStakeDurationOffset": 5400,

--- a/genesis/genesis_columbus.go
+++ b/genesis/genesis_columbus.go
@@ -9,6 +9,7 @@ import (
 	_ "embed"
 
 	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
@@ -37,6 +38,10 @@ var (
 				MinConsumptionRate: .10 * reward.PercentDenominator,
 				MintingPeriod:      365 * 24 * time.Hour,
 				SupplyCap:          1000 * units.MegaAvax,
+			},
+			CaminoConfig: config.CaminoConfig{
+				ValidatorBondAmount:   2 * units.KiloAvax,
+				DaoProposalBondAmount: 100 * units.Avax,
 			},
 		},
 	}

--- a/genesis/genesis_columbus.json
+++ b/genesis/genesis_columbus.json
@@ -23,6 +23,10 @@
             ]
         }
     ],
+    "camino": {
+        "verifyNodeSignature": true,
+        "lockModeBondDeposit": true
+    },
     "startTime": 1647388800,
     "initialStakeDuration": 31536000,
     "initialStakeDurationOffset": 5400,

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -12,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
@@ -60,6 +71,10 @@ var (
 				MinConsumptionRate: .10 * reward.PercentDenominator,
 				MintingPeriod:      365 * 24 * time.Hour,
 				SupplyCap:          720 * units.MegaAvax,
+			},
+			CaminoConfig: config.CaminoConfig{
+				ValidatorBondAmount:   2 * units.KiloAvax,
+				DaoProposalBondAmount: 100 * units.Avax,
 			},
 		},
 	}

--- a/genesis/params.go
+++ b/genesis/params.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -7,6 +17,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
@@ -31,6 +42,8 @@ type StakingConfig struct {
 	MaxStakeDuration time.Duration `json:"maxStakeDuration"`
 	// RewardConfig is the config for the reward function.
 	RewardConfig reward.Config `json:"rewardConfig"`
+	// CaminoConfig is the config for camino related features.
+	CaminoConfig config.CaminoConfig `json:"caminoConfig"`
 }
 
 type TxFeeConfig struct {

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -18,6 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs/txheap"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validator"
@@ -140,6 +151,7 @@ type Chain struct {
 // [UTXOs] are the UTXOs on the Platform Chain that exist at genesis.
 // [Validators] are the validators of the primary network at genesis.
 // [Chains] are the chains that exist at genesis.
+// [Camino] are the camino specific genesis args.
 // [Time] is the Platform Chain's time at network genesis.
 type BuildGenesisArgs struct {
 	AvaxAssetID   ids.ID                    `json:"avaxAssetID"`
@@ -147,6 +159,7 @@ type BuildGenesisArgs struct {
 	UTXOs         []UTXO                    `json:"utxos"`
 	Validators    []PermissionlessValidator `json:"validators"`
 	Chains        []Chain                   `json:"chains"`
+	Camino        state.Camino              `json:"camino"`
 	Time          json.Uint64               `json:"time"`
 	InitialSupply json.Uint64               `json:"initialSupply"`
 	Message       string                    `json:"message"`

--- a/vms/platformvm/config/camino.go
+++ b/vms/platformvm/config/camino.go
@@ -1,0 +1,9 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package config
+
+type CaminoConfig struct {
+	ValidatorBondAmount   uint64
+	DaoProposalBondAmount uint64
+}

--- a/vms/platformvm/config/config.go
+++ b/vms/platformvm/config/config.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -104,6 +114,9 @@ type Config struct {
 	// If a subnet is whitelisted but not in this map, we use the value for the
 	// Primary Network.
 	MinPercentConnectedStakeHealthy map[ids.ID]float64
+
+	// Camino relevant configuration
+	CaminoConfig CaminoConfig
 }
 
 func (c *Config) IsApricotPhase3Activated(timestamp time.Time) bool {

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -1,0 +1,10 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesis
+
+// Camino genesis args
+type Camino struct {
+	VerifyNodeSignature bool `json:"verifyNodeSignature"`
+	LockModeBondDeposit bool `json:"lockModeBondDeposit"`
+}

--- a/vms/platformvm/genesis/genesis.go
+++ b/vms/platformvm/genesis/genesis.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -19,6 +29,7 @@ type Genesis struct {
 	UTXOs         []*UTXO   `serialize:"true"`
 	Validators    []*txs.Tx `serialize:"true"`
 	Chains        []*txs.Tx `serialize:"true"`
+	Camino        Camino    `serialize:"true"`
 	Timestamp     uint64    `serialize:"true"`
 	InitialSupply uint64    `serialize:"true"`
 	Message       string    `serialize:"true"`
@@ -47,6 +58,7 @@ type State struct {
 	UTXOs         []*avax.UTXO
 	Validators    []*txs.Tx
 	Chains        []*txs.Tx
+	Camino        Camino
 	Timestamp     uint64
 	InitialSupply uint64
 }
@@ -66,6 +78,7 @@ func ParseState(genesisBytes []byte) (*State, error) {
 		UTXOs:         utxos,
 		Validators:    genesis.Validators,
 		Chains:        genesis.Chains,
+		Camino:        genesis.Camino,
 		Timestamp:     genesis.Timestamp,
 		InitialSupply: genesis.InitialSupply,
 	}, nil

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -6,10 +6,43 @@ package state
 import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 )
 
 // For state and diff
 type Camino interface {
 	LockedUTXOs(ids.Set, ids.ShortSet, locked.State) ([]*avax.UTXO, error)
+	CaminoGenesisState() (*genesis.Camino, error)
+}
+
+// For state only
+type CaminoState interface {
+	GenesisState() *genesis.Camino
+	SyncGenesis(genesisState *genesis.State) error
+}
+
+type caminoState struct {
+	verifyNodeSignature bool
+	lockModeBondDeposit bool
+}
+
+func newCaminoState() *caminoState {
+	return &caminoState{}
+}
+
+// Return current genesis args
+func (cs *caminoState) GenesisState() *genesis.Camino {
+	return &genesis.Camino{
+		VerifyNodeSignature: cs.verifyNodeSignature,
+		LockModeBondDeposit: cs.lockModeBondDeposit,
+	}
+}
+
+// Extract camino tag from genesis
+func (cs *caminoState) SyncGenesis(genesisState *genesis.State) error {
+	cs.lockModeBondDeposit = genesisState.Camino.LockModeBondDeposit
+	cs.verifyNodeSignature = genesisState.Camino.VerifyNodeSignature
+
+	return nil
 }

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 )
 
@@ -50,4 +51,12 @@ func (d *diff) LockedUTXOs(txIDs ids.Set, addresses ids.ShortSet, lockState lock
 	}
 
 	return nil, nil
+}
+
+func (d *diff) CaminoGenesisState() (*genesis.Camino, error) {
+	parentState, ok := d.stateVersions.GetState(d.parentID)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
+	}
+	return parentState.CaminoGenesisState()
 }

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 )
 
@@ -32,4 +33,8 @@ func (s *state) LockedUTXOs(txIDs ids.Set, addresses ids.ShortSet, lockState loc
 		}
 	}
 	return retUtxos, nil
+}
+
+func (s *state) CaminoGenesisState() (*genesis.Camino, error) {
+	return s.caminoState.GenesisState(), nil
 }

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -13,7 +13,8 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
-	lock "github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	genesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	locked "github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	gomock "github.com/golang/mock/gomock"
@@ -112,6 +113,21 @@ func (m *MockChain) AddUTXO(arg0 *avax.UTXO) {
 func (mr *MockChainMockRecorder) AddUTXO(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUTXO", reflect.TypeOf((*MockChain)(nil).AddUTXO), arg0)
+}
+
+// CaminoGenesisState mocks base method.
+func (m *MockChain) CaminoGenesisState() (*genesis.Camino, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaminoGenesisState")
+	ret0, _ := ret[0].(*genesis.Camino)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CaminoGenesisState indicates an expected call of CaminoGenesisState.
+func (mr *MockChainMockRecorder) CaminoGenesisState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaminoGenesisState", reflect.TypeOf((*MockChain)(nil).CaminoGenesisState))
 }
 
 // DeleteCurrentDelegator mocks base method.
@@ -385,7 +401,7 @@ func (mr *MockChainMockRecorder) GetUTXO(arg0 interface{}) *gomock.Call {
 }
 
 // LockedUTXOs mocks base method.
-func (m *MockChain) LockedUTXOs(arg0 ids.Set, arg1 ids.ShortSet, arg2 lock.State) ([]*avax.UTXO, error) {
+func (m *MockChain) LockedUTXOs(arg0 ids.Set, arg1 ids.ShortSet, arg2 locked.State) ([]*avax.UTXO, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LockedUTXOs", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*avax.UTXO)

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -13,7 +13,8 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
-	lock "github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	genesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	locked "github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	gomock "github.com/golang/mock/gomock"
@@ -124,6 +125,21 @@ func (m *MockDiff) Apply(arg0 State) {
 func (mr *MockDiffMockRecorder) Apply(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockDiff)(nil).Apply), arg0)
+}
+
+// CaminoGenesisState mocks base method.
+func (m *MockDiff) CaminoGenesisState() (*genesis.Camino, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaminoGenesisState")
+	ret0, _ := ret[0].(*genesis.Camino)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CaminoGenesisState indicates an expected call of CaminoGenesisState.
+func (mr *MockDiffMockRecorder) CaminoGenesisState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaminoGenesisState", reflect.TypeOf((*MockDiff)(nil).CaminoGenesisState))
 }
 
 // DeleteCurrentDelegator mocks base method.
@@ -397,7 +413,7 @@ func (mr *MockDiffMockRecorder) GetUTXO(arg0 interface{}) *gomock.Call {
 }
 
 // LockedUTXOs mocks base method.
-func (m *MockDiff) LockedUTXOs(arg0 ids.Set, arg1 ids.ShortSet, arg2 lock.State) ([]*avax.UTXO, error) {
+func (m *MockDiff) LockedUTXOs(arg0 ids.Set, arg1 ids.ShortSet, arg2 locked.State) ([]*avax.UTXO, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LockedUTXOs", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*avax.UTXO)

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -17,7 +17,8 @@ import (
 	validators "github.com/ava-labs/avalanchego/snow/validators"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
 	blocks "github.com/ava-labs/avalanchego/vms/platformvm/blocks"
-	lock "github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	genesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	locked "github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	gomock "github.com/golang/mock/gomock"
@@ -140,6 +141,21 @@ func (m *MockState) AddUTXO(arg0 *avax.UTXO) {
 func (mr *MockStateMockRecorder) AddUTXO(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUTXO", reflect.TypeOf((*MockState)(nil).AddUTXO), arg0)
+}
+
+// CaminoGenesisState mocks base method.
+func (m *MockState) CaminoGenesisState() (*genesis.Camino, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaminoGenesisState")
+	ret0, _ := ret[0].(*genesis.Camino)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CaminoGenesisState indicates an expected call of CaminoGenesisState.
+func (mr *MockStateMockRecorder) CaminoGenesisState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaminoGenesisState", reflect.TypeOf((*MockState)(nil).CaminoGenesisState))
 }
 
 // Close mocks base method.
@@ -532,7 +548,7 @@ func (mr *MockStateMockRecorder) GetValidatorWeightDiffs(arg0, arg1 interface{})
 }
 
 // LockedUTXOs mocks base method.
-func (m *MockState) LockedUTXOs(arg0 ids.Set, arg1 ids.ShortSet, arg2 lock.State) ([]*avax.UTXO, error) {
+func (m *MockState) LockedUTXOs(arg0 ids.Set, arg1 ids.ShortSet, arg2 locked.State) ([]*avax.UTXO, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LockedUTXOs", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*avax.UTXO)

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -226,6 +226,8 @@ type state struct {
 	currentStakers *baseStakers
 	pendingStakers *baseStakers
 
+	caminoState CaminoState
+
 	currentHeight uint64
 
 	addedBlocks map[ids.ID]stateBlk // map of blockID -> Block
@@ -492,6 +494,8 @@ func new(
 
 		currentStakers: newBaseStakers(),
 		pendingStakers: newBaseStakers(),
+
+		caminoState: newCaminoState(),
 
 		uptimes:        make(map[ids.NodeID]*uptimeAndReward),
 		updatedUptimes: make(map[ids.NodeID]struct{}),
@@ -1360,6 +1364,11 @@ func (s *state) init(genesisBytes []byte) error {
 	if err != nil {
 		return err
 	}
+
+	if err := s.caminoState.SyncGenesis(genesisState); err != nil {
+		return err
+	}
+
 	if err := s.syncGenesis(genesisBlock, genesisState); err != nil {
 		return err
 	}

--- a/vms/platformvm/utxo/camino_helpers_test.go
+++ b/vms/platformvm/utxo/camino_helpers_test.go
@@ -73,6 +73,10 @@ func defaultConfig() *config.Config {
 		ApricotPhase3Time: defaultValidateEndTime,
 		ApricotPhase5Time: defaultValidateEndTime,
 		BanffTime:         mockable.MaxTime,
+		CaminoConfig: config.CaminoConfig{
+			ValidatorBondAmount:   2 * units.KiloAvax,
+			DaoProposalBondAmount: 100 * units.Avax,
+		},
 	}
 }
 


### PR DESCRIPTION
## Add new Parameters to control Platform Behaviour

`VerifyNodeSignature (bool) and LockModeBondDeposit (bool)` are defined in genesis and are ment to be system parameters which will never change. Modifying these values lead to a new genesis hash id and would  be incompatible to the current fork.

`ValidatorBondAmount (uint64) and DaoProposalBondAmount (uint64)` are defined as Parameters and can be changed with an upcoming version. Genesis hash id is not changed, therefore changes doesn't lead to a new fork.
