### PR TITLE
[Genesis] Better error text for missing initialAdmin

### DIFF
--- a/genesis/camino_unparsed_config.go
+++ b/genesis/camino_unparsed_config.go
@@ -4,11 +4,15 @@
 package genesis
 
 import (
+	"fmt"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 )
+
+var errCannotParseInitialAdmin = "cannot parse initialAdmin from genesis: %w"
 
 type UnparsedCamino struct {
 	VerifyNodeSignature bool   `json:"verifyNodeSignature"`
@@ -24,11 +28,11 @@ func (us UnparsedCamino) Parse() (genesis.Camino, error) {
 
 	_, _, avaxAddrBytes, err := address.Parse(us.InitialAdmin)
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf(errCannotParseInitialAdmin, err)
 	}
 	avaxAddr, err := ids.ToShortID(avaxAddrBytes)
 	if err != nil {
-		return c, err
+		return c, fmt.Errorf(errCannotParseInitialAdmin, err)
 	}
 	c.InitialAdmin = avaxAddr
 	return c, nil


### PR DESCRIPTION
## Better error text for missing initialAdmin
When parsing genesis file and the camino:initialAdmin is not properly set, camino-node fails to launch with a too short error text.