### PR TITLE
camino builder: add node signature to AddValidatorTx, AddSubnetValidatorTx

### DIFF
--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -4,6 +4,7 @@
 package builder
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -13,6 +14,11 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validator"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+var (
+	errNodeKeyMissing   = errors.New("couldn't find key matching nodeID")
+	errWrongNodeKeyType = errors.New("node key type isn't *crypto.PrivateKeySECP256K1R")
 )
 
 type caminoBuilder struct {
@@ -29,9 +35,12 @@ func (b *caminoBuilder) NewAddValidatorTx(
 	keys []*crypto.PrivateKeySECP256K1R,
 	changeAddr ids.ShortID,
 ) (*txs.Tx, error) {
-	if state, err := b.builder.state.CaminoGenesisState(); err != nil {
+	caminoGenesis, err := b.builder.state.CaminoGenesisState()
+	if err != nil {
 		return nil, err
-	} else if !state.LockModeBondDeposit {
+	}
+
+	if !caminoGenesis.LockModeBondDeposit {
 		return b.builder.NewAddValidatorTx(
 			stakeAmount,
 			startTime,
@@ -47,6 +56,14 @@ func (b *caminoBuilder) NewAddValidatorTx(
 	ins, outs, signers, err := b.Lock(keys, stakeAmount, b.cfg.AddPrimaryNetworkValidatorFee, locked.StateBonded, changeAddr)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
+	}
+
+	if caminoGenesis.VerifyNodeSignature {
+		nodeSigners, err := getNodeSigners(keys, nodeID)
+		if err != nil {
+			return nil, err
+		}
+		signers = append(signers, nodeSigners)
 	}
 
 	utx := &txs.CaminoAddValidatorTx{
@@ -76,4 +93,87 @@ func (b *caminoBuilder) NewAddValidatorTx(
 		return nil, err
 	}
 	return tx, tx.SyntacticVerify(b.ctx)
+}
+
+func (b *caminoBuilder) NewAddSubnetValidatorTx(
+	weight,
+	startTime,
+	endTime uint64,
+	nodeID ids.NodeID,
+	subnetID ids.ID,
+	keys []*crypto.PrivateKeySECP256K1R,
+	changeAddr ids.ShortID,
+) (*txs.Tx, error) {
+	if caminoGenesis, err := b.builder.state.CaminoGenesisState(); err != nil {
+		return nil, err
+	} else if !caminoGenesis.VerifyNodeSignature {
+		return b.builder.NewAddSubnetValidatorTx(
+			weight,
+			startTime,
+			endTime,
+			nodeID,
+			subnetID,
+			keys,
+			changeAddr,
+		)
+	}
+
+	ins, outs, signers, err := b.Lock(keys, 0, b.cfg.TxFee, locked.StateUnlocked, changeAddr)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
+	}
+
+	subnetAuth, subnetSigners, err := b.Authorize(b.state, subnetID, keys)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't authorize tx's subnet restrictions: %w", err)
+	}
+	signers = append(signers, subnetSigners)
+
+	nodeSigners, err := getNodeSigners(keys, nodeID)
+	if err != nil {
+		return nil, err
+	}
+	signers = append(signers, nodeSigners)
+
+	// Create the tx
+	utx := &txs.AddSubnetValidatorTx{
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.ctx.NetworkID,
+			BlockchainID: b.ctx.ChainID,
+			Ins:          ins,
+			Outs:         outs,
+		}},
+		Validator: validator.SubnetValidator{
+			Validator: validator.Validator{
+				NodeID: nodeID,
+				Start:  startTime,
+				End:    endTime,
+				Wght:   weight,
+			},
+			Subnet: subnetID,
+		},
+		SubnetAuth: subnetAuth,
+	}
+	tx, err := txs.NewSigned(utx, txs.Codec, signers)
+	if err != nil {
+		return nil, err
+	}
+	return tx, tx.SyntacticVerify(b.ctx)
+}
+
+func getNodeSigners(
+	keys []*crypto.PrivateKeySECP256K1R,
+	nodeID ids.NodeID,
+) ([]*crypto.PrivateKeySECP256K1R, error) {
+	signer, found := secp256k1fx.NewKeychain(keys...).Get(ids.ShortID(nodeID))
+	if !found {
+		return nil, errNodeKeyMissing
+	}
+
+	key, ok := signer.(*crypto.PrivateKeySECP256K1R)
+	if !ok {
+		return nil, errWrongNodeKeyType
+	}
+
+	return []*crypto.PrivateKeySECP256K1R{key}, nil
 }


### PR DESCRIPTION
This PR updates caminoBuilder in platformVM
- Adds node-signature to AddValidatorTx method
- Adds AddSubnetValidatorTx method (with node-sig)