### PR TITLE
[CI] Provide github token for buf-setup-action

### DIFF
--- a/.github/workflows/buf-lint.yml
+++ b/.github/workflows/buf-lint.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.7.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: "proto"


### PR DESCRIPTION
## Why this should be merged
We issue sometimes CI rate-limit failures in buf-setup-action

## How this works
Provide our github access token to increase rate-limit