### PR TITLE
Loop offerID closure fix, UnlockHalfPeriodDuration is uint32

### DIFF
--- a/genesis/camino.go
+++ b/genesis/camino.go
@@ -34,7 +34,7 @@ func validateCaminoConfig(config *Config) error {
 			return errors.New("deposit minimum duration is greater than maximum duration")
 		}
 
-		if uint64(offer.MinDuration) < offer.UnlockHalfPeriodDuration {
+		if offer.MinDuration < offer.UnlockHalfPeriodDuration {
 			return fmt.Errorf(
 				"deposit offer minimum duration (%v) is less than unlock half-period duration (%v)",
 				offer.MinDuration,

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -368,7 +368,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "g1fd25eZ28PxG7wierV61fNeiLXQGFLmL5JBBM19LtRVmxkMn",
+			expectedID: "292LtuyRDTd1n9sCceu9AFZH4EdMncToBDXSaNrpY6tKBUVkJB",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -16,7 +16,7 @@ type Camino struct {
 }
 
 type DepositOffer struct {
-	UnlockHalfPeriodDuration uint64 `serialize:"true" json:"unlockHalfPeriodDuration"`
+	UnlockHalfPeriodDuration uint32 `serialize:"true" json:"unlockHalfPeriodDuration"`
 	InterestRateNominator    uint64 `serialize:"true" json:"interestRateNominator"`
 	Start                    uint64 `serialize:"true" json:"start"`
 	End                      uint64 `serialize:"true" json:"end"`

--- a/vms/platformvm/state/camino_deposit_offer.go
+++ b/vms/platformvm/state/camino_deposit_offer.go
@@ -18,7 +18,7 @@ const interestRateDenominator uint64 = 1_000_000
 type DepositOffer struct {
 	id ids.ID
 
-	UnlockHalfPeriodDuration uint64 `serialize:"true"`
+	UnlockHalfPeriodDuration uint32 `serialize:"true"`
 	InterestRateNominator    uint64 `serialize:"true"`
 	Start                    uint64 `serialize:"true"`
 	End                      uint64 `serialize:"true"`
@@ -119,6 +119,7 @@ func (cs *caminoState) writeDepositOffers() error {
 			return fmt.Errorf("failed to serialize deposit offer: %w", err)
 		}
 
+		offerID := offerID
 		if err := cs.depositOffersList.Put(offerID[:], offerBytes); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixed minor bug, changed offer.UnlockHalfPeriodDuration field type from unint64 to uint32