### PR TITLE
TECH-440: Add tests for deposit offers

### DIFF
--- a/genesis/genesis_camino_test.go
+++ b/genesis/genesis_camino_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+)
+
+func TestValidateCaminoConfig(t *testing.T) {
+	tests := map[string]struct {
+		config Config
+		err    error
+	}{
+		"deposit offer's end time before start time": {
+			config: func() Config {
+				tempOffers := make([]genesis.DepositOffer, len(CaminoConfig.Camino.DepositOffers))
+				copy(tempOffers, CaminoConfig.Camino.DepositOffers)
+				thisConfig := CaminoConfig
+				thisConfig.Camino.DepositOffers = tempOffers
+
+				offerStartTime := time.Now()
+				offerEndTime := time.Now().Add(-1 * time.Hour)
+				thisConfig.Camino.DepositOffers[0].Start = uint64(offerStartTime.Unix())
+				thisConfig.Camino.DepositOffers[0].End = uint64(offerEndTime.Unix())
+				return thisConfig
+			}(),
+			err: genesis.ErrOfferStartLessThanEnd,
+		},
+		"deposit offer's min duration greater than max duration": {
+			config: func() Config {
+				tempOffers := make([]genesis.DepositOffer, len(CaminoConfig.Camino.DepositOffers))
+				copy(tempOffers, CaminoConfig.Camino.DepositOffers)
+				thisConfig := CaminoConfig
+				thisConfig.Camino.DepositOffers = tempOffers
+
+				minDuration := 91
+				thisConfig.Camino.DepositOffers[0].MinDuration = uint32(minDuration)
+				return thisConfig
+			}(),
+			err: genesis.ErrOfferMinDurationGreaterThanMax,
+		},
+		"deposit offer's min duration less than half duration": {
+			config: func() Config {
+				tempOffers := make([]genesis.DepositOffer, len(CaminoConfig.Camino.DepositOffers))
+				copy(tempOffers, CaminoConfig.Camino.DepositOffers)
+				thisConfig := CaminoConfig
+				thisConfig.Camino.DepositOffers = tempOffers
+
+				minDuration := 29
+				thisConfig.Camino.DepositOffers[0].MinDuration = uint32(minDuration)
+				return thisConfig
+			}(),
+			err: genesis.ErrOfferMinDurationLessThanNoReward,
+		},
+		"deposit offer's min duration less than unlock period duration": {
+			config: func() Config {
+				tempOffers := make([]genesis.DepositOffer, len(CaminoConfig.Camino.DepositOffers))
+				copy(tempOffers, CaminoConfig.Camino.DepositOffers)
+				thisConfig := CaminoConfig
+				thisConfig.Camino.DepositOffers = tempOffers
+
+				minDuration := 59
+				thisConfig.Camino.DepositOffers[0].MinDuration = uint32(minDuration)
+				return thisConfig
+			}(),
+			err: genesis.ErrOfferMinDurationLessThanUnlock,
+		},
+		"deposit offer's min duration is zero": {
+			config: func() Config {
+				tempOffers := make([]genesis.DepositOffer, len(CaminoConfig.Camino.DepositOffers))
+				copy(tempOffers, CaminoConfig.Camino.DepositOffers)
+				thisConfig := CaminoConfig
+				thisConfig.Camino.DepositOffers = tempOffers
+
+				minDuration := 0
+				thisConfig.Camino.DepositOffers[0].MinDuration = uint32(minDuration)
+				return thisConfig
+			}(),
+			err: genesis.ErrOfferZerosMinDuration,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateCaminoConfig(&tt.config)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -13,6 +13,14 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
+var (
+	ErrOfferStartLessThanEnd            = errors.New("deposit offer's end time is before start time")
+	ErrOfferMinDurationGreaterThanMax   = errors.New("deposit offer's minimum duration is greater than maximum duration")
+	ErrOfferMinDurationLessThanUnlock   = errors.New("deposit offer's minimum duration is less than unlock period duration")
+	ErrOfferMinDurationLessThanNoReward = errors.New("deposit offer minimum duration is less than no-rewards period duration")
+	ErrOfferZerosMinDuration            = errors.New("deposit offer has zero minimum duration")
+)
+
 // Camino genesis args
 type Camino struct {
 	VerifyNodeSignature bool           `serialize:"true" json:"verifyNodeSignature"`
@@ -46,23 +54,25 @@ func (offer DepositOffer) ID() (ids.ID, error) {
 func (offer DepositOffer) Verify() error {
 	if offer.Start >= offer.End {
 		return fmt.Errorf(
-			"deposit offer starttime (%v) is not before its endtime (%v)",
+			"%w, starttime (%v) endtime (%v)",
+			ErrOfferStartLessThanEnd,
 			offer.Start,
 			offer.End,
 		)
 	}
 
 	if offer.MinDuration > offer.MaxDuration {
-		return errors.New("deposit minimum duration is greater than maximum duration")
+		return ErrOfferMinDurationGreaterThanMax
 	}
 
 	if offer.MinDuration == 0 {
-		return errors.New("deposit offer has zero minimum duration")
+		return ErrOfferZerosMinDuration
 	}
 
 	if offer.MinDuration < offer.NoRewardsPeriodDuration {
 		return fmt.Errorf(
-			"deposit offer minimum duration (%v) is less than no-rewards period duration (%v)",
+			"%w, minimum duration (%v) no-rewards period duration (%v)",
+			ErrOfferMinDurationLessThanNoReward,
 			offer.MinDuration,
 			offer.NoRewardsPeriodDuration,
 		)
@@ -70,7 +80,8 @@ func (offer DepositOffer) Verify() error {
 
 	if offer.MinDuration < offer.UnlockPeriodDuration {
 		return fmt.Errorf(
-			"deposit offer minimum duration (%v) is less than unlock period duration (%v)",
+			"%w, minimum duration (%v) unlock period duration (%v)",
+			ErrOfferMinDurationLessThanUnlock,
 			offer.MinDuration,
 			offer.UnlockPeriodDuration,
 		)

--- a/vms/platformvm/state/camino_deposit_offer_test.go
+++ b/vms/platformvm/state/camino_deposit_offer_test.go
@@ -1,0 +1,112 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/manager"
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+)
+
+var (
+	genesisDepositOffer = deposit.Offer{
+		ID:                    ids.ID{0},
+		InterestRateNominator: 0,
+		Start:                 uint64(time.Now().Add(-60 * time.Hour).Unix()),
+		End:                   uint64(time.Now().Add(+60 * time.Hour).Unix()),
+		MinAmount:             1,
+		MinDuration:           60,
+		MaxDuration:           60,
+		UnlockPeriodDuration:  60,
+	}
+
+	newDepositOffer = deposit.Offer{
+		ID:                    ids.ID{1},
+		InterestRateNominator: 0,
+		Start:                 uint64(time.Now().Add(-120 * time.Hour).Unix()),
+		End:                   uint64(time.Now().Add(+120 * time.Hour).Unix()),
+		MinAmount:             2,
+		MinDuration:           120,
+		MaxDuration:           120,
+		UnlockPeriodDuration:  120,
+	}
+)
+
+func TestGetDepositOffer(t *testing.T) {
+	baseDBManager := manager.NewMemDB(version.CurrentDatabase)
+	cs, err := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+	require.NoError(t, err)
+	cs.AddDepositOffer(&genesisDepositOffer)
+
+	tests := map[string]struct {
+		expectedErr error
+		offerID     ids.ID
+	}{
+		"Deposit offer does not exist": {
+			offerID:     ids.GenerateTestID(),
+			expectedErr: database.ErrNotFound,
+		},
+		"Happy path": {
+			offerID:     ids.ID{0},
+			expectedErr: nil,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := cs.GetDepositOffer(tt.offerID)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestGetAllDepositOffers(t *testing.T) {
+	baseDBManager := manager.NewMemDB(version.CurrentDatabase)
+	cs, err := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	cs.AddDepositOffer(&newDepositOffer)
+	cs.AddDepositOffer(&genesisDepositOffer)
+	depositOffers, err := cs.GetAllDepositOffers()
+	require.NoError(t, err)
+
+	sort.Slice(depositOffers, func(i, j int) bool {
+		return bytes.Compare(
+			depositOffers[i].ID[:],
+			depositOffers[j].ID[:]) == -1
+	})
+
+	require.Equal(t, depositOffers, []*deposit.Offer{&genesisDepositOffer, &newDepositOffer})
+}
+
+func TestLoadDepositOffers(t *testing.T) {
+	baseDBManager := manager.NewMemDB(version.CurrentDatabase)
+	cs, err := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	cs.AddDepositOffer(&newDepositOffer)
+	cs.AddDepositOffer(&genesisDepositOffer)
+	err = cs.writeDepositOffers()
+	require.NoError(t, err)
+	err = cs.loadDepositOffers()
+	require.NoError(t, err)
+
+	expectedDepositOffers := map[ids.ID]*deposit.Offer{
+		genesisDepositOffer.ID: &genesisDepositOffer,
+		newDepositOffer.ID:     &newDepositOffer,
+	}
+
+	require.Equal(t, cs.depositOffers, expectedDepositOffers)
+}


### PR DESCRIPTION
## Description ##
This PR adds unit tests for camino genesis validation regarding the deposit offers feature.

## Changes ##
- Added tests for `validateCaminoConfig` function.
- Replaced returned string errors with the explicitly defined ones accordingly. 
- Add `DepositOffers` object to `genesis_camino` and to `genesis_local` json files.
- Add unit tests for deposit offer function in camino state.