### PR TITLE
TECH-417: Add camino executor helpers

### DIFF
--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -20,7 +20,6 @@ import (
 	"path"
 
 	"github.com/gorilla/rpc/v2"
-
 	"go.uber.org/zap"
 
 	"github.com/ava-labs/avalanchego/api"
@@ -36,7 +35,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/nodeid"
 	"github.com/ava-labs/avalanchego/utils/perms"
 	"github.com/ava-labs/avalanchego/utils/profiler"
 	"github.com/ava-labs/avalanchego/vms"
@@ -342,7 +340,7 @@ func (service *Admin) GetNodeSigner(_ *http.Request, _ *struct{}, reply *GetNode
 	config := service.Config.NodeConfig.(*node.Config)
 
 	rsaPrivKey := config.StakingTLSCert.PrivateKey.(*rsa.PrivateKey)
-	privKey := nodeid.RsaPrivateKeyToSecp256PrivateKey(rsaPrivKey)
+	privKey := crypto.RsaPrivateKeyToSecp256PrivateKey(rsaPrivKey)
 	pubKeyBytes := hashing.PubkeyBytesToAddress(privKey.PubKey().SerializeCompressed())
 	nodeID, err := ids.ToShortID(pubKeyBytes)
 	if err != nil {

--- a/network/peer/upgrader.go
+++ b/network/peer/upgrader.go
@@ -20,7 +20,7 @@ import (
 	"net"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils/nodeid"
+	"github.com/ava-labs/avalanchego/utils/crypto"
 )
 
 var (
@@ -79,7 +79,7 @@ func connToIDAndCert(conn *tls.Conn) (ids.NodeID, net.Conn, *x509.Certificate, e
 }
 
 func CertToID(cert *x509.Certificate) (ids.NodeID, error) {
-	pubKeyBytes, err := nodeid.RecoverSecp256PublicKey(cert)
+	pubKeyBytes, err := crypto.RecoverSecp256PublicKey(cert)
 	if err != nil {
 		return ids.EmptyNodeID, err
 	}

--- a/staking/tls.go
+++ b/staking/tls.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/nodeid"
+	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/utils/perms"
 )
 
@@ -125,8 +125,8 @@ func NewCertAndKeyBytes() ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("couldn't generate rsa key: %w", err)
 	}
 	// Create SECP256K1 key to sign cert with
-	secpKey := nodeid.RsaPrivateKeyToSecp256PrivateKey(rsaKey)
-	extension := nodeid.SignRsaPublicKey(secpKey, &rsaKey.PublicKey)
+	secpKey := crypto.RsaPrivateKeyToSecp256PrivateKey(rsaKey)
+	extension := crypto.SignRsaPublicKey(secpKey, &rsaKey.PublicKey)
 
 	// Create self-signed staking cert
 	certTemplate := &x509.Certificate{

--- a/utils/crypto/rsa2secp256k1.go
+++ b/utils/crypto/rsa2secp256k1.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2022, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package nodeid
+package crypto
 
 import (
 	rsa "crypto/rsa"
@@ -10,10 +10,10 @@ import (
 	"encoding/asn1"
 	"errors"
 
+	"github.com/ava-labs/avalanchego/utils/hashing"
+
 	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v3"
 	ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
-
-	"github.com/ava-labs/avalanchego/utils/hashing"
 )
 
 var oidLocalKeyID = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 21}

--- a/utils/crypto/rsa2secp256k1_test.go
+++ b/utils/crypto/rsa2secp256k1_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2022, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package nodeid
+package crypto
 
 import (
 	"bytes"
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,8 +66,8 @@ func newCertAndKeyBytesWithNoExt() ([]byte, []byte, error) {
 }
 
 func getPublicKey(t *testing.T, tlsCert *tls.Certificate) []byte {
-	secp256Factory := crypto.FactorySECP256K1R{}
-	var nodePrivateKey crypto.PrivateKey
+	secp256Factory := FactorySECP256K1R{}
+	var nodePrivateKey PrivateKey
 
 	rsaPrivateKey, ok := tlsCert.PrivateKey.(*rsa.PrivateKey)
 	require.True(t, ok)

--- a/utils/nodeid/helpers.go
+++ b/utils/nodeid/helpers.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package nodeid
+
+import (
+	"crypto/rsa"
+	"strconv"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/staking"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+)
+
+var localNodesCount = 5
+
+func LoadLocalCaminoNodeKeysAndIDs(localStakingPath string) ([]*crypto.PrivateKeySECP256K1R, []ids.NodeID) {
+	nodeKeys := make([]*crypto.PrivateKeySECP256K1R, localNodesCount)
+	nodeIDs := make([]ids.NodeID, localNodesCount)
+
+	for index := 1; index < localNodesCount; index++ {
+		secp256Factory := crypto.FactorySECP256K1R{}
+		var nodePrivateKey crypto.PrivateKey
+
+		cert, err := staking.LoadTLSCertFromFiles(
+			localStakingPath+"staker"+strconv.Itoa(index)+".key",
+			localStakingPath+"staker"+strconv.Itoa(index)+".crt")
+		if err != nil {
+			panic(err)
+		}
+
+		rsaKey, ok := cert.PrivateKey.(*rsa.PrivateKey)
+		if !ok {
+			panic("Wrong private key type")
+		}
+		secpPrivateKey := crypto.RsaPrivateKeyToSecp256PrivateKey(rsaKey)
+		nodePrivateKey, err = secp256Factory.ToPrivateKey(secpPrivateKey.Serialize())
+		if err != nil {
+			panic(err)
+		}
+		nodeSECP256PrivateKey, ok := nodePrivateKey.(*crypto.PrivateKeySECP256K1R)
+		if !ok {
+			panic("Could not cast node's private key to PrivateKeySECP256K1R")
+		}
+		nodeID := nodePrivateKey.PublicKey().Address()
+		nodeKeys[index] = nodeSECP256PrivateKey
+		nodeIDs[index] = ids.NodeID(nodeID)
+	}
+	return nodeKeys, nodeIDs
+}
+
+func GenerateCaminoNodeKeyAndID() (*crypto.PrivateKeySECP256K1R, ids.NodeID) {
+	secp256Factory := crypto.FactorySECP256K1R{}
+	nodePrivateKey, err := secp256Factory.NewPrivateKey()
+	if err != nil {
+		panic("Couldn't generate private key")
+	}
+	nodeSECP256PrivateKey, ok := nodePrivateKey.(*crypto.PrivateKeySECP256K1R)
+	if !ok {
+		panic("Could not cast node's private key to PrivateKeySECP256K1R")
+	}
+	nodeID := nodePrivateKey.PublicKey().Address()
+	return nodeSECP256PrivateKey, ids.NodeID(nodeID)
+}

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -1,0 +1,283 @@
+// Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package executor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/ava-labs/avalanchego/chains"
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/manager"
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/uptime"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/formatting"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/json"
+	"github.com/ava-labs/avalanchego/utils/nodeid"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/metrics"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+	"github.com/ava-labs/avalanchego/vms/platformvm/status"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs/builder"
+	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
+)
+
+var (
+	localStakingPath          = "../../../../staking/local/"
+	caminoPreFundedKeys       = crypto.BuildTestKeys()
+	_, caminoPreFundedNodeIDs = nodeid.LoadLocalCaminoNodeKeysAndIDs(localStakingPath)
+)
+
+func newCaminoEnvironment(postBanff bool, caminoGenesisConf genesis.Camino) *environment {
+	var isBootstrapped utils.AtomicBool
+	isBootstrapped.SetValue(true)
+
+	config := defaultCaminoConfig(postBanff)
+	clk := defaultClock(postBanff)
+
+	baseDBManager := manager.NewMemDB(version.CurrentDatabase)
+	baseDB := versiondb.New(baseDBManager.Current().Database)
+	ctx, msm := defaultCtx(baseDB)
+
+	fx := defaultFx(&clk, ctx.Log, isBootstrapped.GetValue())
+
+	rewards := reward.NewCalculator(config.RewardConfig)
+	baseState := defaultCaminoState(&config, ctx, baseDB, rewards, caminoGenesisConf)
+
+	atomicUTXOs := avax.NewAtomicUTXOManager(ctx.SharedMemory, txs.Codec)
+	uptimes := uptime.NewManager(baseState)
+	utxoHandler := utxo.NewHandler(ctx, &clk, baseState, fx)
+
+	txBuilder := builder.New(
+		ctx,
+		&config,
+		&clk,
+		fx,
+		baseState,
+		atomicUTXOs,
+		utxoHandler,
+	)
+
+	backend := Backend{
+		Config:       &config,
+		Ctx:          ctx,
+		Clk:          &clk,
+		Bootstrapped: &isBootstrapped,
+		Fx:           fx,
+		FlowChecker:  utxoHandler,
+		Uptimes:      uptimes,
+		Rewards:      rewards,
+	}
+
+	env := &environment{
+		isBootstrapped: &isBootstrapped,
+		config:         &config,
+		clk:            &clk,
+		baseDB:         baseDB,
+		ctx:            ctx,
+		msm:            msm,
+		fx:             fx,
+		state:          baseState,
+		states:         make(map[ids.ID]state.Chain),
+		atomicUTXOs:    atomicUTXOs,
+		uptimes:        uptimes,
+		utxosHandler:   utxoHandler,
+		txBuilder:      txBuilder,
+		backend:        backend,
+	}
+
+	addCaminoSubnet(env, txBuilder)
+
+	return env
+}
+
+func addCaminoSubnet(
+	env *environment,
+	txBuilder builder.Builder,
+) {
+	// Create a subnet
+	var err error
+	testSubnet1, err = txBuilder.NewCreateSubnetTx(
+		2, // threshold; 2 sigs from keys[0], keys[1], keys[2] needed to add validator to this subnet
+		[]ids.ShortID{ // control keys
+			caminoPreFundedKeys[0].PublicKey().Address(),
+			caminoPreFundedKeys[1].PublicKey().Address(),
+			caminoPreFundedKeys[2].PublicKey().Address(),
+		},
+		[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0]},
+		caminoPreFundedKeys[0].PublicKey().Address(),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// store it
+	stateDiff, err := state.NewDiff(lastAcceptedID, env)
+	if err != nil {
+		panic(err)
+	}
+
+	executor := CaminoStandardTxExecutor{
+		StandardTxExecutor{
+			Backend: &env.backend,
+			State:   stateDiff,
+			Tx:      testSubnet1,
+		},
+	}
+	err = testSubnet1.Unsigned.Visit(&executor)
+	if err != nil {
+		panic(err)
+	}
+
+	stateDiff.AddTx(testSubnet1, status.Committed)
+	stateDiff.Apply(env.state)
+}
+
+func defaultCaminoState(
+	cfg *config.Config,
+	ctx *snow.Context,
+	db database.Database,
+	rewards reward.Calculator,
+	caminoGenesisConf genesis.Camino,
+) state.State {
+	genesisBytes := buildCaminoGenesisTest(ctx, caminoGenesisConf)
+	state, err := state.New(
+		db,
+		genesisBytes,
+		prometheus.NewRegistry(),
+		cfg,
+		ctx,
+		metrics.Noop,
+		rewards,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// persist and reload to init a bunch of in-memory stuff
+	state.SetHeight(0)
+	if err := state.Commit(); err != nil {
+		panic(err)
+	}
+	state.SetHeight( /*height*/ 0)
+	if err := state.Commit(); err != nil {
+		panic(err)
+	}
+	lastAcceptedID = state.GetLastAccepted()
+	return state
+}
+
+func defaultCaminoConfig(postBanff bool) config.Config {
+	banffTime := mockable.MaxTime
+	if postBanff {
+		banffTime = defaultValidateEndTime.Add(-2 * time.Second)
+	}
+	return config.Config{
+		Chains:                 chains.MockManager{},
+		UptimeLockedCalculator: uptime.NewLockedCalculator(),
+		Validators:             validators.NewManager(),
+		TxFee:                  defaultTxFee,
+		CreateSubnetTxFee:      100 * defaultTxFee,
+		CreateBlockchainTxFee:  100 * defaultTxFee,
+		MinValidatorStake:      5 * units.MilliAvax,
+		MaxValidatorStake:      500 * units.MilliAvax,
+		MinDelegatorStake:      1 * units.MilliAvax,
+		MinStakeDuration:       defaultMinStakingDuration,
+		MaxStakeDuration:       defaultMaxStakingDuration,
+		RewardConfig: reward.Config{
+			MaxConsumptionRate: .12 * reward.PercentDenominator,
+			MinConsumptionRate: .10 * reward.PercentDenominator,
+			MintingPeriod:      365 * 24 * time.Hour,
+			SupplyCap:          720 * units.MegaAvax,
+		},
+		ApricotPhase3Time: defaultValidateEndTime,
+		ApricotPhase5Time: defaultValidateEndTime,
+		BanffTime:         banffTime,
+		CaminoConfig: config.CaminoConfig{
+			ValidatorBondAmount:   2 * units.KiloAvax,
+			DaoProposalBondAmount: 100 * units.Avax,
+		},
+	}
+}
+
+func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf genesis.Camino) []byte {
+	genesisUTXOs := make([]api.UTXO, len(caminoPreFundedKeys))
+	hrp := constants.NetworkIDToHRP[testNetworkID]
+	for i, key := range caminoPreFundedKeys {
+		addr, err := address.FormatBech32(hrp, key.PublicKey().Address().Bytes())
+		if err != nil {
+			panic(err)
+		}
+		genesisUTXOs[i] = api.UTXO{
+			Amount:  json.Uint64(defaultBalance),
+			Address: addr,
+		}
+	}
+
+	genesisValidators := make([]api.PermissionlessValidator, len(caminoPreFundedKeys))
+	for i, key := range caminoPreFundedKeys {
+		addr, err := address.FormatBech32(hrp, key.PublicKey().Address().Bytes())
+		if err != nil {
+			panic(err)
+		}
+		genesisValidators[i] = api.PermissionlessValidator{
+			Staker: api.Staker{
+				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
+				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
+				NodeID:    caminoPreFundedNodeIDs[i],
+			},
+			RewardOwner: &api.Owner{
+				Threshold: 1,
+				Addresses: []string{addr},
+			},
+			Staked: []api.UTXO{{
+				Amount:  json.Uint64(defaultWeight),
+				Address: addr,
+			}},
+			DelegationFee: reward.PercentDenominator,
+		}
+	}
+
+	buildGenesisArgs := api.BuildGenesisArgs{
+		NetworkID:     json.Uint32(testNetworkID),
+		AvaxAssetID:   ctx.AVAXAssetID,
+		UTXOs:         genesisUTXOs,
+		Validators:    genesisValidators,
+		Chains:        nil,
+		Time:          json.Uint64(defaultGenesisTime.Unix()),
+		Camino:        caminoGenesisConf,
+		InitialSupply: json.Uint64(360 * units.MegaAvax),
+		Encoding:      formatting.Hex,
+	}
+
+	buildGenesisResponse := api.BuildGenesisReply{}
+	platformvmSS := api.StaticService{}
+	if err := platformvmSS.BuildGenesis(nil, &buildGenesisArgs, &buildGenesisResponse); err != nil {
+		panic(fmt.Errorf("problem while building platform chain's genesis state: %v", err))
+	}
+
+	genesisBytes, err := formatting.Decode(buildGenesisResponse.Encoding, buildGenesisResponse.Bytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return genesisBytes
+}

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+)
+
+func TestCaminoEnv(t *testing.T) {
+	caminoGenesisConf := genesis.Camino{
+		VerifyNodeSignature: true,
+		LockModeBondDeposit: true,
+	}
+	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+	env.ctx.Lock.Lock()
+	defer func() {
+		if err := shutdownEnvironment(env); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	env.config.BanffTime = env.state.GetTimestamp()
+}

--- a/vms/proposervm/block/block.go
+++ b/vms/proposervm/block/block.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/staking"
+	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/utils/hashing"
-	"github.com/ava-labs/avalanchego/utils/nodeid"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
 
@@ -101,7 +101,7 @@ func (b *statelessBlock) initialize(bytes []byte) error {
 
 	b.cert = cert
 
-	nodeIDBytes, err := nodeid.RecoverSecp256PublicKey(cert)
+	nodeIDBytes, err := crypto.RecoverSecp256PublicKey(cert)
 	if err != nil {
 		return err
 	}

--- a/vms/proposervm/block/block_test.go
+++ b/vms/proposervm/block/block_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/stretchr/testify/require"
 )
 
 func equal(require *require.Assertions, chainID ids.ID, want, have SignedBlock) {

--- a/vms/proposervm/block/parse_test.go
+++ b/vms/proposervm/block/parse_test.go
@@ -19,11 +19,12 @@ import (
 	"testing"
 	"time"
 
+	crypto2 "github.com/ava-labs/avalanchego/utils/crypto"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/staking"
-	"github.com/ava-labs/avalanchego/utils/nodeid"
 )
 
 func TestParse(t *testing.T) {
@@ -41,7 +42,7 @@ func TestParse(t *testing.T) {
 	cert := tlsCert.Leaf
 	key := tlsCert.PrivateKey.(crypto.Signer)
 
-	nodeIDBytes, err := nodeid.RecoverSecp256PublicKey(cert)
+	nodeIDBytes, err := crypto2.RecoverSecp256PublicKey(cert)
 	require.NoError(err)
 
 	nodeID, err := ids.ToNodeID(nodeIDBytes)

--- a/vms/proposervm/state/block_state_test.go
+++ b/vms/proposervm/state/block_state_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -27,8 +26,9 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/choices"
 	"github.com/ava-labs/avalanchego/staking"
-	"github.com/ava-labs/avalanchego/utils/nodeid"
 	"github.com/ava-labs/avalanchego/vms/proposervm/block"
+
+	crypto2 "github.com/ava-labs/avalanchego/utils/crypto"
 )
 
 func testBlockState(a *require.Assertions, bs BlockState) {
@@ -44,7 +44,7 @@ func testBlockState(a *require.Assertions, bs BlockState) {
 	cert := tlsCert.Leaf
 	key := tlsCert.PrivateKey.(crypto.Signer)
 
-	nodeIDBytes, err := nodeid.RecoverSecp256PublicKey(cert)
+	nodeIDBytes, err := crypto2.RecoverSecp256PublicKey(cert)
 	a.NoError(err)
 	nodeID, err := ids.ToNodeID(nodeIDBytes)
 	a.NoError(err)
@@ -137,7 +137,7 @@ func initCommonTestData(a *require.Assertions) (database.Database, BlockState, b
 	cert := tlsCert.Leaf
 	key := tlsCert.PrivateKey.(crypto.Signer)
 
-	nodeIDBytes, err := nodeid.RecoverSecp256PublicKey(cert)
+	nodeIDBytes, err := crypto2.RecoverSecp256PublicKey(cert)
 	a.NoError(err)
 	nodeID, err := ids.ToNodeID(nodeIDBytes)
 	a.NoError(err)

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database/manager"
@@ -35,13 +34,13 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block/mocks"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/staking"
-	"github.com/ava-labs/avalanchego/utils/nodeid"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/proposervm/proposer"
 	"github.com/ava-labs/avalanchego/vms/proposervm/state"
 	"github.com/ava-labs/avalanchego/vms/proposervm/tree"
 
+	crypto2 "github.com/ava-labs/avalanchego/utils/crypto"
 	statelessblock "github.com/ava-labs/avalanchego/vms/proposervm/block"
 )
 
@@ -77,7 +76,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	nodeIDBytes, err := nodeid.RecoverSecp256PublicKey(pTestCert.Leaf)
+	nodeIDBytes, err := crypto2.RecoverSecp256PublicKey(pTestCert.Leaf)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Description ## 
With this PR we are creating a new testing environment in the executor package in order to be able to use our camino related changes (genesis and config changes) in our tests. 

## Changes ##

- `camino_helpers_test.go` file was added inducing the implementation of the camino environment described above.
- `rsa2secp256k1.go` and `rsa2secp256k1test.go` files have been moved to the `crypto` package in order to resolve the import circular dependency issues (and also IMO seems more reasonable to be there)
- `helpers.go` file was added to the `nodeid` package including helper functions load the already existing nodeIDs and nodeKey and generate new ones for testing purposes.
- `camino_tx_executor_test.go` was added in order to include a dummy test using the camino environment