### PR TITLE
Feature/tech 426 extend get balance

### DIFF
--- a/utils/json/camino.go
+++ b/utils/json/camino.go
@@ -1,0 +1,15 @@
+package json
+
+import (
+	"github.com/ava-labs/avalanchego/utils/math"
+
+	stdmath "math"
+)
+
+func SafeAdd(a, b Uint64) Uint64 {
+	ret, err := math.Add64(uint64(a), uint64(b))
+	if err != nil {
+		return stdmath.MaxUint64
+	}
+	return Uint64(ret)
+}

--- a/vms/platformvm/camino_helpers_test.go
+++ b/vms/platformvm/camino_helpers_test.go
@@ -1,0 +1,188 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package platformvm
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ava-labs/avalanchego/chains"
+	"github.com/ava-labs/avalanchego/chains/atomic"
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/manager"
+	"github.com/ava-labs/avalanchego/database/prefixdb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/snow/uptime"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/formatting"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/json"
+	"github.com/ava-labs/avalanchego/utils/nodeid"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+)
+
+const (
+	defaultCaminoValidatorWeight = 2 * units.KiloAvax
+)
+
+var (
+	localStakingPath          = "../../staking/local/"
+	_, caminoPreFundedNodeIDs = nodeid.LoadLocalCaminoNodeKeysAndIDs(localStakingPath)
+)
+
+func newCaminoVM(genesisConfig genesis.Camino, genesisUTXOs []api.UTXO) (*VM, database.Database, *mutableSharedMemory) {
+	vm := &VM{Factory: Factory{defaultCaminoConfig(true)}}
+
+	baseDBManager := manager.NewMemDB(version.Semantic1_0_0)
+	chainDBManager := baseDBManager.NewPrefixDBManager([]byte{0})
+	atomicDB := prefixdb.New([]byte{1}, baseDBManager.Current().Database)
+
+	vm.clock.Set(banffForkTime.Add(time.Second))
+	msgChan := make(chan common.Message, 1)
+	ctx := defaultContext()
+
+	m := atomic.NewMemory(atomicDB)
+	msm := &mutableSharedMemory{
+		SharedMemory: m.NewSharedMemory(ctx.ChainID),
+	}
+	ctx.SharedMemory = msm
+
+	ctx.Lock.Lock()
+	defer ctx.Lock.Unlock()
+	_, genesisBytes := newCaminoGenesisWithUTXOs(genesisConfig, genesisUTXOs)
+	appSender := &common.SenderTest{}
+	appSender.CantSendAppGossip = true
+	appSender.SendAppGossipF = func(context.Context, []byte) error { return nil }
+
+	if err := vm.Initialize(ctx, chainDBManager, genesisBytes, nil, nil, msgChan, nil, appSender); err != nil {
+		panic(err)
+	}
+	if err := vm.SetState(snow.NormalOp); err != nil {
+		panic(err)
+	}
+
+	// Create a subnet and store it in testSubnet1
+	// Note: following Banff activation, block acceptance will move
+	// chain time ahead
+	var err error
+	testSubnet1, err = vm.txBuilder.NewCreateSubnetTx(
+		2, // threshold; 2 sigs from keys[0], keys[1], keys[2] needed to add validator to this subnet
+		// control keys are keys[0], keys[1], keys[2]
+		[]ids.ShortID{keys[0].PublicKey().Address(), keys[1].PublicKey().Address(), keys[2].PublicKey().Address()},
+		[]*crypto.PrivateKeySECP256K1R{keys[0]}, // pays tx fee
+		keys[0].PublicKey().Address(),           // change addr
+	)
+	if err != nil {
+		panic(err)
+	} else if err := vm.Builder.AddUnverifiedTx(testSubnet1); err != nil {
+		panic(err)
+	} else if blk, err := vm.Builder.BuildBlock(); err != nil {
+		panic(err)
+	} else if err := blk.Verify(); err != nil {
+		panic(err)
+	} else if err := blk.Accept(); err != nil {
+		panic(err)
+	} else if err := vm.SetPreference(vm.manager.LastAccepted()); err != nil {
+		panic(err)
+	}
+
+	return vm, baseDBManager.Current().Database, msm
+}
+
+func defaultCaminoConfig(postBanff bool) config.Config {
+	banffTime := mockable.MaxTime
+	if postBanff {
+		banffTime = defaultValidateEndTime.Add(-2 * time.Second)
+	}
+	return config.Config{
+		Chains:                 chains.MockManager{},
+		UptimeLockedCalculator: uptime.NewLockedCalculator(),
+		Validators:             validators.NewManager(),
+		TxFee:                  defaultTxFee,
+		CreateSubnetTxFee:      100 * defaultTxFee,
+		CreateBlockchainTxFee:  100 * defaultTxFee,
+		MinValidatorStake:      defaultCaminoValidatorWeight,
+		MaxValidatorStake:      defaultCaminoValidatorWeight,
+		MinDelegatorStake:      1 * units.MilliAvax,
+		MinStakeDuration:       defaultMinStakingDuration,
+		MaxStakeDuration:       defaultMaxStakingDuration,
+		RewardConfig: reward.Config{
+			MaxConsumptionRate: .12 * reward.PercentDenominator,
+			MinConsumptionRate: .10 * reward.PercentDenominator,
+			MintingPeriod:      365 * 24 * time.Hour,
+			SupplyCap:          720 * units.MegaAvax,
+		},
+		ApricotPhase3Time: defaultValidateEndTime,
+		ApricotPhase5Time: defaultValidateEndTime,
+		BanffTime:         banffTime,
+		CaminoConfig: config.CaminoConfig{
+			DaoProposalBondAmount: 100 * units.Avax,
+		},
+	}
+}
+
+// Returns:
+// 1) The genesis state
+// 2) The byte representation of the default genesis for tests
+func newCaminoGenesisWithUTXOs(caminoGenesisConfig genesis.Camino, genesisUTXOs []api.UTXO) (*api.BuildGenesisArgs, []byte) {
+	hrp := constants.NetworkIDToHRP[testNetworkID]
+	genesisValidators := make([]api.PermissionlessValidator, len(keys))
+	for i, key := range keys {
+		addr, err := address.FormatBech32(hrp, key.PublicKey().Address().Bytes())
+		if err != nil {
+			panic(err)
+		}
+		genesisValidators[i] = api.PermissionlessValidator{
+			Staker: api.Staker{
+				StartTime: json.Uint64(defaultValidateStartTime.Unix()),
+				EndTime:   json.Uint64(defaultValidateEndTime.Unix()),
+				NodeID:    caminoPreFundedNodeIDs[i],
+			},
+			RewardOwner: &api.Owner{
+				Threshold: 1,
+				Addresses: []string{addr},
+			},
+			Staked: []api.UTXO{{
+				Amount:  json.Uint64(defaultWeight),
+				Address: addr,
+			}},
+		}
+	}
+
+	buildGenesisArgs := api.BuildGenesisArgs{
+		Encoding:      formatting.Hex,
+		NetworkID:     json.Uint32(testNetworkID),
+		AvaxAssetID:   avaxAssetID,
+		UTXOs:         genesisUTXOs,
+		Validators:    genesisValidators,
+		Chains:        nil,
+		Time:          json.Uint64(defaultGenesisTime.Unix()),
+		InitialSupply: json.Uint64(360 * units.MegaAvax),
+		Camino:        caminoGenesisConfig,
+	}
+
+	buildGenesisResponse := api.BuildGenesisReply{}
+	platformvmSS := api.StaticService{}
+	if err := platformvmSS.BuildGenesis(nil, &buildGenesisArgs, &buildGenesisResponse); err != nil {
+		panic(fmt.Errorf("problem while building platform chain's genesis state: %w", err))
+	}
+
+	genesisBytes, err := formatting.Decode(buildGenesisResponse.Encoding, buildGenesisResponse.Bytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return &buildGenesisArgs, genesisBytes
+}

--- a/vms/platformvm/camino_service_test.go
+++ b/vms/platformvm/camino_service_test.go
@@ -1,0 +1,209 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package platformvm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/api/keystore"
+	"github.com/ava-labs/avalanchego/database/manager"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/json"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
+)
+
+// Test method GetBalance in CaminoService
+func TestGetCaminoBalance(t *testing.T) {
+	hrp := constants.NetworkIDToHRP[testNetworkID]
+
+	id := keys[0].PublicKey().Address()
+	addr, err := address.FormatBech32(hrp, id.Bytes())
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		camino          genesis.Camino
+		genesisUTXOs    []api.UTXO
+		address         string
+		bonded          uint64
+		deposited       uint64
+		depositedBonded uint64
+		expectedError   error
+	}{
+		"Genesis Validator with added balance": {
+			camino: genesis.Camino{
+				LockModeBondDeposit: true,
+			},
+			genesisUTXOs: []api.UTXO{
+				{
+					Amount:  json.Uint64(defaultBalance),
+					Address: addr,
+				},
+			},
+			address: addr,
+			bonded:  defaultWeight,
+		},
+		"Genesis Validator with deposited amount": {
+			camino: genesis.Camino{
+				LockModeBondDeposit: true,
+			},
+			genesisUTXOs: []api.UTXO{
+				{
+					Amount:  json.Uint64(defaultBalance),
+					Address: addr,
+				},
+			},
+			address:   addr,
+			bonded:    defaultWeight,
+			deposited: defaultBalance,
+		},
+		"Genesis Validator with depositedBonded amount": {
+			camino: genesis.Camino{
+				LockModeBondDeposit: true,
+			},
+			genesisUTXOs: []api.UTXO{
+				{
+					Amount:  json.Uint64(defaultBalance),
+					Address: addr,
+				},
+			},
+			address:         addr,
+			bonded:          defaultWeight,
+			depositedBonded: defaultBalance,
+		},
+		"Genesis Validator with added balance and disabled LockModeBondDeposit": {
+			camino: genesis.Camino{
+				LockModeBondDeposit: false,
+			},
+			genesisUTXOs: []api.UTXO{
+				{
+					Amount:  json.Uint64(defaultBalance),
+					Address: addr,
+				},
+			},
+			address: addr,
+			bonded:  defaultWeight,
+		},
+		"Error - Empty address ": {
+			camino: genesis.Camino{
+				LockModeBondDeposit: true,
+			},
+			expectedError: fmt.Errorf("couldn't parse address %q: %s", "P-", ""),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			service := defaultCaminoService(t, tt.camino, tt.genesisUTXOs)
+			service.vm.ctx.Lock.Lock()
+			defer func() {
+				if err := service.vm.Shutdown(); err != nil {
+					t.Fatal(err)
+				}
+				service.vm.ctx.Lock.Unlock()
+			}()
+
+			request := GetBalanceRequest{
+				Addresses: []string{
+					fmt.Sprintf("P-%s", tt.address),
+				},
+			}
+			responseWrapper := GetBalanceResponseWrapper{}
+
+			if tt.deposited != 0 {
+				outputOwners := secp256k1fx.OutputOwners{
+					Locktime:  0,
+					Threshold: 1,
+					Addrs:     []ids.ShortID{keys[0].PublicKey().Address()},
+				}
+				utxo := generateTestUTXO(ids.GenerateTestID(), avaxAssetID, tt.deposited, outputOwners, ids.GenerateTestID(), ids.Empty)
+				service.vm.state.AddUTXO(utxo)
+				err := service.vm.state.Commit()
+				require.NoError(t, err)
+			}
+
+			if tt.depositedBonded != 0 {
+				outputOwners := secp256k1fx.OutputOwners{
+					Locktime:  0,
+					Threshold: 1,
+					Addrs:     []ids.ShortID{keys[0].PublicKey().Address()},
+				}
+				utxo := generateTestUTXO(ids.GenerateTestID(), avaxAssetID, tt.depositedBonded, outputOwners, ids.GenerateTestID(), ids.GenerateTestID())
+				service.vm.state.AddUTXO(utxo)
+				err := service.vm.state.Commit()
+				require.NoError(t, err)
+			}
+
+			err := service.GetBalance(nil, &request, &responseWrapper)
+			if tt.expectedError != nil {
+				require.ErrorContains(t, err, tt.expectedError.Error())
+				return
+			}
+			require.NoError(t, err)
+			expectedBalance := json.Uint64(defaultBalance + tt.bonded + tt.deposited + tt.depositedBonded)
+
+			if !tt.camino.LockModeBondDeposit {
+				response := responseWrapper.GetBalanceResponse
+				require.Equal(t, json.Uint64(defaultBalance), response.Balance, "Wrong balance. Expected %d ; Returned %d", json.Uint64(defaultBalance), response.Balance)
+				require.Equal(t, json.Uint64(0), response.LockedStakeable, "Wrong locked stakeable balance. Expected %d ; Returned %d", 0, response.LockedStakeable)
+				require.Equal(t, json.Uint64(0), response.LockedNotStakeable, "Wrong locked not stakeable balance. Expected %d ; Returned %d", 0, response.LockedNotStakeable)
+				require.Equal(t, json.Uint64(defaultBalance), response.Unlocked, "Wrong unlocked balance. Expected %d ; Returned %d", defaultBalance, response.Unlocked)
+			} else {
+				response := responseWrapper.GetBalanceResponseV2
+				require.Equal(t, json.Uint64(defaultBalance+tt.bonded+tt.deposited+tt.depositedBonded), response.Balances[avaxAssetID], "Wrong balance. Expected %d ; Returned %d", expectedBalance, response.Balances[avaxAssetID])
+				require.Equal(t, json.Uint64(tt.deposited), response.DepositedOutputs[avaxAssetID], "Wrong deposited balance. Expected %d ; Returned %d", tt.deposited, response.DepositedOutputs[avaxAssetID])
+				require.Equal(t, json.Uint64(tt.depositedBonded), response.DepositedBondedOutputs[avaxAssetID], "Wrong depositedBonded balance. Expected %d ; Returned %d", tt.depositedBonded, response.DepositedBondedOutputs[avaxAssetID])
+				require.Equal(t, json.Uint64(defaultBalance), response.UnlockedOutputs[avaxAssetID], "Wrong unlocked balance. Expected %d ; Returned %d", defaultBalance, response.UnlockedOutputs[avaxAssetID])
+			}
+		})
+	}
+}
+
+func defaultCaminoService(t *testing.T, camino genesis.Camino, utxos []api.UTXO) *CaminoService {
+	vm, _, _ := newCaminoVM(camino, utxos)
+
+	vm.ctx.Lock.Lock()
+	defer vm.ctx.Lock.Unlock()
+	ks := keystore.New(logging.NoLog{}, manager.NewMemDB(version.Semantic1_0_0))
+	if err := ks.CreateUser(testUsername, testPassword); err != nil {
+		t.Fatal(err)
+	}
+	vm.ctx.Keystore = ks.NewBlockchainKeyStore(vm.ctx.ChainID)
+	return &CaminoService{
+		Service: Service{
+			vm:          vm,
+			addrManager: avax.NewAddressManager(vm.ctx),
+		},
+	}
+}
+
+func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.UTXO {
+	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
+		Amt:          amount,
+		OutputOwners: outputOwners,
+	}
+	if depositTxID != ids.Empty || bondTxID != ids.Empty {
+		out = &locked.Out{
+			IDs: locked.IDs{
+				DepositTxID: depositTxID,
+				BondTxID:    bondTxID,
+			},
+			TransferableOut: out,
+		}
+	}
+	return &avax.UTXO{
+		UTXOID: avax.UTXOID{TxID: txID},
+		Asset:  avax.Asset{ID: assetID},
+		Out:    out,
+	}
+}

