### PR TITLE
[CI] Run all tests also on push[c4t/dev]

### DIFF
--- a/.github/workflows/buf-lint.yml
+++ b/.github/workflows/buf-lint.yml
@@ -1,6 +1,8 @@
 name: Lint proto files
 
 on:
+  push:
+    branches: [chain4travel, dev]
   pull_request:
     tags-ignore: ["*"]  
     branches: [chain4travel, dev]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,8 @@
 name: Unit Tests
 
 on:
+  push:
+    branches: [chain4travel, dev]
   pull_request:
     tags-ignore: ["*"]
     branches: [chain4travel, dev]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,8 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [chain4travel, dev]
   pull_request:
     tags-ignore: ["*"]
     branches: [chain4travel, dev]

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,5 +1,7 @@
 name: Static analysis
 on:
+  push:
+    branches: [chain4travel, dev]
   pull_request:
     tags-ignore: ["*"]
     branches: [chain4travel, dev]


### PR DESCRIPTION
## Why this should be merged
CI tests on c4t / dev branch currently do not run after PR is merged (push).
I was wrongly in opinion, that CI checks from PR are transfered to dest branch on merge.
