### PR TITLE
TECH-414: RewardValidatorTx integration tests

### DIFF
--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -51,25 +51,25 @@ import (
 const (
 	testNetworkID                = 10 // To be used in tests
 	defaultCaminoValidatorWeight = 2 * units.KiloAvax
+	defaultMinStakingDuration    = 24 * time.Hour
+	defaultMaxStakingDuration    = 365 * 24 * time.Hour
+	defaultCaminoBalance         = 100 * defaultCaminoValidatorWeight
+	defaultTxFee                 = uint64(100)
+	localStakingPath             = "../../../../staking/local/"
 )
 
 var (
-	defaultMinStakingDuration    = 24 * time.Hour
-	defaultMaxStakingDuration    = 365 * 24 * time.Hour
 	defaultGenesisTime           = time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC)
 	defaultValidateStartTime     = defaultGenesisTime
 	defaultValidateEndTime       = defaultValidateStartTime.Add(10 * defaultMinStakingDuration)
-	defaultCaminoBalance         = 100 * defaultCaminoValidatorWeight
 	avaxAssetID                  = ids.ID{'y', 'e', 'e', 't'}
-	defaultTxFee                 = uint64(100)
 	xChainID                     = ids.Empty.Prefix(0)
 	cChainID                     = ids.Empty.Prefix(1)
-	localStakingPath             = "../../../../staking/local/"
 	caminoPreFundedKeys          = crypto.BuildTestKeys()
 	_, caminoPreFundedNodeIDs    = nodeid.LoadLocalCaminoNodeKeysAndIDs(localStakingPath)
 	testCaminoSubnet1ControlKeys = caminoPreFundedKeys[0:3]
-	testSubnet1                  *txs.Tx
 	lastAcceptedID               = ids.GenerateTestID()
+	testSubnet1                  *txs.Tx
 )
 
 type mutableSharedMemory struct {

--- a/vms/platformvm/txs/camino_helpers_test.go
+++ b/vms/platformvm/txs/camino_helpers_test.go
@@ -18,15 +18,15 @@ import (
 
 const (
 	defaultCaminoValidatorWeight = 2 * units.KiloAvax
+	defaultMinStakingDuration    = 24 * time.Hour
+	defaultTxFee                 = uint64(100)
 )
 
 var (
-	caminoPreFundedKeys       = crypto.BuildTestKeys()
-	defaultMinStakingDuration = 24 * time.Hour
-	defaultGenesisTime        = time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC)
-	defaultValidateStartTime  = defaultGenesisTime
-	defaultValidateEndTime    = defaultValidateStartTime.Add(10 * defaultMinStakingDuration)
-	defaultTxFee              = uint64(100)
+	caminoPreFundedKeys      = crypto.BuildTestKeys()
+	defaultGenesisTime       = time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC)
+	defaultValidateStartTime = defaultGenesisTime
+	defaultValidateEndTime   = defaultValidateStartTime.Add(10 * defaultMinStakingDuration)
 )
 
 func generateTestOut(assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.TransferableOutput {

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -45,13 +45,13 @@ import (
 
 const (
 	defaultCaminoValidatorWeight = 2 * units.KiloAvax
+	defaultCaminoBalance         = 100 * defaultCaminoValidatorWeight
+	localStakingPath             = "../../../../staking/local/"
 )
 
 var (
-	localStakingPath                                = "../../../../staking/local/"
 	caminoPreFundedKeys                             = crypto.BuildTestKeys()
 	caminoPreFundedNodeKeys, caminoPreFundedNodeIDs = nodeid.LoadLocalCaminoNodeKeysAndIDs(localStakingPath)
-	defaultCaminoBalance                            = 100 * defaultCaminoValidatorWeight
 	testCaminoSubnet1ControlKeys                    = caminoPreFundedKeys[0:3]
 )
 
@@ -304,11 +304,13 @@ func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners s
 			TransferableOut: out,
 		}
 	}
-	return &avax.UTXO{
+	testUTXO := &avax.UTXO{
 		UTXOID: avax.UTXOID{TxID: txID},
 		Asset:  avax.Asset{ID: assetID},
 		Out:    out,
 	}
+	testUTXO.InputID()
+	return testUTXO
 }
 
 func generateTestOut(assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.TransferableOutput {

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -31,6 +31,8 @@ var (
 	errInvalidRoles         = errors.New("invalid role")
 	errValidatorExists      = errors.New("node is already a validator")
 	errInvalidSystemTxBody  = errors.New("tx body doesn't match expected one")
+	errRewardBeforeEndTime  = errors.New("attempting to remove TxID before its end time")
+	errRewardWrongID        = errors.New("attempting to remove wrong TxID")
 )
 
 type CaminoStandardTxExecutor struct {
@@ -387,7 +389,8 @@ func (e *CaminoProposalTxExecutor) RewardValidatorTx(tx *txs.RewardValidatorTx) 
 
 	if stakerToRemove.TxID != tx.TxID {
 		return fmt.Errorf(
-			"attempting to remove TxID: %s. Should be removing %s",
+			"%w. Attempting to remove TxID: %s. Should be removing %s",
+			errRewardWrongID,
 			tx.TxID,
 			stakerToRemove.TxID,
 		)
@@ -397,7 +400,8 @@ func (e *CaminoProposalTxExecutor) RewardValidatorTx(tx *txs.RewardValidatorTx) 
 	currentChainTime := e.OnCommitState.GetTimestamp()
 	if !stakerToRemove.EndTime.Equal(currentChainTime) {
 		return fmt.Errorf(
-			"attempting to remove TxID: %s before their end time %s",
+			"%w. TxID: %s. End time %s",
+			errRewardBeforeEndTime,
 			tx.TxID,
 			stakerToRemove.EndTime,
 		)

--- a/vms/platformvm/utxo/camino_helpers_test.go
+++ b/vms/platformvm/utxo/camino_helpers_test.go
@@ -191,11 +191,13 @@ func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners s
 			TransferableOut: out,
 		}
 	}
-	return &avax.UTXO{
+	testUTXO := &avax.UTXO{
 		UTXOID: avax.UTXOID{TxID: txID},
 		Asset:  avax.Asset{ID: assetID},
 		Out:    out,
 	}
+	testUTXO.InputID()
+	return testUTXO
 }
 
 func generateTestStakeableUTXO(txID ids.ID, assetID ids.ID, amount, locktime uint64, outputOwners secp256k1fx.OutputOwners) *avax.UTXO {

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -379,7 +379,7 @@ func (h *handler) Unlock(
 	for lockTxID := range lockTxIDsSet {
 		tx, s, err := state.GetTx(lockTxID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch lockedTx %s: %v", lockTxID, err)
+			return nil, nil, fmt.Errorf("failed to fetch lockedTx %s: %w", lockTxID, err)
 		}
 		if s != status.Committed {
 			return nil, nil, fmt.Errorf("%s is not a committed tx", lockTxID)


### PR DESCRIPTION
## Description ##
This PR adds integration tests for `rewardValidatorTx` in the camino executor.

## Changes ##
- Added `rewardValidatorTx` integration tests for camino executor
- Changed some returned errors to be more specific
- Update `generateTestUTXO` helper function to generate `UTXOID.id`