### PR TITLE
[PVM] Add AddressState bits for consortium member and validator

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,4 +16,4 @@ jobs:
           go-version: "1.18" # The Go version to download (if necessary) and use.
       - name: test
         shell: bash
-        run: scripts/test.sh race
+        run: scripts/test.sh --race

--- a/vms/platformvm/txs/camino_address_state_tx.go
+++ b/vms/platformvm/txs/camino_address_state_tx.go
@@ -13,15 +13,21 @@ import (
 
 // AddressState flags, max 63
 const (
-	AddressStateRoleAdmin    = uint8(0)
-	AddressStateRoleAdminBit = uint64(0b1)
-	AddressStateRoleKyc      = uint8(1)
-	AddressStateRoleKycBit   = uint64(0b10)
-	AddressStateRoleBits     = uint64(0b11)
+	AddressStateRoleAdmin        = uint8(0)
+	AddressStateRoleAdminBit     = uint64(0b1)
+	AddressStateRoleKyc          = uint8(1)
+	AddressStateRoleKycBit       = uint64(0b10)
+	AddressStateRoleValidator    = uint8(2)
+	AddressStateRoleValidatorBit = uint64(0b100)
+	AddressStateRoleBits         = uint64(0b111)
 
 	AddressStateKycVerified = 32
 	AddressStateKycExpired  = 33
-	AddressStateKycBits     = uint64(0b1100000000000000000000000000000000)
+	AddressStateConsortium  = 34
+	AddressStateKycBits     = uint64(0b11100000000000000000000000000000000)
+
+	AddressStateValidator     = 38
+	AddressStateValidatorBits = uint64(0b100000000000000000000000000000000000000)
 
 	AddressStateMax       = 63
 	AddressStateValidBits = AddressStateRoleBits | AddressStateKycBits

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -532,6 +532,10 @@ func verifyAccess(roles, statesBit uint64) error {
 		if (roles & txs.AddressStateRoleKycBit) == 0 {
 			return errInvalidRoles
 		}
+	case (txs.AddressStateValidatorBits & statesBit) != 0:
+		if (roles & txs.AddressStateRoleValidatorBit) == 0 {
+			return errInvalidRoles
+		}
 	case (txs.AddressStateRoleBits & statesBit) != 0:
 		return errInvalidRoles
 	}


### PR DESCRIPTION
## Why this should be merged
Implement new address specific bits for in AddressState state for:
- Consortium Member ( a member allowed to become a validator)
- Validator (Consortium member has a validator running / prevent multiple nodes)

## How this works
- Only signers with `AddressStateRoleAdminBit `or `AddressStateRoleKycBit` set can set / remove consortium state to an arbitrary address.
- Only signers with `AddressStateRoleAdminBit `or `AddressStateRoleValidatorBit` can set / remove validator state to an arbitrary address. AddValidatorTX will set this state flag automatically.
