### PR TITLE
TECH-414: AddSubnetValidatorTx integration tests 

### DIFF
--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
-func TestCaminoBuilderNewAddValidatorTxNodeSig(t *testing.T) {
+func TestCaminoBuilderTxNodeSig(t *testing.T) {
 	nodeKey1, nodeID1 := nodeid.GenerateCaminoNodeKeyAndID()
 	nodeKey2, _ := nodeid.GenerateCaminoNodeKeyAndID()
 
@@ -56,7 +56,7 @@ func TestCaminoBuilderNewAddValidatorTxNodeSig(t *testing.T) {
 		// because the error will rise from the execution
 	}
 	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
+		t.Run("AddValidatorTx: "+name, func(t *testing.T) {
 			b := newCaminoBuilder(true, tt.caminoConfig)
 
 			_, err := b.NewAddValidatorTx(
@@ -67,6 +67,21 @@ func TestCaminoBuilderNewAddValidatorTxNodeSig(t *testing.T) {
 				ids.ShortEmpty,
 				reward.PercentDenominator,
 				[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], tt.nodeKey},
+				ids.ShortEmpty,
+			)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+
+		t.Run("AddSubnetValidatorTx: "+name, func(t *testing.T) {
+			b := newCaminoBuilder(true, tt.caminoConfig)
+
+			_, err := b.NewAddSubnetValidatorTx(
+				defaultCaminoValidatorWeight,
+				uint64(defaultValidateStartTime.Unix()+1),
+				uint64(defaultValidateEndTime.Unix()),
+				tt.nodeID,
+				testSubnet1.ID(),
+				[]*crypto.PrivateKeySECP256K1R{testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], tt.nodeKey},
 				ids.ShortEmpty,
 			)
 			require.ErrorIs(t, err, tt.expectedErr)

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -52,6 +52,7 @@ var (
 	caminoPreFundedKeys                             = crypto.BuildTestKeys()
 	caminoPreFundedNodeKeys, caminoPreFundedNodeIDs = nodeid.LoadLocalCaminoNodeKeysAndIDs(localStakingPath)
 	defaultCaminoBalance                            = 100 * defaultCaminoValidatorWeight
+	testCaminoSubnet1ControlKeys                    = caminoPreFundedKeys[0:3]
 )
 
 func newCaminoEnvironment(postBanff bool, caminoGenesisConf genesis.Camino) *environment {

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/nodeid"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
@@ -212,6 +214,286 @@ func TestCaminoStandardTxExecutorAddValidatorTx(t *testing.T) {
 			}
 			err = tx.Unsigned.Visit(&executor)
 			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestCaminoStandardTxExecutorAddSubnetValidatorTx(t *testing.T) {
+	caminoGenesisConf := genesis.Camino{
+		VerifyNodeSignature: true,
+		LockModeBondDeposit: true,
+	}
+	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+	env.ctx.Lock.Lock()
+	defer func() {
+		if err := shutdownEnvironment(env); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	env.config.BanffTime = env.state.GetTimestamp()
+	nodeKey, nodeID := caminoPreFundedNodeKeys[0], caminoPreFundedNodeIDs[0]
+	tempNodeKey, tempNodeID := nodeid.GenerateCaminoNodeKeyAndID()
+
+	pendingDSValidatorKey, pendingDSValidatorID := nodeid.GenerateCaminoNodeKeyAndID()
+	DSStartTime := defaultGenesisTime.Add(10 * time.Second)
+	DSEndTime := DSStartTime.Add(5 * defaultMinStakingDuration)
+
+	// Add `pendingDSValidatorID` as validator to pending set
+	addDSTx, err := env.txBuilder.NewAddValidatorTx(
+		env.config.MinValidatorStake,
+		uint64(DSStartTime.Unix()),
+		uint64(DSEndTime.Unix()),
+		pendingDSValidatorID,
+		ids.ShortEmpty,
+		reward.PercentDenominator,
+		[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], pendingDSValidatorKey},
+		ids.ShortEmpty,
+	)
+	require.NoError(t, err)
+	staker := state.NewCurrentStaker(
+		addDSTx.ID(),
+		addDSTx.Unsigned.(*txs.CaminoAddValidatorTx),
+		0,
+	)
+	env.state.PutCurrentValidator(staker)
+	env.state.AddTx(addDSTx, status.Committed)
+	dummyHeight := uint64(1)
+	env.state.SetHeight(dummyHeight)
+	err = env.state.Commit()
+	require.NoError(t, err)
+
+	// Add `caminoPreFundedNodeIDs[1]` as subnet validator
+	subnetTx, err := env.txBuilder.NewAddSubnetValidatorTx(
+		env.config.MinValidatorStake,
+		uint64(defaultValidateStartTime.Unix()),
+		uint64(defaultValidateEndTime.Unix()),
+		caminoPreFundedNodeIDs[1],
+		testSubnet1.ID(),
+		[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], caminoPreFundedNodeKeys[1]},
+		ids.ShortEmpty,
+	)
+	require.NoError(t, err)
+	staker = state.NewCurrentStaker(
+		subnetTx.ID(),
+		subnetTx.Unsigned.(*txs.AddSubnetValidatorTx),
+		0,
+	)
+	env.state.PutCurrentValidator(staker)
+	env.state.AddTx(subnetTx, status.Committed)
+	env.state.SetHeight(dummyHeight)
+
+	err = env.state.Commit()
+	require.NoError(t, err)
+
+	type args struct {
+		weight     uint64
+		startTime  uint64
+		endTime    uint64
+		nodeID     ids.NodeID
+		subnetID   ids.ID
+		keys       []*crypto.PrivateKeySECP256K1R
+		changeAddr ids.ShortID
+	}
+	tests := map[string]struct {
+		generateArgs        func() args
+		preExecute          func(*testing.T, *txs.Tx)
+		expectedSpecificErr error
+		// In some checks, avalanche implementation is not returning a specific error or this error is private
+		// So in order not to change avalanche files we should just assert that we have some error
+		expectedGeneralErr bool
+	}{
+		"Happy path validator in current set of primary network": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(defaultValidateStartTime.Unix()) + 1,
+					endTime:    uint64(defaultValidateEndTime.Unix()),
+					nodeID:     nodeID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], nodeKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute:          func(t *testing.T, tx *txs.Tx) {},
+			expectedSpecificErr: nil,
+		},
+		"Validator stops validating subnet after stops validating primary network": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(defaultValidateStartTime.Unix()) + 1,
+					endTime:    uint64(defaultValidateEndTime.Unix() + 1),
+					nodeID:     nodeID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], nodeKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute:          func(t *testing.T, tx *txs.Tx) {},
+			expectedSpecificErr: errValidatorSubset,
+		},
+		"Validator not in pending or current validator set": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(defaultValidateStartTime.Unix()) + 1,
+					endTime:    uint64(defaultValidateEndTime.Unix()),
+					nodeID:     tempNodeID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], tempNodeKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute:          func(t *testing.T, tx *txs.Tx) {},
+			expectedSpecificErr: database.ErrNotFound,
+		},
+		"Validator in pending set but starts validating before primary network": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(DSStartTime.Unix()) - 1,
+					endTime:    uint64(DSEndTime.Unix()),
+					nodeID:     pendingDSValidatorID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], pendingDSValidatorKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute:          func(t *testing.T, tx *txs.Tx) {},
+			expectedSpecificErr: errValidatorSubset,
+		},
+		"Validator in pending set but stops after primary network": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(DSStartTime.Unix()),
+					endTime:    uint64(DSEndTime.Unix()) + 1,
+					nodeID:     pendingDSValidatorID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], pendingDSValidatorKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute:          func(t *testing.T, tx *txs.Tx) {},
+			expectedSpecificErr: errValidatorSubset,
+		},
+		"Happy path validator in pending set": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(DSStartTime.Unix()),
+					endTime:    uint64(DSEndTime.Unix()),
+					nodeID:     pendingDSValidatorID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], pendingDSValidatorKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute:          func(t *testing.T, tx *txs.Tx) {},
+			expectedSpecificErr: nil,
+		},
+		"Validator starts at current timestamp": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(defaultValidateStartTime.Unix()),
+					endTime:    uint64(defaultValidateEndTime.Unix()),
+					nodeID:     nodeID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], nodeKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute:          func(t *testing.T, tx *txs.Tx) {},
+			expectedSpecificErr: errTimestampNotBeforeStartTime,
+		},
+		"Validator is already a subnet validator": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(defaultValidateStartTime.Unix() + 1),
+					endTime:    uint64(defaultValidateEndTime.Unix()),
+					nodeID:     caminoPreFundedNodeIDs[1],
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], caminoPreFundedNodeKeys[1]},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute:         func(t *testing.T, tx *txs.Tx) {},
+			expectedGeneralErr: true,
+		},
+		"Too few signatures": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(defaultValidateStartTime.Unix() + 1),
+					endTime:    uint64(defaultValidateEndTime.Unix()),
+					nodeID:     nodeID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], nodeKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute: func(t *testing.T, tx *txs.Tx) {
+				addSubnetValidatorTx := tx.Unsigned.(*txs.AddSubnetValidatorTx)
+				input := addSubnetValidatorTx.SubnetAuth.(*secp256k1fx.Input)
+				input.SigIndices = input.SigIndices[1:]
+			},
+			expectedSpecificErr: errUnauthorizedSubnetModification,
+		},
+		"Control signature from invalid key": {
+			generateArgs: func() args {
+				return args{
+					weight:     env.config.MinValidatorStake,
+					startTime:  uint64(defaultValidateStartTime.Unix() + 1),
+					endTime:    uint64(defaultValidateEndTime.Unix()),
+					nodeID:     nodeID,
+					subnetID:   testSubnet1.ID(),
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], testCaminoSubnet1ControlKeys[0], testCaminoSubnet1ControlKeys[1], nodeKey},
+					changeAddr: ids.ShortEmpty,
+				}
+			},
+			preExecute: func(t *testing.T, tx *txs.Tx) {
+				// Replace a valid signature with one from keys[3]
+				sig, err := caminoPreFundedKeys[3].SignHash(hashing.ComputeHash256(tx.Unsigned.Bytes()))
+				require.NoError(t, err)
+				copy(tx.Creds[0].(*secp256k1fx.Credential).Sigs[0][:], sig)
+			},
+			expectedSpecificErr: errFlowCheckFailed,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			addSubnetValidatorArgs := tt.generateArgs()
+			tx, err := env.txBuilder.NewAddSubnetValidatorTx(
+				addSubnetValidatorArgs.weight,
+				addSubnetValidatorArgs.startTime,
+				addSubnetValidatorArgs.endTime,
+				addSubnetValidatorArgs.nodeID,
+				addSubnetValidatorArgs.subnetID,
+				addSubnetValidatorArgs.keys,
+				addSubnetValidatorArgs.changeAddr,
+			)
+			require.NoError(t, err)
+
+			tt.preExecute(t, tx)
+
+			onAcceptState, err := state.NewDiff(lastAcceptedID, env)
+			require.NoError(t, err)
+
+			executor := CaminoStandardTxExecutor{
+				StandardTxExecutor{
+					Backend: &env.backend,
+					State:   onAcceptState,
+					Tx:      tx,
+				},
+			}
+			err = tx.Unsigned.Visit(&executor)
+			if tt.expectedGeneralErr {
+				require.Error(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.expectedSpecificErr)
+			}
 		})
 	}
 }
