### PR TITLE
A few small critical fixes

### DIFF
--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -227,9 +227,12 @@ func (ss *StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, r
 	// Specify the validators that are validating the primary network at genesis.
 	vdrs := txheap.NewByEndTime()
 	if args.Camino.LockModeBondDeposit {
-		if err := getCaminoValidators(args, vdrs, utxos); err != nil {
+		caminoVdrs, updatedUTXOs, err := getCaminoValidators(args, vdrs, utxos)
+		if err != nil {
 			return err
 		}
+		vdrs = caminoVdrs
+		utxos = updatedUTXOs
 	} else {
 		for _, vdr := range args.Validators {
 			weight := uint64(0)

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -50,7 +50,7 @@ func (d *diff) LockedUTXOs(txIDs ids.Set, addresses ids.ShortSet, lockState lock
 		}
 	}
 
-	return nil, nil
+	return retUtxos, nil
 }
 
 func (d *diff) CaminoGenesisState() (*genesis.Camino, error) {

--- a/vms/platformvm/txs/camino_add_validator_tx.go
+++ b/vms/platformvm/txs/camino_add_validator_tx.go
@@ -18,7 +18,7 @@ var _ ValidatorTx = (*CaminoAddValidatorTx)(nil)
 
 // CaminoAddValidatorTx is an unsigned caminoAddValidatorTx
 type CaminoAddValidatorTx struct {
-	AddValidatorTx
+	AddValidatorTx `serialize:"true"`
 }
 
 // SyntacticVerify returns nil iff [tx] is valid


### PR DESCRIPTION
This PR fixes some critical typos and bugs:
- state.Diff LockedUTXOs was always returning nil utxos.
- CaminoAddValidatorTx.AddValidatorTx didn't have the serialize tag.
- static service BuildGenesis getCaminoValidators func meant to update utxos slice, but only underlying array was updated, so some validator utxos was missing.