### PR TITLE
add camino runtime struct and print node id flag

### DIFF
--- a/config/camino.go
+++ b/config/camino.go
@@ -13,11 +13,18 @@ import (
 
 const (
 	DaoProposalBondAmountKey = "dao-proposal-bond-amount"
+	CaminoPrintNodeIDKey     = "print-node-id"
 )
+
+type CaminoRuntimeConfig struct {
+	// if true stop execution after staker certs are parsed
+	OnlyShowNodeID bool `json:"onlyShowNodeID"`
+}
 
 func addCaminoFlags(fs *flag.FlagSet) {
 	// Bond amount required to place a DAO proposal on the Primary Network
 	fs.Uint64(DaoProposalBondAmountKey, genesis.LocalParams.CaminoConfig.DaoProposalBondAmount, "Amount, in nAVAX, required to place a DAO proposal")
+	fs.Bool(CaminoPrintNodeIDKey, false, "If true, only print the node id and exit")
 }
 
 func getCaminoPlatformConfig(v *viper.Viper) config.CaminoConfig {
@@ -25,4 +32,10 @@ func getCaminoPlatformConfig(v *viper.Viper) config.CaminoConfig {
 		DaoProposalBondAmount: v.GetUint64(DaoProposalBondAmountKey),
 	}
 	return conf
+}
+
+func getCaminoRuntimeConfig(v *viper.Viper) CaminoRuntimeConfig {
+	return CaminoRuntimeConfig{
+		OnlyShowNodeID: v.GetBool(CaminoPrintNodeIDKey),
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1285,6 +1285,9 @@ func GetNodeConfig(v *viper.Viper, buildDir string) (node.Config, error) {
 		return node.Config{}, err
 	}
 
+	// Camino Runtime Config
+	nodeConfig.CaminoRuntimeConfig = getCaminoRuntimeConfig(v)
+
 	// IP configuration
 	nodeConfig.IPConfig, err = getIPConfig(v)
 	if err != nil {

--- a/node/config.go
+++ b/node/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/chains"
+	"github.com/ava-labs/avalanchego/config"
 	"github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/nat"
@@ -142,6 +143,8 @@ type Config struct {
 	StateSyncConfig     `json:"stateSyncConfig"`
 	BootstrapConfig     `json:"bootstrapConfig"`
 	DatabaseConfig      `json:"databaseConfig"`
+
+	config.CaminoRuntimeConfig `json:"caminoRuntimeConfig"`
 
 	// Genesis information
 	GenesisBytes []byte `json:"-"`


### PR DESCRIPTION
## Why this should be merged
It adds a simple flag to grab the node id and end the process
This makes communication with validators and general automation much easier

## How this works
It adds a new flag that parses the node id if this flag is set and gracefuly stops the process
## How this was tested
Manual, e.g. set the flag and it prints the id. Nothing critical so no elaborate tests