@@ -424,7 +706,7 @@ func TestCaminoAddValidatorTxNodeSig(t *testing.T) {
 				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
 			},
 			stakedOuts: []*avax.TransferableOutput{
-				generateTestStakeableOut(avaxAssetID, defaultCaminoValidatorWeight, uint64(defaultMinStakingDuration), outputOwners),
+				generateTestStakeableOut(avaxAssetID, 1, uint64(defaultMinStakingDuration), outputOwners),
 			},
 			expectedErr: errNodeSignatureMissing,
 		},
@@ -530,6 +812,178 @@ func TestCaminoAddValidatorTxNodeSig(t *testing.T) {
 				utx = &txs.CaminoAddValidatorTx{AddValidatorTx: *addValidatorTx}
 			}
 
+			tx, _ := txs.NewSigned(utx, txs.Codec, signers)
+			onAcceptState, err := state.NewDiff(lastAcceptedID, env)
+			require.NoError(t, err)
+
+			executor := CaminoStandardTxExecutor{
+				StandardTxExecutor{
+					Backend: &env.backend,
+					State:   onAcceptState,
+					Tx:      tx,
+				},
+			}
+
+			err = tx.Unsigned.Visit(&executor)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
+	nodeKey1, nodeID1 := caminoPreFundedNodeKeys[0], caminoPreFundedNodeIDs[0]
+	nodeKey2 := caminoPreFundedNodeKeys[1]
+
+	outputOwners := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{caminoPreFundedKeys[0].PublicKey().Address()},
+	}
+	sigIndices := []uint32{0}
+	inputSigners := []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0]}
+
+	tests := map[string]struct {
+		caminoConfig genesis.Camino
+		nodeID       ids.NodeID
+		nodeKey      *crypto.PrivateKeySECP256K1R
+		utxos        []*avax.UTXO
+		outs         []*avax.TransferableOutput
+		stakedOuts   []*avax.TransferableOutput
+		expectedErr  error
+	}{
+		"Happy path, LockModeBondDeposit false, VerifyNodeSignature true": {
+			caminoConfig: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: false,
+			},
+			nodeID:  nodeID1,
+			nodeKey: nodeKey1,
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight*2, outputOwners, ids.Empty, ids.Empty),
+			},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			stakedOuts: []*avax.TransferableOutput{
+				generateTestStakeableOut(avaxAssetID, defaultCaminoValidatorWeight, uint64(defaultMinStakingDuration), outputOwners),
+			},
+			expectedErr: nil,
+		},
+		"NodeId node and signature mismatch, LockModeBondDeposit false, VerifyNodeSignature true": {
+			caminoConfig: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: false,
+			},
+			nodeID:  nodeID1,
+			nodeKey: nodeKey2,
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight*2, outputOwners, ids.Empty, ids.Empty),
+			},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			stakedOuts: []*avax.TransferableOutput{
+				generateTestStakeableOut(avaxAssetID, defaultCaminoValidatorWeight, uint64(defaultMinStakingDuration), outputOwners),
+			},
+			expectedErr: errNodeSignatureMissing,
+		},
+		"NodeId node and signature mismatch, LockModeBondDeposit true, VerifyNodeSignature true": {
+			caminoConfig: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+			},
+			nodeID:  nodeID1,
+			nodeKey: nodeKey2,
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight*2, outputOwners, ids.Empty, ids.Empty),
+			},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			expectedErr: errNodeSignatureMissing,
+		},
+		"Inputs and credentials mismatch, LockModeBondDeposit true, VerifyNodeSignature false": {
+			caminoConfig: genesis.Camino{
+				VerifyNodeSignature: false,
+				LockModeBondDeposit: true,
+			},
+			nodeID:  nodeID1,
+			nodeKey: nodeKey2,
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight*2, outputOwners, ids.Empty, ids.Empty),
+			},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			expectedErr: errUnauthorizedSubnetModification,
+		},
+		"Inputs and credentials mismatch, LockModeBondDeposit false, VerifyNodeSignature false": {
+			caminoConfig: genesis.Camino{
+				VerifyNodeSignature: false,
+				LockModeBondDeposit: false,
+			},
+			nodeID:  nodeID1,
+			nodeKey: nodeKey1,
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight*2, outputOwners, ids.Empty, ids.Empty),
+			},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			stakedOuts: []*avax.TransferableOutput{
+				generateTestStakeableOut(avaxAssetID, defaultCaminoValidatorWeight, uint64(defaultMinStakingDuration), outputOwners),
+			},
+			expectedErr: errUnauthorizedSubnetModification,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env.ctx.Lock.Lock()
+			defer func() {
+				if err := shutdownEnvironment(env); err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			env.config.BanffTime = env.state.GetTimestamp()
+
+			ins := make([]*avax.TransferableInput, len(tt.utxos))
+			var signers [][]*crypto.PrivateKeySECP256K1R
+			for i, utxo := range tt.utxos {
+				env.state.AddUTXO(utxo)
+				ins[i] = generateTestInFromUTXO(utxo, sigIndices)
+				signers = append(signers, inputSigners)
+			}
+
+			avax.SortTransferableInputsWithSigners(ins, signers)
+			avax.SortTransferableOutputs(tt.outs, txs.Codec)
+
+			subnetAuth, subnetSigners, err := env.utxosHandler.Authorize(env.state, testSubnet1.ID(), testCaminoSubnet1ControlKeys)
+			require.NoError(t, err)
+			signers = append(signers, subnetSigners)
+			signers = append(signers, []*crypto.PrivateKeySECP256K1R{tt.nodeKey})
+
+			addSubentValidatorTx := &txs.AddSubnetValidatorTx{
+				BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    env.ctx.NetworkID,
+					BlockchainID: env.ctx.ChainID,
+					Ins:          ins,
+					Outs:         tt.outs,
+				}},
+				Validator: validator.SubnetValidator{
+					Validator: validator.Validator{
+						NodeID: tt.nodeID,
+						Start:  uint64(defaultValidateStartTime.Unix()) + 1,
+						End:    uint64(defaultValidateEndTime.Unix()),
+						Wght:   env.config.MinValidatorStake,
+					},
+					Subnet: testSubnet1.ID(),
+				},
+				SubnetAuth: subnetAuth,
+			}
+
+			var utx txs.UnsignedTx = addSubentValidatorTx
 			tx, _ := txs.NewSigned(utx, txs.Codec, signers)
 			onAcceptState, err := state.NewDiff(lastAcceptedID, env)
 			require.NoError(t, err)


### PR DESCRIPTION
## Description ##
This PR adds integration tests for `addSubnetValidatorTx` in the camino builder and the camino executor.

## Changes ##
- Modified camino test helpers on builder package to include environment
- Added addSubnetValidatorTx integration tests for camino builder
- Added addSubnetValidatorTx integration tests for camino executor