### PR TITLE
Add RewardValidatorTx method to CaminoProposalTxExecutor

### DIFF
--- a/vms/platformvm/blocks/executor/proposal_block_test.go
+++ b/vms/platformvm/blocks/executor/proposal_block_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -20,6 +30,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
@@ -89,6 +100,7 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 	}
 
 	// setup state to validate proposal block transaction
+	onParentAccept.EXPECT().CaminoGenesisState().Return(&genesis.Camino{}, nil)
 	onParentAccept.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 
 	currentStakersIt := state.NewMockStakerIterator(ctrl)
@@ -172,6 +184,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	env.mockedState.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 
 	onParentAccept := state.NewMockDiff(ctrl)
+	onParentAccept.EXPECT().CaminoGenesisState().Return(&genesis.Camino{}, nil)
 	onParentAccept.EXPECT().GetTimestamp().Return(parentTime).AnyTimes()
 	onParentAccept.EXPECT().GetCurrentSupply(constants.PrimaryNetworkID).Return(uint64(1000), nil).AnyTimes()
 

--- a/vms/platformvm/txs/camino_add_validator_tx.go
+++ b/vms/platformvm/txs/camino_add_validator_tx.go
@@ -21,6 +21,16 @@ type CaminoAddValidatorTx struct {
 	AddValidatorTx `serialize:"true"`
 }
 
+func (tx *CaminoAddValidatorTx) Stake() []*avax.TransferableOutput {
+	var stake []*avax.TransferableOutput
+	for _, out := range tx.Outs {
+		if lockedOut, ok := out.Out.(*locked.Out); ok && lockedOut.IsNewlyLockedWith(locked.StateBonded) {
+			stake = append(stake, out)
+		}
+	}
+	return stake
+}
+
 // SyntacticVerify returns nil iff [tx] is valid
 func (tx *CaminoAddValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 	switch {

--- a/vms/platformvm/txs/camino_reward_validator_tx.go
+++ b/vms/platformvm/txs/camino_reward_validator_tx.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import "github.com/ava-labs/avalanchego/vms/components/avax"
+
+var _ UnsignedTx = (*CaminoRewardValidatorTx)(nil)
+
+// CaminoRewardValidatorTx is a transaction that represents a proposal to
+// remove a validator that is currently validating from the validator set.
+//
+// If this transaction is accepted and the next block accepted is a Commit
+// block, the validator is removed and the address that the validator specified
+// receives the staked AVAX as well as a validating reward.
+//
+// If this transaction is accepted and the next block accepted is an Abort
+// block, the validator is removed and the address that the validator specified
+// receives the staked AVAX but no reward.
+type CaminoRewardValidatorTx struct {
+	Ins  []*avax.TransferableInput  `serialize:"true" json:"inputs"`
+	Outs []*avax.TransferableOutput `serialize:"true" json:"outputs"`
+
+	RewardValidatorTx `serialize:"true"`
+}

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -108,6 +108,7 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&locked.Out{}),
 
 		targetCodec.RegisterCustomType(&CaminoAddValidatorTx{}),
+		targetCodec.RegisterCustomType(&CaminoRewardValidatorTx{}),
 		targetCodec.RegisterCustomType(&AddAddressStateTx{}),
 	)
 	return errs.Err

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -74,6 +74,30 @@ func ProduceLocked(
 	return nil
 }
 
+type Unlocker interface {
+	// Unlock fetches utxos locked by [lockTxIDs] transactions
+	// with lock state [removedLockState], and then spends them producing
+	// [inputs] and [outputs].
+	// Outputs will have their lock state [removedLockState] removed,
+	// but could still be locked with other lock state.
+	// Arguments:
+	// - [state] are the state from which lock txs and locked utxos will be fetched.
+	// - [lockTxIDs] is array of lock transaction ids.
+	// - [removedLockState] is lock state that will be removed from result [outputs].
+	// Returns:
+	// - [inputs] the inputs that should be consumed to fund the outputs
+	// - [outputs] the outputs that should be returned to the UTXO set
+	Unlock(
+		state state.Chain,
+		lockTxIDs []ids.ID,
+		removedLockState locked.State,
+	) (
+		[]*avax.TransferableInput, // inputs
+		[]*avax.TransferableOutput, // outputs
+		error,
+	)
+}
+
 func (h *handler) Lock(
 	keys []*crypto.PrivateKeySECP256K1R,
 	totalAmountToLock uint64,

--- a/vms/platformvm/utxo/handler.go
+++ b/vms/platformvm/utxo/handler.go
@@ -130,6 +130,8 @@ type Spender interface {
 		[][]*crypto.PrivateKeySECP256K1R, // signers
 		error,
 	)
+
+	Unlocker
 }
 
 type Verifier interface {
@@ -192,6 +194,8 @@ type Verifier interface {
 		assetID ids.ID,
 		appliedLockState locked.State,
 	) error
+
+	Unlocker
 }
 
 type Handler interface {

--- a/vms/platformvm/utxo/mock_verifier.go
+++ b/vms/platformvm/utxo/mock_verifier.go
@@ -42,6 +42,22 @@ func (m *MockVerifier) EXPECT() *MockVerifierMockRecorder {
 	return m.recorder
 }
 
+// Unlock mocks base method.
+func (m *MockVerifier) Unlock(arg0 state.Chain, arg1 []ids.ID, arg2 locked.State) ([]*avax.TransferableInput, []*avax.TransferableOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Unlock", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*avax.TransferableInput)
+	ret1, _ := ret[1].([]*avax.TransferableOutput)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Unlock indicates an expected call of Unlock.
+func (mr *MockVerifierMockRecorder) Unlock(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlock", reflect.TypeOf((*MockVerifier)(nil).Unlock), arg0, arg1, arg2)
+}
+
 // VerifyLock mocks base method.
 func (m *MockVerifier) VerifyLock(arg0 txs.UnsignedTx, arg1 state.UTXOGetter, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID, arg7 locked.State) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR adds new tx type CaminoRewardValidatorTx and corresponding logic to tx builder and executor. This this wraps avax RewardValidatorTx and has inputs and outputs just like the normal transaction, but without signatures, because its system transaction.
CaminoRewardValidatorTx consumes utxos bonded by CaminoAddValidatorTx and produces unbonded ones.
On execute, this tx recreates its inputs and outputs based on AddValidatorTx id (which is part of avax RewardValidatorTx) and then checks that all values from tx body are equal to expected ones.
It also has all reward issuing and commit preference logic removed and its onAbort and onCommit states are equal.