### PR TITLE
CaminoExecutor

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,4 +4,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go test -race -timeout="120s" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v /mocks | grep -v proto | grep -v tests)
+CGO_CFLAGS="-O -D__BLST_PORTABLE__" go test -race -timeout="120s" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v /mocks | grep -v proto | grep -v tests)

--- a/vms/platformvm/blocks/executor/verifier.go
+++ b/vms/platformvm/blocks/executor/verifier.go
@@ -354,11 +354,13 @@ func (v *verifier) proposalBlock(
 	onCommitState state.Diff,
 	onAbortState state.Diff,
 ) error {
-	txExecutor := executor.ProposalTxExecutor{
-		OnCommitState: onCommitState,
-		OnAbortState:  onAbortState,
-		Backend:       v.txExecutorBackend,
-		Tx:            b.Tx,
+	txExecutor := executor.CaminoProposalTxExecutor{
+		ProposalTxExecutor: executor.ProposalTxExecutor{
+			OnCommitState: onCommitState,
+			OnAbortState:  onAbortState,
+			Backend:       v.txExecutorBackend,
+			Tx:            b.Tx,
+		},
 	}
 
 	if err := b.Tx.Unsigned.Visit(&txExecutor); err != nil {
@@ -403,10 +405,12 @@ func (v *verifier) standardBlock(
 	// Finally we process the transactions
 	funcs := make([]func(), 0, len(b.Transactions))
 	for _, tx := range b.Transactions {
-		txExecutor := executor.StandardTxExecutor{
-			Backend: v.txExecutorBackend,
-			State:   onAcceptState,
-			Tx:      tx,
+		txExecutor := executor.CaminoStandardTxExecutor{
+			StandardTxExecutor: executor.StandardTxExecutor{
+				Backend: v.txExecutorBackend,
+				State:   onAcceptState,
+				Tx:      tx,
+			},
 		}
 		if err := tx.Unsigned.Visit(&txExecutor); err != nil {
 			txID := tx.ID()

--- a/vms/platformvm/blocks/executor/verifier_test.go
+++ b/vms/platformvm/blocks/executor/verifier_test.go
@@ -71,7 +71,7 @@ func TestVerifierVisitProposalBlock(t *testing.T) {
 	}
 
 	blkTx := txs.NewMockUnsignedTx(ctrl)
-	blkTx.EXPECT().Visit(gomock.AssignableToTypeOf(&executor.ProposalTxExecutor{})).Return(nil).Times(1)
+	blkTx.EXPECT().Visit(gomock.AssignableToTypeOf(&executor.CaminoProposalTxExecutor{})).Return(nil).Times(1)
 
 	// We can't serialize [blkTx] because it isn't
 	// registered with the blocks.Codec.
@@ -261,8 +261,8 @@ func TestVerifierVisitStandardBlock(t *testing.T) {
 			},
 		},
 	}
-	blkTx.EXPECT().Visit(gomock.AssignableToTypeOf(&executor.StandardTxExecutor{})).DoAndReturn(
-		func(e *executor.StandardTxExecutor) error {
+	blkTx.EXPECT().Visit(gomock.AssignableToTypeOf(&executor.CaminoStandardTxExecutor{})).DoAndReturn(
+		func(e *executor.CaminoStandardTxExecutor) error {
 			e.OnAccept = func() {}
 			e.Inputs = ids.Set{}
 			e.AtomicRequests = atomicRequests
@@ -747,8 +747,8 @@ func TestVerifierVisitStandardBlockWithDuplicateInputs(t *testing.T) {
 			},
 		},
 	}
-	blkTx.EXPECT().Visit(gomock.AssignableToTypeOf(&executor.StandardTxExecutor{})).DoAndReturn(
-		func(e *executor.StandardTxExecutor) error {
+	blkTx.EXPECT().Visit(gomock.AssignableToTypeOf(&executor.CaminoStandardTxExecutor{})).DoAndReturn(
+		func(e *executor.CaminoStandardTxExecutor) error {
 			e.OnAccept = func() {}
 			e.Inputs = atomicInputs
 			e.AtomicRequests = atomicRequests

--- a/vms/platformvm/txs/executor/atomic_tx_executor.go
+++ b/vms/platformvm/txs/executor/atomic_tx_executor.go
@@ -65,10 +65,12 @@ func (e *AtomicTxExecutor) atomicTx(tx txs.UnsignedTx) error {
 	}
 	e.OnAccept = onAccept
 
-	executor := StandardTxExecutor{
-		Backend: e.Backend,
-		State:   e.OnAccept,
-		Tx:      e.Tx,
+	executor := CaminoStandardTxExecutor{
+		StandardTxExecutor{
+			Backend: e.Backend,
+			State:   e.OnAccept,
+			Tx:      e.Tx,
+		},
 	}
 	err = tx.Visit(&executor)
 	e.Inputs = executor.Inputs

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package executor
+
+type CaminoStandardTxExecutor struct {
+	StandardTxExecutor
+}
+
+type CaminoProposalTxExecutor struct {
+	ProposalTxExecutor
+}

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -3,10 +3,63 @@
 
 package executor
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+var errNodeSignatureMissing = errors.New("last signature is not nodeID's signature")
+
 type CaminoStandardTxExecutor struct {
 	StandardTxExecutor
 }
 
 type CaminoProposalTxExecutor struct {
 	ProposalTxExecutor
+}
+
+/* TLS certificates build by caminogo contain a secp256k1 signature of the
+ * x509 public signed with the nodeIDs private key
+ * TX which require nodeID verification (tx with nodeID parameter) must contain
+ * an additional signature after the signatures used for input verification.
+ * This signature must recover to the nodeID itself to verify that the sender
+ * has access to this node specific private key.
+ */
+func (e *CaminoStandardTxExecutor) verifyNodeSignature(nodeID ids.NodeID) error {
+	if state, err := e.State.CaminoGenesisState(); err != nil {
+		return err
+	} else if state.VerifyNodeSignature {
+		if err := e.Backend.Fx.VerifyPermission(
+			e.Tx.Unsigned,
+			&secp256k1fx.Input{SigIndices: []uint32{0}},
+			e.Tx.Creds[len(e.Tx.Creds)-1],
+			&secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs: []ids.ShortID{
+					ids.ShortID(nodeID),
+				},
+			},
+		); err != nil {
+			return fmt.Errorf("%w: %s", errNodeSignatureMissing, err)
+		}
+	}
+	return nil
+}
+
+func (e *CaminoStandardTxExecutor) AddValidatorTx(tx *txs.AddValidatorTx) error {
+	if err := e.verifyNodeSignature(tx.NodeID()); err != nil {
+		return err
+	}
+	return e.StandardTxExecutor.AddValidatorTx(tx)
+}
+
+func (e *CaminoStandardTxExecutor) AddSubnetValidatorTx(tx *txs.AddSubnetValidatorTx) error {
+	if err := e.verifyNodeSignature(tx.NodeID()); err != nil {
+		return err
+	}
+	return e.StandardTxExecutor.AddSubnetValidatorTx(tx)
 }

--- a/vms/platformvm/txs/executor/tx_mempool_verifier.go
+++ b/vms/platformvm/txs/executor/tx_mempool_verifier.go
@@ -75,10 +75,12 @@ func (v *MempoolTxVerifier) standardTx(tx txs.UnsignedTx) error {
 		return err
 	}
 
-	executor := StandardTxExecutor{
-		Backend: v.Backend,
-		State:   baseState,
-		Tx:      v.Tx,
+	executor := CaminoStandardTxExecutor{
+		StandardTxExecutor{
+			Backend: v.Backend,
+			State:   baseState,
+			Tx:      v.Tx,
+		},
 	}
 	err = tx.Visit(&executor)
 	// We ignore [errFutureStakeTime] here because the time will be advanced


### PR DESCRIPTION
## CaminoExecutor implementation
In order to implement camino features on Platform chain with less as possible changes in the existing source code, we decided to inherit from existing `StandardTxExecutor` and `ProposalTxExecutor` which allows us to extend and control already implemented functionality.
A sample implementation is part of this PR in the second commit which restricts addValidator and addSubnetValidator tx to the presence of an additional signature to verify that the signer of the tx is the owner of the nodeId in focus.