### PR TITLE
[PlatformVM] Re-Add changeAddr for Lock (==Spend)

### DIFF
--- a/vms/platformvm/locked/camino_lock.go
+++ b/vms/platformvm/locked/camino_lock.go
@@ -56,10 +56,14 @@ func (ls State) IsDeposited() bool {
 	return StateDeposited&ls == StateDeposited
 }
 
+/**********************  IDs *********************/
+
 type IDs struct {
 	DepositTxID ids.ID `serialize:"true" json:"depositTxID"`
 	BondTxID    ids.ID `serialize:"true" json:"bondTxID"`
 }
+
+var IDsEmpty = IDs{ids.Empty, ids.Empty}
 
 func (lock IDs) LockState() State {
 	lockState := StateUnlocked
@@ -136,6 +140,8 @@ func (lock *IDs) Match(lockState State, txIDs ids.Set) bool {
 	}
 	return false
 }
+
+/**********************  In / Out *********************/
 
 type Out struct {
 	IDs                  `serialize:"true" json:"lockIDs"`

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -44,7 +44,7 @@ func (b *caminoBuilder) NewAddValidatorTx(
 		)
 	}
 
-	ins, outs, signers, err := b.Lock(keys, stakeAmount, b.cfg.AddPrimaryNetworkValidatorFee, locked.StateBonded)
+	ins, outs, signers, err := b.Lock(keys, stakeAmount, b.cfg.AddPrimaryNetworkValidatorFee, locked.StateBonded, changeAddr)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
 	}

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -78,6 +78,7 @@ func (h *handler) Lock(
 	totalAmountToLock uint64,
 	totalAmountToBurn uint64,
 	appliedLockState locked.State,
+	changeAddr ids.ShortID,
 ) (
 	[]*avax.TransferableInput, // inputs
 	[]*avax.TransferableOutput, // outputs
@@ -290,11 +291,21 @@ func (h *handler) Lock(
 						},
 					})
 				} else {
+					var owners secp256k1fx.OutputOwners
+					if changeAddr != ids.ShortEmpty {
+						owners = secp256k1fx.OutputOwners{
+							Locktime:  0,
+							Threshold: 1,
+							Addrs:     []ids.ShortID{changeAddr},
+						}
+					} else {
+						owners = ownerAmounts.owners
+					}
 					outs = append(outs, &avax.TransferableOutput{
 						Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 						Out: &secp256k1fx.TransferOutput{
 							Amt:          amounts.remained,
-							OutputOwners: ownerAmounts.owners,
+							OutputOwners: owners,
 						},
 					})
 				}
@@ -564,29 +575,32 @@ func (h *handler) VerifyLockUTXOs(
 			return fmt.Errorf("failed to verify transfer: %w", err)
 		}
 
-		ownerID, err := GetOwnerID(out)
-		if err != nil {
-			return err
+		otherLockTxID := &lockIDs.DepositTxID
+		if appliedLockState == locked.StateDeposited {
+			otherLockTxID = &lockIDs.BondTxID
+		}
+
+		ownerID := &ids.Empty
+		if *otherLockTxID != ids.Empty {
+			id, err := GetOwnerID(out)
+			if err != nil {
+				return err
+			}
+			ownerID = &id
 		}
 
 		amount := in.Amount()
-
-		consumedOwnerAmounts, ok := consumed[ownerID]
+		consumedOwnerAmounts, ok := consumed[*ownerID]
 		if !ok {
 			consumedOwnerAmounts = make(map[ids.ID]uint64)
-			consumed[ownerID] = consumedOwnerAmounts
+			consumed[*ownerID] = consumedOwnerAmounts
 		}
 
-		otherLockTxID := lockIDs.DepositTxID
-		if appliedLockState == locked.StateDeposited {
-			otherLockTxID = lockIDs.BondTxID
-		}
-
-		newAmount, err := math.Add64(consumedOwnerAmounts[otherLockTxID], amount)
+		newAmount, err := math.Add64(consumedOwnerAmounts[*otherLockTxID], amount)
 		if err != nil {
 			return err
 		}
-		consumedOwnerAmounts[otherLockTxID] = newAmount
+		consumedOwnerAmounts[*otherLockTxID] = newAmount
 	}
 
 	for _, output := range outs {
@@ -601,22 +615,25 @@ func (h *handler) VerifyLockUTXOs(
 			out = lockedOut.TransferableOut
 		}
 
-		ownerID, err := GetOwnerID(out)
-		if err != nil {
-			return err
+		otherLockTxID := &lockIDs.DepositTxID
+		if appliedLockState == locked.StateDeposited {
+			otherLockTxID = &lockIDs.BondTxID
+		}
+
+		ownerID := &ids.Empty
+		if *otherLockTxID != ids.Empty {
+			id, err := GetOwnerID(out)
+			if err != nil {
+				return err
+			}
+			ownerID = &id
 		}
 
 		producedAmount := out.Amount()
-
-		otherLockTxID := lockIDs.DepositTxID
-		if appliedLockState == locked.StateDeposited {
-			otherLockTxID = lockIDs.BondTxID
-		}
-
 		consumedAmount := uint64(0)
-		consumedOwnerAmounts, ok := consumed[ownerID]
+		consumedOwnerAmounts, ok := consumed[*ownerID]
 		if ok {
-			consumedAmount = consumedOwnerAmounts[otherLockTxID]
+			consumedAmount = consumedOwnerAmounts[*otherLockTxID]
 		}
 
 		if consumedAmount < producedAmount {
@@ -631,7 +648,7 @@ func (h *handler) VerifyLockUTXOs(
 			)
 		}
 
-		consumedOwnerAmounts[otherLockTxID] = consumedAmount - producedAmount
+		consumedOwnerAmounts[*otherLockTxID] = consumedAmount - producedAmount
 	}
 
 	amountToBurn := burnedAmount

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -199,6 +199,7 @@ func TestLock(t *testing.T) {
 		totalAmountToSpend uint64
 		totalAmountToBurn  uint64
 		appliedLockState   locked.State
+		changeAddr         ids.ShortID
 	}
 	type want struct {
 		ins  []*avax.TransferableInput
@@ -394,6 +395,7 @@ func TestLock(t *testing.T) {
 				tt.args.totalAmountToSpend,
 				tt.args.totalAmountToBurn,
 				tt.args.appliedLockState,
+				tt.args.changeAddr,
 			)
 
 			avax.SortTransferableOutputs(want.outs, txs.Codec)

--- a/vms/platformvm/utxo/handler.go
+++ b/vms/platformvm/utxo/handler.go
@@ -123,6 +123,7 @@ type Spender interface {
 		totalAmountToLock uint64,
 		totalAmountToBurn uint64,
 		appliedLockState locked.State,
+		changeAddr ids.ShortID,
 	) (
 		[]*avax.TransferableInput, // inputs
 		[]*avax.TransferableOutput, // outputs


### PR DESCRIPTION
## [PlatformVM] Re-Add changeAddr for Lock (==Spend)
Currently changeAddr is not supported for our Lock() method which is used for preparing inputs and outputs for several transactions.
With this PR:
-> changeAddr comes back, but is ONLY applied to funds which will be in unlocked state after the transaction. 
-> Allows to transfer all unlocked Inputs (even they become locked) in Verify
-> Allows LockModeUnlocked in Lock(): Different UTXO sorting, needs test
-> Use as many pointers to ids as possible to reduce memcopies in sort.