--- a/vms/platformvm/locked/camino_lock.go
+++ b/vms/platformvm/locked/camino_lock.go
@@ -56,6 +56,10 @@ func (ls State) IsDeposited() bool {
 	return StateDeposited&ls == StateDeposited
 }
 
+func (ls State) IsStateDepositedBonded() bool {
+	return StateDepositedBonded&ls == StateDepositedBonded
+}
+
 /**********************  IDs *********************/
 
 type IDs struct {

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -413,9 +413,11 @@ func (vm *VM) CreateHandlers() (map[string]*common.HTTPHandler, error) {
 	server.RegisterInterceptFunc(vm.metrics.InterceptRequest)
 	server.RegisterAfterFunc(vm.metrics.AfterRequest)
 	if err := server.RegisterService(
-		&Service{
-			vm:          vm,
-			addrManager: avax.NewAddressManager(vm.ctx),
+		&CaminoService{
+			Service: Service{
+				vm:          vm,
+				addrManager: avax.NewAddressManager(vm.ctx),
+			},
 		},
 		"platform",
 	); err != nil {


### PR DESCRIPTION
## Why this should be merged
Upon rebuilding the staking/delegation logic and the introduction of the new locked states (bonded, deposited & depositedBonded), the logic returning the balance of an address has to be refactored accordingly. 

## How this works
A new version of the getBalance has been introduced under camino_service. This new method "overrides" the default avalanche logic when the genesis flag 'LockModeBondDeposit' is set to true. Otherwise, it calls the original avalanche implementation.
The GetBalanceResposne struct has been extended to include the new fields "BondedOutputs", "DepositedOutputs" and "DepositedBondedOutputs". Existing unused fields are overriden in the sense of adjusting the json tag with the 'omitempty' suffix to exclude non-relative/empty fields.

Example response:
```json
{
  "jsonrpc": "2.0",
  "result": {
    "balances": {
      "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe": "10000000000000000"
    },
    "unlockedOutputs": {},
    "bondedOutputs": {
      "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe": "10000000000000000"
    },
    "depositedOutputs": {},
    "bondedDepositedOutputs": {}
  },
  "id": 1
}
```


## How this was tested
Existing tests for original getBalance have been adjusted covering also new test cases and error cases.