### PR TITLE
Deposit and unlock deposit txs

### DIFF
--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -5,7 +5,6 @@ package platformvm
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/keystore"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs/builder"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"go.uber.org/zap"
 
@@ -27,7 +25,6 @@ import (
 )
 
 var (
-	errNotCaminoBuilder  = errors.New("tx builder must provide CaminoBuilder interface")
 	errSerializeTx       = "couldn't serialize TX: %w"
 	errEncodeTx          = "couldn't encode TX as string: %w"
 	errInvalidChangeAddr = "couldn't parse changeAddr: %w"
@@ -326,13 +323,8 @@ func (service *Service) buildAddressStateTx(args *SetAddressStateArgs, keys *sec
 		return nil, fmt.Errorf("couldn't parse param Address: %w", err)
 	}
 
-	builder, ok := service.vm.txBuilder.(builder.CaminoBuilder)
-	if !ok {
-		return nil, errNotCaminoBuilder
-	}
-
 	// Create the transaction
-	tx, err := builder.NewAddAddressStateTx(
+	tx, err := service.vm.txBuilder.NewAddAddressStateTx(
 		targetAddr,  // Address to change state
 		args.Remove, // Add or remove State
 		args.State,  // The state to change

--- a/vms/platformvm/deposit/deposit.go
+++ b/vms/platformvm/deposit/deposit.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package deposit
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/hashing"
+	"github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+)
+
+const (
+	interestRateBase        = 365 * 24 * 60 * 60
+	interestRateDenominator = 1_000_000 * interestRateBase
+)
+
+var bigInterestRateDenominator = (&big.Int{}).SetInt64(interestRateDenominator)
+
+type Offer struct {
+	ID ids.ID
+
+	UnlockHalfPeriodDuration uint32 `serialize:"true"`
+	InterestRateNominator    uint64 `serialize:"true"`
+	Start                    uint64 `serialize:"true"`
+	End                      uint64 `serialize:"true"`
+	MinAmount                uint64 `serialize:"true"`
+	MinDuration              uint32 `serialize:"true"`
+	MaxDuration              uint32 `serialize:"true"`
+}
+
+// Sets offer id from its bytes hash
+func (o *Offer) SetID() error {
+	bytes, err := blocks.GenesisCodec.Marshal(blocks.Version, o)
+	if err != nil {
+		return err
+	}
+	o.ID = hashing.ComputeHash256Array(bytes)
+	return nil
+}
+
+// Time when this offer becomes active
+func (o *Offer) StartTime() time.Time {
+	return time.Unix(int64(o.Start), 0)
+}
+
+// Time when this offer becomes inactive
+func (o *Offer) EndTime() time.Time {
+	return time.Unix(int64(o.End), 0)
+}
+
+func (o *Offer) InterestRateFloat64() float64 {
+	return float64(o.InterestRateNominator) / float64(interestRateDenominator)
+}
+
+type Deposit struct {
+	DepositOfferID      ids.ID `serialize:"true"`
+	UnlockedAmount      uint64 `serialize:"true"`
+	ClaimedRewardAmount uint64 `serialize:"true"`
+	Start               uint64 `serialize:"true"`
+	Duration            uint32 `serialize:"true"`
+	Amount              uint64 `serialize:"true"`
+}
+
+func (deposit *Deposit) StartTime() time.Time {
+	return time.Unix(int64(deposit.Start), 0)
+}
+
+func (deposit *Deposit) IsExpired(
+	depositOffer *Offer,
+	timestamp uint64,
+) bool {
+	return deposit.Start+uint64(deposit.Duration)+uint64(depositOffer.UnlockHalfPeriodDuration) < timestamp
+}
+
+// Returns amount of tokens that can be unlocked from [deposit] at [unlockTime] (seconds).
+//
+// Precondition: all args are valid in conjunction.
+func (deposit *Deposit) UnlockableAmount(offer *Offer, unlockTime uint64) uint64 {
+	unlockPeriodStart, err := math.Add64(
+		deposit.Start,
+		uint64(deposit.Duration-offer.UnlockHalfPeriodDuration),
+	)
+	if err != nil || unlockPeriodStart > unlockTime {
+		// if err (overflow), than unlockPeriodStart > unlockTime for sure
+		return 0
+	}
+
+	unlockPeriodDuration := uint64(offer.UnlockHalfPeriodDuration) * 2
+	passedUnlockPeriodDuration := math.Min(unlockTime-unlockPeriodStart, unlockPeriodDuration)
+
+	bigTotalUnlockableAmount := (&big.Int{}).SetUint64(deposit.Amount)
+	bigPassedUnlockPeriodDuration := (&big.Int{}).SetUint64(passedUnlockPeriodDuration)
+	bigUnlockPeriodDuration := (&big.Int{}).SetUint64(unlockPeriodDuration)
+
+	// totalUnlockableAmount := depositAmount * passedUnlockPeriodDuration / unlockPeriodDuration
+	bigTotalUnlockableAmount.Mul(bigTotalUnlockableAmount, bigPassedUnlockPeriodDuration)
+	bigTotalUnlockableAmount.Div(bigTotalUnlockableAmount, bigUnlockPeriodDuration)
+
+	return bigTotalUnlockableAmount.Uint64() - deposit.UnlockedAmount
+}
+
+// Returns amount of tokens that can be claimed as reward for [deposit] at [claimetime] (seconds).
+//
+// Precondition: all args are valid in conjunction.
+func (deposit *Deposit) ClaimableReward(offer *Offer, depositAmount, claimTime uint64) uint64 {
+	if deposit.Start > claimTime {
+		return 0
+	}
+
+	bigTotalRewardAmount := (&big.Int{}).SetUint64(depositAmount)
+	bigPassedDepositDuration := (&big.Int{}).SetUint64(claimTime - deposit.Start)
+	bigInterestRateNominator := (&big.Int{}).SetUint64(offer.InterestRateNominator)
+
+	// totalRewardAmount := depositAmount * offer.InterestRate * passedDepositDuration / interestRateBase
+	bigTotalRewardAmount.Mul(bigTotalRewardAmount, bigPassedDepositDuration)
+	bigTotalRewardAmount.Mul(bigTotalRewardAmount, bigInterestRateNominator)
+	bigTotalRewardAmount.Div(bigTotalRewardAmount, bigInterestRateDenominator)
+
+	return bigTotalRewardAmount.Uint64() - deposit.ClaimedRewardAmount
+}
+
+// Returns amount of tokens that can be claimed as reward for [depositAmount].
+//
+// Precondition: all args are valid in conjunction.
+func (deposit *Deposit) TotalReward(offer *Offer) uint64 {
+	bigTotalRewardAmount := (&big.Int{}).SetUint64(deposit.Amount)
+	bigDepositDuration := (&big.Int{}).SetUint64(uint64(deposit.Duration))
+	bigInterestRateNominator := (&big.Int{}).SetUint64(offer.InterestRateNominator)
+
+	// totalRewardAmount := depositAmount * offer.InterestRate * depositDuration / interestRateBase
+	bigTotalRewardAmount.Mul(bigTotalRewardAmount, bigDepositDuration)
+	bigTotalRewardAmount.Mul(bigTotalRewardAmount, bigInterestRateNominator)
+	bigTotalRewardAmount.Div(bigTotalRewardAmount, bigInterestRateDenominator)
+
+	return bigTotalRewardAmount.Uint64()
+}

--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -13,7 +13,9 @@ var _ txs.Visitor = (*caminoTxMetrics)(nil)
 
 type caminoTxMetrics struct {
 	txMetrics
-	numAddAddressStateTxs prometheus.Counter
+	numAddAddressStateTxs,
+	numDepositTxs,
+	numUnlockDepositTxs prometheus.Counter
 }
 
 func newCaminoTxMetrics(
@@ -35,8 +37,20 @@ func newCaminoTxMetrics(
 }
 
 func (m *txMetrics) AddAddressStateTx(*txs.AddAddressStateTx) error { return nil }
+func (m *txMetrics) DepositTx(*txs.DepositTx) error                 { return nil }
+func (m *txMetrics) UnlockDepositTx(*txs.UnlockDepositTx) error     { return nil }
 
 func (m *caminoTxMetrics) AddAddressStateTx(*txs.AddAddressStateTx) error {
 	m.numAddAddressStateTxs.Inc()
+	return nil
+}
+
+func (m *caminoTxMetrics) DepositTx(*txs.DepositTx) error {
+	m.numDepositTxs.Inc()
+	return nil
+}
+
+func (m *caminoTxMetrics) UnlockDepositTx(*txs.UnlockDepositTx) error {
+	m.numUnlockDepositTxs.Inc()
 	return nil
 }

--- a/vms/platformvm/state/camino_deposit.go
+++ b/vms/platformvm/state/camino_deposit.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+)
+
+func (cs *caminoState) UpdateDeposit(depositTxID ids.ID, deposit *deposit.Deposit) {
+	cs.modifiedDeposits[depositTxID] = deposit
+}
+
+func (cs *caminoState) GetDeposit(depositTxID ids.ID) (*deposit.Deposit, error) {
+	// Try to get from modified state
+	d, ok := cs.modifiedDeposits[depositTxID]
+	// deposit was deleted
+	if ok && d == nil {
+		return nil, database.ErrNotFound
+	}
+	// Try to get it from cache
+	if !ok {
+		var depositIntf interface{}
+		if depositIntf, ok = cs.depositsCache.Get(depositTxID); ok {
+			d = depositIntf.(*deposit.Deposit)
+		}
+	}
+	// Try to get it from database
+	if !ok {
+		depositBytes, err := cs.depositsDB.Get(depositTxID[:])
+		if err != nil {
+			return nil, err
+		}
+
+		d = &deposit.Deposit{}
+		if _, err := blocks.GenesisCodec.Unmarshal(depositBytes, d); err != nil {
+			return nil, err
+		}
+
+		cs.depositsCache.Put(depositTxID, d)
+	}
+
+	return d, nil
+}
+
+func (cs *caminoState) writeDeposits() error {
+	for depositTxID, deposit := range cs.modifiedDeposits {
+		delete(cs.modifiedDeposits, depositTxID)
+
+		if deposit == nil {
+			if err := cs.depositsDB.Delete(depositTxID[:]); err != nil {
+				return err
+			}
+		} else {
+			depositBytes, err := blocks.GenesisCodec.Marshal(blocks.Version, deposit)
+			if err != nil {
+				return fmt.Errorf("failed to serialize deposit: %w", err)
+			}
+
+			if err := cs.depositsDB.Put(depositTxID[:], depositBytes); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/vms/platformvm/state/camino_deposit_test.go
+++ b/vms/platformvm/state/camino_deposit_test.go
@@ -1,0 +1,222 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	db_manager "github.com/ava-labs/avalanchego/database/manager"
+)
+
+func TestGetDeposit(t *testing.T) {
+	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
+	addr0 := ids.GenerateTestShortID()
+	addresses := ids.ShortSet{}
+	addresses.Add(addr0)
+	testID := ids.GenerateTestID()
+	deposit1 := deposit.Deposit{
+		DepositOfferID: testID,
+		Start:          uint64(time.Now().Unix()),
+		Duration:       uint32((10 * time.Minute).Seconds()),
+		Amount:         1,
+	}
+	type args struct {
+		depositTxID ids.ID
+	}
+	tests := map[string]struct {
+		cs          CaminoState
+		args        args
+		prepareFunc func(cs CaminoState)
+		want        *deposit.Deposit
+		err         error
+	}{
+		"retrieve from modified state": {
+			cs: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				return cs
+			}(),
+			args: args{
+				depositTxID: testID,
+			},
+			prepareFunc: func(cs CaminoState) {
+				cs.UpdateDeposit(testID, &deposit1)
+			},
+			want: &deposit1,
+		},
+		"retrieve from modified state when deposit already in db": {
+			cs: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				return cs
+			}(),
+			args: args{
+				depositTxID: testID,
+			},
+			prepareFunc: func(cs CaminoState) {
+				cs.UpdateDeposit(testID, &deposit1)
+
+				db := cs.(*caminoState).depositsDB
+				depositBytes, _ := blocks.GenesisCodec.Marshal(blocks.Version, deposit.Deposit{DepositOfferID: testID, Amount: deposit1.Amount + 1})
+				db.Put(testID[:], depositBytes) //nolint:errcheck
+			},
+			want: &deposit1,
+		},
+		"retrieval fails when deposit already in modified state but with nil value even if present in db": {
+			cs: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				return cs
+			}(),
+			args: args{
+				depositTxID: testID,
+			},
+			prepareFunc: func(cs CaminoState) {
+				cs.UpdateDeposit(testID, nil)
+
+				db := cs.(*caminoState).depositsDB
+				depositBytes, _ := blocks.GenesisCodec.Marshal(blocks.Version, &deposit1)
+				db.Put(testID[:], depositBytes) //nolint:errcheck
+			},
+			err: database.ErrNotFound,
+		},
+		"retrieve from cache": {
+			cs: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				return cs
+			}(),
+			args: args{
+				depositTxID: testID,
+			},
+			prepareFunc: func(cs CaminoState) {
+				cache := cs.(*caminoState).depositsCache
+				cache.Put(testID, &deposit1)
+			},
+			want: &deposit1,
+		},
+		"retrieve from cache when deposit already in db": {
+			cs: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				return cs
+			}(),
+			args: args{
+				depositTxID: testID,
+			},
+			prepareFunc: func(cs CaminoState) {
+				cache := cs.(*caminoState).depositsCache
+				cache.Put(testID, &deposit1)
+
+				db := cs.(*caminoState).depositsDB
+				depositBytes, _ := blocks.GenesisCodec.Marshal(blocks.Version, deposit.Deposit{DepositOfferID: testID, Amount: deposit1.Amount + 1})
+				db.Put(testID[:], depositBytes) //nolint:errcheck
+			},
+			want: &deposit1,
+		},
+		"retrieve from db": {
+			cs: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				return cs
+			}(),
+			args: args{
+				depositTxID: testID,
+			},
+			prepareFunc: func(cs CaminoState) {
+				db := cs.(*caminoState).depositsDB
+				depositBytes, _ := blocks.GenesisCodec.Marshal(blocks.Version, deposit1)
+				db.Put(testID[:], depositBytes) //nolint:errcheck
+			},
+			want: &deposit1,
+		},
+		"db retrieval failed": {
+			cs: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				return cs
+			}(),
+			args: args{
+				depositTxID: testID,
+			},
+			prepareFunc: func(cs CaminoState) {},
+			err:         database.ErrNotFound,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tt.prepareFunc(tt.cs)
+			got, err := tt.cs.GetDeposit(tt.args.depositTxID)
+			if tt.err != nil {
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWriteDeposits(t *testing.T) {
+	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
+	addr0 := ids.GenerateTestShortID()
+	addresses := ids.ShortSet{}
+	addresses.Add(addr0)
+	testID := ids.GenerateTestID()
+
+	deposit1 := deposit.Deposit{
+		DepositOfferID: testID,
+		Start:          uint64(time.Now().Unix()),
+		Duration:       uint32((10 * time.Minute).Seconds()),
+		Amount:         1,
+	}
+	tests := map[string]struct {
+		prepareFunc            func() CaminoState
+		wantedModifiedDeposits map[ids.ID]*deposit.Deposit
+		wantedDepositsDB       database.Database
+		err                    error
+	}{
+		"Deposit nil / success db deletion": {
+			prepareFunc: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs.modifiedDeposits[testID] = nil
+				return cs
+			},
+			wantedModifiedDeposits: map[ids.ID]*deposit.Deposit{},
+		},
+		"Deposit nil / error in db deletion": {
+			prepareFunc: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs.modifiedDeposits[testID] = nil
+				cs.depositsDB.Close() // close db connection to cause error on deletion
+				return cs
+			},
+			err: database.ErrClosed,
+		},
+		"Success": {
+			prepareFunc: func() CaminoState {
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs.modifiedDeposits[testID] = &deposit1
+				return cs
+			},
+			wantedModifiedDeposits: map[ids.ID]*deposit.Deposit{},
+			wantedDepositsDB:       versiondb.New(baseDBManager.Current().Database),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cs := tt.prepareFunc()
+
+			err := cs.(*caminoState).writeDeposits()
+			if tt.err != nil {
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantedModifiedDeposits, cs.(*caminoState).modifiedDeposits)
+		})
+	}
+}

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 )
@@ -47,14 +48,22 @@ func (s *state) GetAddressStates(address ids.ShortID) (uint64, error) {
 	return s.caminoState.GetAddressStates(address)
 }
 
-func (s *state) AddDepositOffer(offer *DepositOffer) {
+func (s *state) AddDepositOffer(offer *deposit.Offer) {
 	s.caminoState.AddDepositOffer(offer)
 }
 
-func (s *state) GetDepositOffer(offerID ids.ID) (*DepositOffer, error) {
+func (s *state) GetDepositOffer(offerID ids.ID) (*deposit.Offer, error) {
 	return s.caminoState.GetDepositOffer(offerID)
 }
 
-func (s *state) GetAllDepositOffers() ([]*DepositOffer, error) {
+func (s *state) GetAllDepositOffers() ([]*deposit.Offer, error) {
 	return s.caminoState.GetAllDepositOffers()
+}
+
+func (s *state) UpdateDeposit(depositTxID ids.ID, deposit *deposit.Deposit) {
+	s.caminoState.UpdateDeposit(depositTxID, deposit)
+}
+
+func (s *state) GetDeposit(depositTxID ids.ID) (*deposit.Deposit, error) {
+	return s.caminoState.GetDeposit(depositTxID)
 }

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -68,7 +68,7 @@ type diff struct {
 	modifiedUTXOs map[ids.ID]*utxoModification
 
 	// camino state diff handler
-	caminoDiff caminoDiff
+	caminoDiff *caminoDiff
 }
 
 type utxoModification struct {
@@ -88,6 +88,7 @@ func NewDiff(
 		parentID:      parentID,
 		stateVersions: stateVersions,
 		timestamp:     parentState.GetTimestamp(),
+		caminoDiff:    newCaminoDiff(),
 	}, nil
 }
 

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -13,6 +13,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
+	deposit "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	genesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	locked "github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
@@ -56,7 +57,7 @@ func (mr *MockChainMockRecorder) AddChain(arg0 interface{}) *gomock.Call {
 }
 
 // AddDepositOffer mocks base method.
-func (m *MockChain) AddDepositOffer(arg0 *DepositOffer) {
+func (m *MockChain) AddDepositOffer(arg0 *deposit.Offer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddDepositOffer", arg0)
 }
@@ -218,10 +219,10 @@ func (mr *MockChainMockRecorder) GetAddressStates(arg0 interface{}) *gomock.Call
 }
 
 // GetAllDepositOffers mocks base method.
-func (m *MockChain) GetAllDepositOffers() ([]*DepositOffer, error) {
+func (m *MockChain) GetAllDepositOffers() ([]*deposit.Offer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllDepositOffers")
-	ret0, _ := ret[0].([]*DepositOffer)
+	ret0, _ := ret[0].([]*deposit.Offer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -307,11 +308,26 @@ func (mr *MockChainMockRecorder) GetCurrentValidator(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentValidator", reflect.TypeOf((*MockChain)(nil).GetCurrentValidator), arg0, arg1)
 }
 
+// GetDeposit mocks base method.
+func (m *MockChain) GetDeposit(arg0 ids.ID) (*deposit.Deposit, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeposit", arg0)
+	ret0, _ := ret[0].(*deposit.Deposit)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeposit indicates an expected call of GetDeposit.
+func (mr *MockChainMockRecorder) GetDeposit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeposit", reflect.TypeOf((*MockChain)(nil).GetDeposit), arg0)
+}
+
 // GetDepositOffer mocks base method.
-func (m *MockChain) GetDepositOffer(arg0 ids.ID) (*DepositOffer, error) {
+func (m *MockChain) GetDepositOffer(arg0 ids.ID) (*deposit.Offer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDepositOffer", arg0)
-	ret0, _ := ret[0].(*DepositOffer)
+	ret0, _ := ret[0].(*deposit.Offer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -554,4 +570,16 @@ func (m *MockChain) SetTimestamp(arg0 time.Time) {
 func (mr *MockChainMockRecorder) SetTimestamp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTimestamp", reflect.TypeOf((*MockChain)(nil).SetTimestamp), arg0)
+}
+
+// UpdateDeposit mocks base method.
+func (m *MockChain) UpdateDeposit(arg0 ids.ID, arg1 *deposit.Deposit) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateDeposit", arg0, arg1)
+}
+
+// UpdateDeposit indicates an expected call of UpdateDeposit.
+func (mr *MockChainMockRecorder) UpdateDeposit(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeposit", reflect.TypeOf((*MockChain)(nil).UpdateDeposit), arg0, arg1)
 }

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -13,6 +13,7 @@ import (
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
+	deposit "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	genesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	locked "github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
@@ -56,7 +57,7 @@ func (mr *MockDiffMockRecorder) AddChain(arg0 interface{}) *gomock.Call {
 }
 
 // AddDepositOffer mocks base method.
-func (m *MockDiff) AddDepositOffer(arg0 *DepositOffer) {
+func (m *MockDiff) AddDepositOffer(arg0 *deposit.Offer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddDepositOffer", arg0)
 }
@@ -242,10 +243,10 @@ func (mr *MockDiffMockRecorder) GetAddressStates(arg0 interface{}) *gomock.Call 
 }
 
 // GetAllDepositOffers mocks base method.
-func (m *MockDiff) GetAllDepositOffers() ([]*DepositOffer, error) {
+func (m *MockDiff) GetAllDepositOffers() ([]*deposit.Offer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllDepositOffers")
-	ret0, _ := ret[0].([]*DepositOffer)
+	ret0, _ := ret[0].([]*deposit.Offer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -331,11 +332,26 @@ func (mr *MockDiffMockRecorder) GetCurrentValidator(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentValidator", reflect.TypeOf((*MockDiff)(nil).GetCurrentValidator), arg0, arg1)
 }
 
+// GetDeposit mocks base method.
+func (m *MockDiff) GetDeposit(arg0 ids.ID) (*deposit.Deposit, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeposit", arg0)
+	ret0, _ := ret[0].(*deposit.Deposit)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeposit indicates an expected call of GetDeposit.
+func (mr *MockDiffMockRecorder) GetDeposit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeposit", reflect.TypeOf((*MockDiff)(nil).GetDeposit), arg0)
+}
+
 // GetDepositOffer mocks base method.
-func (m *MockDiff) GetDepositOffer(arg0 ids.ID) (*DepositOffer, error) {
+func (m *MockDiff) GetDepositOffer(arg0 ids.ID) (*deposit.Offer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDepositOffer", arg0)
-	ret0, _ := ret[0].(*DepositOffer)
+	ret0, _ := ret[0].(*deposit.Offer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -578,4 +594,16 @@ func (m *MockDiff) SetTimestamp(arg0 time.Time) {
 func (mr *MockDiffMockRecorder) SetTimestamp(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTimestamp", reflect.TypeOf((*MockDiff)(nil).SetTimestamp), arg0)
+}
+
+// UpdateDeposit mocks base method.
+func (m *MockDiff) UpdateDeposit(arg0 ids.ID, arg1 *deposit.Deposit) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateDeposit", arg0, arg1)
+}
+
+// UpdateDeposit indicates an expected call of UpdateDeposit.
+func (mr *MockDiffMockRecorder) UpdateDeposit(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeposit", reflect.TypeOf((*MockDiff)(nil).UpdateDeposit), arg0, arg1)
 }

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -17,6 +17,7 @@ import (
 	validators "github.com/ava-labs/avalanchego/snow/validators"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
 	blocks "github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	deposit "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	genesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	locked "github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
@@ -72,7 +73,7 @@ func (mr *MockStateMockRecorder) AddChain(arg0 interface{}) *gomock.Call {
 }
 
 // AddDepositOffer mocks base method.
-func (m *MockState) AddDepositOffer(arg0 *DepositOffer) {
+func (m *MockState) AddDepositOffer(arg0 *deposit.Offer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddDepositOffer", arg0)
 }
@@ -289,10 +290,10 @@ func (mr *MockStateMockRecorder) GetAddressStates(arg0 interface{}) *gomock.Call
 }
 
 // GetAllDepositOffers mocks base method.
-func (m *MockState) GetAllDepositOffers() ([]*DepositOffer, error) {
+func (m *MockState) GetAllDepositOffers() ([]*deposit.Offer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllDepositOffers")
-	ret0, _ := ret[0].([]*DepositOffer)
+	ret0, _ := ret[0].([]*deposit.Offer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -378,11 +379,26 @@ func (mr *MockStateMockRecorder) GetCurrentValidator(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentValidator", reflect.TypeOf((*MockState)(nil).GetCurrentValidator), arg0, arg1)
 }
 
+// GetDeposit mocks base method.
+func (m *MockState) GetDeposit(arg0 ids.ID) (*deposit.Deposit, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeposit", arg0)
+	ret0, _ := ret[0].(*deposit.Deposit)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeposit indicates an expected call of GetDeposit.
+func (mr *MockStateMockRecorder) GetDeposit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeposit", reflect.TypeOf((*MockState)(nil).GetDeposit), arg0)
+}
+
 // GetDepositOffer mocks base method.
-func (m *MockState) GetDepositOffer(arg0 ids.ID) (*DepositOffer, error) {
+func (m *MockState) GetDepositOffer(arg0 ids.ID) (*deposit.Offer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDepositOffer", arg0)
-	ret0, _ := ret[0].(*DepositOffer)
+	ret0, _ := ret[0].(*deposit.Offer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -754,6 +770,18 @@ func (m *MockState) UTXOIDs(arg0 []byte, arg1 ids.ID, arg2 int) ([]ids.ID, error
 func (mr *MockStateMockRecorder) UTXOIDs(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UTXOIDs", reflect.TypeOf((*MockState)(nil).UTXOIDs), arg0, arg1, arg2)
+}
+
+// UpdateDeposit mocks base method.
+func (m *MockState) UpdateDeposit(arg0 ids.ID, arg1 *deposit.Deposit) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateDeposit", arg0, arg1)
+}
+
+// UpdateDeposit indicates an expected call of UpdateDeposit.
+func (mr *MockStateMockRecorder) UpdateDeposit(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeposit", reflect.TypeOf((*MockState)(nil).UpdateDeposit), arg0, arg1)
 }
 
 // ValidatorSet mocks base method.

--- a/vms/platformvm/txs/builder/builder.go
+++ b/vms/platformvm/txs/builder/builder.go
@@ -1,13 +1,3 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
-//
-// This file is a derived work, based on ava-labs code whose
-// original notices appear below.
-//
-// It is distributed under the same license conditions as the
-// original code from which it is derived.
-//
-// Much love to the original authors for their work.
-// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -187,16 +177,14 @@ func New(
 	atomicUTXOManager avax.AtomicUTXOManager,
 	utxoSpender utxo.Spender,
 ) Builder {
-	return &caminoBuilder{
-		builder: builder{
-			AtomicUTXOManager: atomicUTXOManager,
-			Spender:           utxoSpender,
-			state:             state,
-			cfg:               cfg,
-			ctx:               ctx,
-			clk:               clk,
-			fx:                fx,
-		},
+	return &builder{
+		AtomicUTXOManager: atomicUTXOManager,
+		Spender:           utxoSpender,
+		state:             state,
+		cfg:               cfg,
+		ctx:               ctx,
+		clk:               clk,
+		fx:                fx,
 	}
 }
 

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -8,10 +8,16 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
+	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validator"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
@@ -25,13 +31,54 @@ var (
 
 type CaminoBuilder interface {
 	Builder
+	CaminoTxBuilder
+}
+
+type CaminoTxBuilder interface {
 	NewAddAddressStateTx(
-		ids.ShortID, // address
-		bool, // remove
-		uint8, // state
-		[]*crypto.PrivateKeySECP256K1R,
-		ids.ShortID, // changeAddress
+		address ids.ShortID,
+		remove bool,
+		state uint8,
+		keys []*crypto.PrivateKeySECP256K1R,
+		changeAddr ids.ShortID,
 	) (*txs.Tx, error)
+
+	NewDepositTx(
+		amount uint64,
+		duration uint32,
+		depositOfferID ids.ID,
+		rewardAddress ids.ShortID,
+		keys []*crypto.PrivateKeySECP256K1R,
+		changeAddr ids.ShortID,
+	) (*txs.Tx, error)
+
+	NewUnlockDepositTx(
+		lockTxIDs []ids.ID,
+		keys []*crypto.PrivateKeySECP256K1R,
+		changeAddr ids.ShortID,
+	) (*txs.Tx, error)
+}
+
+func NewCamino(
+	ctx *snow.Context,
+	cfg *config.Config,
+	clk *mockable.Clock,
+	fx fx.Fx,
+	state state.Chain,
+	atomicUTXOManager avax.AtomicUTXOManager,
+	utxoSpender utxo.Spender,
+) CaminoBuilder {
+	return &caminoBuilder{
+		builder: builder{
+			AtomicUTXOManager: atomicUTXOManager,
+			Spender:           utxoSpender,
+			state:             state,
+			cfg:               cfg,
+			ctx:               ctx,
+			clk:               clk,
+			fx:                fx,
+		},
+	}
 }
 
 type caminoBuilder struct {
@@ -176,7 +223,7 @@ func (b *caminoBuilder) NewRewardValidatorTx(txID ids.ID) (*txs.Tx, error) {
 		return b.builder.NewRewardValidatorTx(txID)
 	}
 
-	ins, outs, err := b.Spender.Unlock(b.state, []ids.ID{txID}, locked.StateBonded)
+	ins, outs, err := b.Unlock(b.state, []ids.ID{txID}, locked.StateBonded)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
 	}
@@ -223,6 +270,88 @@ func (b *caminoBuilder) NewAddAddressStateTx(
 		return nil, err
 	}
 
+	return tx, tx.SyntacticVerify(b.ctx)
+}
+
+func (b *caminoBuilder) NewDepositTx(
+	amount uint64,
+	duration uint32,
+	depositOfferID ids.ID,
+	rewardAddress ids.ShortID,
+	keys []*crypto.PrivateKeySECP256K1R,
+	changeAddr ids.ShortID,
+) (*txs.Tx, error) {
+	ins, outs, signers, err := b.Lock(keys, amount, b.cfg.TxFee, locked.StateDeposited, changeAddr)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
+	}
+
+	utx := &txs.DepositTx{
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.ctx.NetworkID,
+			BlockchainID: b.ctx.ChainID,
+			Ins:          ins,
+			Outs:         outs,
+		}},
+		DepositOfferID: depositOfferID,
+		Duration:       duration,
+		RewardsOwner: &secp256k1fx.OutputOwners{
+			Locktime:  0,
+			Threshold: 1,
+			Addrs:     []ids.ShortID{rewardAddress},
+		},
+	}
+
+	tx, err := txs.NewSigned(utx, txs.Codec, signers)
+	if err != nil {
+		return nil, err
+	}
+	return tx, tx.SyntacticVerify(b.ctx)
+}
+
+func (b *caminoBuilder) NewUnlockDepositTx(
+	lockTxIDs []ids.ID,
+	keys []*crypto.PrivateKeySECP256K1R,
+	changeAddr ids.ShortID,
+) (*txs.Tx, error) {
+	var ins []*avax.TransferableInput
+	var outs []*avax.TransferableOutput
+	var signers [][]*crypto.PrivateKeySECP256K1R
+
+	// unlocking
+	ins, outs, signers, err := b.UnlockDeposit(b.state, keys, lockTxIDs)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
+	}
+
+	// burning fee
+	feeIns, feeOuts, feeSigners, err := b.Lock(keys, 0, b.cfg.TxFee, locked.StateUnlocked, changeAddr)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
+	}
+
+	ins = append(ins, feeIns...)
+	outs = append(outs, feeOuts...)
+	signers = append(signers, feeSigners...)
+
+	// we need to sort ins/outs/signers before using them in tx
+	// UnlockDeposit returns unsorted results and we appended arrays
+	avax.SortTransferableInputsWithSigners(ins, signers)
+	avax.SortTransferableOutputs(outs, txs.Codec)
+
+	utx := &txs.UnlockDepositTx{
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.ctx.NetworkID,
+			BlockchainID: b.ctx.ChainID,
+			Ins:          ins,
+			Outs:         outs,
+		}},
+	}
+
+	tx, err := txs.NewSigned(utx, txs.Codec, signers)
+	if err != nil {
+		return nil, err
+	}
 	return tx, tx.SyntacticVerify(b.ctx)
 }
 

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -64,7 +64,7 @@ func TestCaminoBuilderTxAddressState(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := b.(CaminoBuilder).NewAddAddressStateTx(
+			_, err := b.NewAddAddressStateTx(
 				tt.address,
 				tt.remove,
 				tt.state,

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -118,7 +118,7 @@ func (sn *snLookup) SubnetID(chainID ids.ID) (ids.ID, error) {
 	return subnetID, nil
 }
 
-func newCaminoBuilder(postBanff bool, caminoGenesisConf genesis.Camino) Builder {
+func newCaminoBuilder(postBanff bool, caminoGenesisConf genesis.Camino) CaminoBuilder {
 	var isBootstrapped utils.AtomicBool
 	isBootstrapped.SetValue(true)
 
@@ -138,7 +138,7 @@ func newCaminoBuilder(postBanff bool, caminoGenesisConf genesis.Camino) Builder 
 	uptimes := uptime.NewManager(baseState)
 	utxoHandler := utxo.NewHandler(ctx, &clk, baseState, fx)
 
-	txBuilder := New(
+	txBuilder := NewCamino(
 		ctx,
 		&config,
 		&clk,

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -76,7 +76,7 @@ type mutableSharedMemory struct {
 	atomic.SharedMemory
 }
 
-type environment struct {
+type caminoEnvironment struct {
 	isBootstrapped *utils.AtomicBool
 	config         *config.Config
 	clk            *mockable.Clock
@@ -89,11 +89,11 @@ type environment struct {
 	atomicUTXOs    avax.AtomicUTXOManager
 	uptimes        uptime.Manager
 	utxosHandler   utxo.Handler
-	txBuilder      Builder
+	txBuilder      CaminoBuilder
 	backend        executor.Backend
 }
 
-func (e *environment) GetState(blkID ids.ID) (state.Chain, bool) {
+func (e *caminoEnvironment) GetState(blkID ids.ID) (state.Chain, bool) {
 	if blkID == lastAcceptedID {
 		return e.state, true
 	}
@@ -101,7 +101,7 @@ func (e *environment) GetState(blkID ids.ID) (state.Chain, bool) {
 	return chainState, ok
 }
 
-func (e *environment) SetState(blkID ids.ID, chainState state.Chain) {
+func (e *caminoEnvironment) SetState(blkID ids.ID, chainState state.Chain) {
 	e.states[blkID] = chainState
 }
 
@@ -159,7 +159,7 @@ func newCaminoBuilder(postBanff bool, caminoGenesisConf genesis.Camino) CaminoBu
 		Rewards:      rewards,
 	}
 
-	env := &environment{
+	env := &caminoEnvironment{
 		isBootstrapped: &isBootstrapped,
 		config:         &config,
 		clk:            &clk,
@@ -181,7 +181,7 @@ func newCaminoBuilder(postBanff bool, caminoGenesisConf genesis.Camino) CaminoBu
 }
 
 func addCaminoSubnet(
-	env *environment,
+	env *caminoEnvironment,
 	txBuilder Builder,
 ) {
 	// Create a subnet

--- a/vms/platformvm/txs/camino_deposit_tx.go
+++ b/vms/platformvm/txs/camino_deposit_tx.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+)
+
+var _ UnsignedTx = (*DepositTx)(nil)
+
+// DepositTx is an unsigned depositTx
+type DepositTx struct {
+	// Metadata, inputs and outputs
+	BaseTx `serialize:"true"`
+	// ID of active offer that will be used for this deposit
+	DepositOfferID ids.ID `serialize:"true" json:"depositOfferID"`
+	// duration of deposit
+	Duration uint32 `serialize:"true" json:"duration"`
+	// Where to send staking rewards when done validating
+	RewardsOwner fx.Owner `serialize:"true" json:"rewardsOwner"`
+}
+
+// InitCtx sets the FxID fields in the inputs and outputs of this
+// [DepositTx]. Also sets the [ctx] to the given [vm.ctx] so that
+// the addresses can be json marshalled into human readable format
+func (tx *DepositTx) InitCtx(ctx *snow.Context) {
+	tx.BaseTx.InitCtx(ctx)
+	tx.RewardsOwner.InitCtx(ctx)
+}
+
+func (tx *DepositTx) DepositAmount() (uint64, error) {
+	depositAmount := uint64(0)
+	for _, out := range tx.Outs {
+		if lockedOut, ok := out.Out.(*locked.Out); ok && lockedOut.IsNewlyLockedWith(locked.StateDeposited) {
+			newDepositAmount, err := math.Add64(depositAmount, lockedOut.Amount())
+			if err != nil {
+				return 0, err
+			}
+			depositAmount = newDepositAmount
+		}
+	}
+	return depositAmount, nil
+}
+
+// SyntacticVerify returns nil if [tx] is valid
+func (tx *DepositTx) SyntacticVerify(ctx *snow.Context) error {
+	switch {
+	case tx == nil:
+		return ErrNilTx
+	case tx.SyntacticallyVerified: // already passed syntactic verification
+		return nil
+	}
+
+	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {
+		return fmt.Errorf("failed to verify BaseTx: %w", err)
+	}
+	if err := verify.All(tx.RewardsOwner); err != nil {
+		return fmt.Errorf("failed to verify validator or rewards owner: %w", err)
+	}
+
+	// cache that this is valid
+	tx.SyntacticallyVerified = true
+	return nil
+}
+
+func (tx *DepositTx) Visit(visitor Visitor) error {
+	return visitor.DepositTx(tx)
+}

--- a/vms/platformvm/txs/camino_unlock_deposit_tx.go
+++ b/vms/platformvm/txs/camino_unlock_deposit_tx.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/snow"
+)
+
+var _ UnsignedTx = (*UnlockDepositTx)(nil)
+
+// UnlockDepositTx is an unsigned unlockDepositTx
+type UnlockDepositTx struct {
+	// Metadata, inputs and outputs
+	BaseTx `serialize:"true"`
+}
+
+// SyntacticVerify returns nil if [tx] is valid
+func (tx *UnlockDepositTx) SyntacticVerify(ctx *snow.Context) error {
+	switch {
+	case tx == nil:
+		return ErrNilTx
+	case tx.SyntacticallyVerified: // already passed syntactic verification
+		return nil
+	}
+
+	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {
+		return fmt.Errorf("failed to verify BaseTx: %w", err)
+	}
+
+	// cache that this is valid
+	tx.SyntacticallyVerified = true
+	return nil
+}
+
+func (tx *UnlockDepositTx) Visit(visitor Visitor) error {
+	return visitor.UnlockDepositTx(tx)
+}

--- a/vms/platformvm/txs/camino_visitor.go
+++ b/vms/platformvm/txs/camino_visitor.go
@@ -1,0 +1,10 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+type CaminoVisitor interface {
+	AddAddressStateTx(*AddAddressStateTx) error
+	DepositTx(*DepositTx) error
+	UnlockDepositTx(*UnlockDepositTx) error
+}

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -110,6 +110,8 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&CaminoAddValidatorTx{}),
 		targetCodec.RegisterCustomType(&CaminoRewardValidatorTx{}),
 		targetCodec.RegisterCustomType(&AddAddressStateTx{}),
+		targetCodec.RegisterCustomType(&DepositTx{}),
+		targetCodec.RegisterCustomType(&UnlockDepositTx{}),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -75,7 +75,7 @@ func newCaminoEnvironment(postBanff bool, caminoGenesisConf genesis.Camino) *env
 	uptimes := uptime.NewManager(baseState)
 	utxoHandler := utxo.NewHandler(ctx, &clk, baseState, fx)
 
-	txBuilder := builder.New(
+	txBuilder := builder.NewCamino(
 		ctx,
 		&config,
 		&clk,

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 	"time"
 
+	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+
+	"github.com/ava-labs/avalanchego/utils/units"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -34,7 +38,7 @@ func TestCaminoEnv(t *testing.T) {
 	env := newCaminoEnvironment( /*postBanff*/ false, caminoGenesisConf)
 	env.ctx.Lock.Lock()
 	defer func() {
-		err := shutdownEnvironment(env)
+		err := shutdownCaminoEnvironment(env)
 		require.NoError(t, err)
 	}()
 	env.config.BanffTime = env.state.GetTimestamp()
@@ -48,7 +52,7 @@ func TestCaminoStandardTxExecutorAddValidatorTx(t *testing.T) {
 	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
 	env.ctx.Lock.Lock()
 	defer func() {
-		if err := shutdownEnvironment(env); err != nil {
+		if err := shutdownCaminoEnvironment(env); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -226,7 +230,7 @@ func TestCaminoStandardTxExecutorAddSubnetValidatorTx(t *testing.T) {
 	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
 	env.ctx.Lock.Lock()
 	defer func() {
-		if err := shutdownEnvironment(env); err != nil {
+		if err := shutdownCaminoEnvironment(env); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -506,7 +510,7 @@ func TestCaminoStandardTxExecutorAddValidatorTxBody(t *testing.T) {
 	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
 	env.ctx.Lock.Lock()
 	defer func() {
-		if err := shutdownEnvironment(env); err != nil {
+		if err := shutdownCaminoEnvironment(env); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -766,7 +770,7 @@ func TestCaminoAddValidatorTxNodeSig(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				if err := shutdownEnvironment(env); err != nil {
+				if err := shutdownCaminoEnvironment(env); err != nil {
 					t.Fatal(err)
 				}
 			}()
@@ -939,7 +943,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 		},
 	}
 
-	generateExecutor := func(unsidngedTx txs.UnsignedTx, env *environment) CaminoStandardTxExecutor {
+	generateExecutor := func(unsidngedTx txs.UnsignedTx, env *caminoEnvironment) CaminoStandardTxExecutor {
 		tx, err := txs.NewSigned(unsidngedTx, txs.Codec, signers)
 		require.NoError(t, err)
 
@@ -962,7 +966,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				err := shutdownEnvironment(env)
+				err := shutdownCaminoEnvironment(env)
 				require.NoError(t, err)
 			}()
 			env.config.BanffTime = env.state.GetTimestamp()
@@ -1012,7 +1016,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				err := shutdownEnvironment(env)
+				err := shutdownCaminoEnvironment(env)
 				require.NoError(t, err)
 			}()
 			env.config.BanffTime = env.state.GetTimestamp()
@@ -1040,7 +1044,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				err := shutdownEnvironment(env)
+				err := shutdownCaminoEnvironment(env)
 				require.NoError(t, err)
 			}()
 			env.config.BanffTime = env.state.GetTimestamp()
@@ -1067,7 +1071,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				err := shutdownEnvironment(env)
+				err := shutdownCaminoEnvironment(env)
 				require.NoError(t, err)
 			}()
 			env.config.BanffTime = env.state.GetTimestamp()
@@ -1093,7 +1097,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				err := shutdownEnvironment(env)
+				err := shutdownCaminoEnvironment(env)
 				require.NoError(t, err)
 			}()
 			env.config.BanffTime = env.state.GetTimestamp()
@@ -1118,7 +1122,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				err := shutdownEnvironment(env)
+				err := shutdownCaminoEnvironment(env)
 				require.NoError(t, err)
 			}()
 			env.config.BanffTime = env.state.GetTimestamp()
@@ -1145,7 +1149,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				err := shutdownEnvironment(env)
+				err := shutdownCaminoEnvironment(env)
 				require.NoError(t, err)
 			}()
 			env.config.BanffTime = env.state.GetTimestamp()
@@ -1179,7 +1183,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				err := shutdownEnvironment(env)
+				err := shutdownCaminoEnvironment(env)
 				require.NoError(t, err)
 			}()
 			env.config.BanffTime = env.state.GetTimestamp()
@@ -1315,7 +1319,7 @@ func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
 			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {
-				if err := shutdownEnvironment(env); err != nil {
+				if err := shutdownCaminoEnvironment(env); err != nil {
 					t.Fatal(err)
 				}
 			}()
@@ -1625,7 +1629,7 @@ func TestCaminoRewardValidatorTx(t *testing.T) {
 	})
 
 	// Shut down the environment
-	err = shutdownEnvironment(env)
+	err = shutdownCaminoEnvironment(env)
 	require.NoError(t, err)
 }
 
@@ -1638,7 +1642,7 @@ func TestAddAdressStateTxExecutor(t *testing.T) {
 	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
 	env.ctx.Lock.Lock()
 	defer func() {
-		err := shutdownEnvironment(env)
+		err := shutdownCaminoEnvironment(env)
 		require.NoError(t, err)
 	}()
 
@@ -1881,6 +1885,1479 @@ func TestAddAdressStateTxExecutor(t *testing.T) {
 			executor.State.SetAddressStates(tt.targetAddress, tt.flag)
 
 			err = addAddressStateTx.Visit(&executor)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
+	currentTime := time.Now()
+
+	testDepositOffer := genesis.DepositOffer{
+		UnlockHalfPeriodDuration: 30,
+		InterestRateNominator:    0,
+		Start:                    uint64(currentTime.Add(-60 * time.Hour).Unix()),
+		End:                      uint64(currentTime.Add(+60 * time.Hour).Unix()),
+		MinAmount:                1,
+		MinDuration:              60,
+		MaxDuration:              60,
+	}
+
+	testKey, err := testKeyfactory.NewPrivateKey()
+	require.NoError(t, err)
+	dummyKey, err := testKeyfactory.NewPrivateKey()
+	require.NoError(t, err)
+	dummyOutputOwners := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{dummyKey.PublicKey().Address()},
+	}
+
+	outputOwners := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{testKey.PublicKey().Address()},
+	}
+	sigIndices := []uint32{0}
+	inputSigners := []*crypto.PrivateKeySECP256K1R{testKey.(*crypto.PrivateKeySECP256K1R)}
+	existingTxID := ids.GenerateTestID()
+
+	tests := map[string]struct {
+		caminoGenesisConf genesis.Camino
+		utxos             []*avax.UTXO
+		generateIns       func([]*avax.UTXO) []*avax.TransferableInput
+		signers           [][]*crypto.PrivateKeySECP256K1R
+		outs              []*avax.TransferableOutput
+		depositOfferID    func(caminoEnvironment) ids.ID
+		expectedErr       error
+	}{
+		"Wrong lockModeBondDeposit flag": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: false,
+				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+			},
+			utxos:          []*avax.UTXO{},
+			generateIns:    noInputs,
+			outs:           []*avax.TransferableOutput{},
+			depositOfferID: noOffers,
+			expectedErr:    errWrongLockMode,
+		},
+		"Stakeable ins": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestStakeableIn(avaxAssetID, defaultCaminoBalance, uint64(defaultMinStakingDuration), sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: locked.ErrWrongInType,
+		},
+		"Stakeable outs": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestStakeableOut(avaxAssetID, defaultCaminoBalance, uint64(defaultMinStakingDuration), outputOwners),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: locked.ErrWrongOutType,
+		},
+		"Inputs and utxos length mismatch": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Inputs and credentials length mismatch": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Not existing deposit offer ID": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				return ids.GenerateTestID()
+			},
+			expectedErr: database.ErrNotFound,
+		},
+		"Deposit is not active yet": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					{
+						UnlockHalfPeriodDuration: 30,
+						InterestRateNominator:    0,
+						Start:                    uint64(time.Now().Add(+60 * time.Hour).Unix()),
+						End:                      uint64(time.Now().Add(+60 * time.Hour).Unix()),
+						MinAmount:                1,
+						MinDuration:              60,
+						MaxDuration:              60,
+					},
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errDepositOfferNotActiveYet,
+		},
+		"Deposit offer has expired": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					{
+						UnlockHalfPeriodDuration: 30,
+						InterestRateNominator:    0,
+						Start:                    uint64(time.Now().Add(-60 * time.Hour).Unix()),
+						End:                      uint64(time.Now().Add(-60 * time.Hour).Unix()),
+						MinAmount:                1,
+						MinDuration:              60,
+						MaxDuration:              60,
+					},
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errDepositOfferInactive,
+		},
+		"Deposit's duration is too small": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					{
+						UnlockHalfPeriodDuration: 30,
+						InterestRateNominator:    0,
+						Start:                    uint64(time.Now().Add(-60 * time.Hour).Unix()),
+						End:                      uint64(time.Now().Add(+60 * time.Hour).Unix()),
+						MinAmount:                1,
+						MinDuration:              100,
+						MaxDuration:              60,
+					},
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errDepositDurationToSmall,
+		},
+		"Deposit's duration is too big": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					{
+						UnlockHalfPeriodDuration: 30,
+						InterestRateNominator:    0,
+						Start:                    uint64(time.Now().Add(-60 * time.Hour).Unix()),
+						End:                      uint64(time.Now().Add(+60 * time.Hour).Unix()),
+						MinAmount:                1,
+						MinDuration:              60,
+						MaxDuration:              30,
+					},
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errDepositDurationToBig,
+		},
+		"Deposit's amount is too small": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					{
+						UnlockHalfPeriodDuration: 30,
+						InterestRateNominator:    0,
+						Start:                    uint64(time.Now().Add(-60 * time.Hour).Unix()),
+						End:                      uint64(time.Now().Add(+60 * time.Hour).Unix()),
+						MinAmount:                defaultCaminoValidatorWeight * 2,
+						MinDuration:              60,
+						MaxDuration:              60,
+					},
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errDepositToSmall,
+		},
+		"No fee burning": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, existingTxID),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, existingTxID),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Deposit already deposited amount": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultCaminoBalance, outputOwners, existingTxID, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, existingTxID),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Deposit amount of not owned utxos": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, dummyOutputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Not enough balance to deposit": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Supply overflow": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					{
+						UnlockHalfPeriodDuration: 30,
+						InterestRateNominator:    1000 * units.MegaAvax,
+						Start:                    uint64(time.Now().Add(-60 * time.Hour).Unix()),
+						End:                      uint64(time.Now().Add(+60 * time.Hour).Unix()),
+						MinAmount:                1,
+						MinDuration:              60,
+						MaxDuration:              60,
+					},
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: errSupplyOverflow,
+		},
+		"Happy path deposit unlocked": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: nil,
+		},
+		"Happy path deposit unlocked, fee change to new address": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance+10, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, 10, dummyOutputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: nil,
+		},
+		"Happy path deposit bonded": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, existingTxID),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, locked.ThisTxID, existingTxID),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: nil,
+		},
+		"Happy path deposit bonded and unlocked": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee+defaultCaminoValidatorWeight/2, outputOwners, ids.Empty, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultCaminoValidatorWeight/2, outputOwners, ids.Empty, existingTxID),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight/2, outputOwners, locked.ThisTxID, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight/2, outputOwners, locked.ThisTxID, existingTxID),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: nil,
+		},
+		"Happy path, deposited amount transferred to another owner": {
+			caminoGenesisConf: genesis.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				DepositOffers: []genesis.DepositOffer{
+					testDepositOffer,
+				},
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoBalance-defaultCaminoValidatorWeight-defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, dummyOutputOwners, locked.ThisTxID, ids.Empty),
+			},
+			depositOfferID: func(env caminoEnvironment) ids.ID {
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				return genesisOffers[0].ID
+			},
+			expectedErr: nil,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoGenesisConf)
+			env.ctx.Lock.Lock()
+			defer func() {
+				if err := shutdownCaminoEnvironment(env); err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			env.config.BanffTime = env.state.GetTimestamp()
+			env.state.SetTimestamp(time.Now())
+
+			for _, utxo := range tt.utxos {
+				env.state.AddUTXO(utxo)
+			}
+
+			err := env.state.Commit()
+			require.NoError(t, err)
+			ins := tt.generateIns(tt.utxos)
+
+			avax.SortTransferableInputsWithSigners(ins, tt.signers)
+			avax.SortTransferableOutputs(tt.outs, txs.Codec)
+
+			utx := &txs.DepositTx{
+				BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    env.ctx.NetworkID,
+					BlockchainID: env.ctx.ChainID,
+					Ins:          ins,
+					Outs:         tt.outs,
+				}},
+				DepositOfferID: tt.depositOfferID(*env),
+				Duration:       60,
+				RewardsOwner: &secp256k1fx.OutputOwners{
+					Locktime:  0,
+					Threshold: 1,
+					Addrs:     []ids.ShortID{ids.ShortEmpty},
+				},
+			}
+
+			tx, err := txs.NewSigned(utx, txs.Codec, tt.signers)
+			require.NoError(t, err)
+
+			onAcceptState, err := state.NewDiff(lastAcceptedID, env)
+			require.NoError(t, err)
+
+			executor := CaminoStandardTxExecutor{
+				StandardTxExecutor{
+					Backend: &env.backend,
+					State:   onAcceptState,
+					Tx:      tx,
+				},
+			}
+
+			err = tx.Unsigned.Visit(&executor)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
+	testUndepositAmount := uint64(10000)
+	testKey, err := testKeyfactory.NewPrivateKey()
+	require.NoError(t, err)
+	dummyKey, err := testKeyfactory.NewPrivateKey()
+	require.NoError(t, err)
+
+	outputOwners := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{testKey.PublicKey().Address()},
+	}
+	dummyOutputOwners := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{dummyKey.PublicKey().Address()},
+	}
+	sigIndices := []uint32{0}
+	inputSigners := []*crypto.PrivateKeySECP256K1R{testKey.(*crypto.PrivateKeySECP256K1R)}
+	existingTxID := ids.GenerateTestID()
+	depositTxID := ids.GenerateTestID()
+	depositTxID2 := ids.GenerateTestID()
+	depositStartTime := time.Now()
+
+	depositExpiredTime := depositStartTime.Add(100 * time.Second)
+	depositEndedTime := depositStartTime.Add(80 * time.Second)
+	depositNotEndedTime := depositStartTime.Add(50 * time.Second)
+	genesisDepositOffer := genesis.DepositOffer{
+		UnlockHalfPeriodDuration: 30,
+		InterestRateNominator:    0,
+		Start:                    uint64(time.Now().Add(-60 * time.Hour).Unix()),
+		End:                      uint64(time.Now().Add(+60 * time.Hour).Unix()),
+		MinAmount:                1,
+		MinDuration:              60,
+		MaxDuration:              100,
+	}
+	caminoGenesisConf := genesis.Camino{
+		VerifyNodeSignature: true,
+		LockModeBondDeposit: true,
+		DepositOffers: []genesis.DepositOffer{
+			genesisDepositOffer,
+		},
+	}
+	depositOffer := &deposits.Offer{
+		UnlockHalfPeriodDuration: 30,
+		InterestRateNominator:    0,
+		Start:                    uint64(time.Now().Add(-60 * time.Hour).Unix()),
+		End:                      uint64(time.Now().Add(+60 * time.Hour).Unix()),
+		MinAmount:                1,
+		MinDuration:              60,
+		MaxDuration:              100,
+	}
+	deposit := &deposits.Deposit{
+		Duration: 60,
+		Amount:   defaultCaminoValidatorWeight,
+		Start:    uint64(depositStartTime.Unix()),
+	}
+
+	tests := map[string]struct {
+		utxos       []*avax.UTXO
+		generateIns func([]*avax.UTXO) []*avax.TransferableInput
+		signers     [][]*crypto.PrivateKeySECP256K1R
+		outs        []*avax.TransferableOutput
+		preExecute  func(env caminoEnvironment)
+		expectedErr error
+	}{
+		"Stakeable ins": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestStakeableIn(avaxAssetID, defaultCaminoValidatorWeight, uint64(defaultMinStakingDuration), sigIndices),
+				}
+			},
+			signers:     [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs:        []*avax.TransferableOutput{},
+			preExecute:  func(env caminoEnvironment) {},
+			expectedErr: locked.ErrWrongInType,
+		},
+		"Stakeable outs": {
+			utxos:       []*avax.UTXO{},
+			generateIns: noInputs,
+			outs: []*avax.TransferableOutput{
+				generateTestStakeableOut(avaxAssetID, defaultCaminoValidatorWeight, uint64(defaultMinStakingDuration), outputOwners),
+			},
+			preExecute:  func(env caminoEnvironment) {},
+			expectedErr: locked.ErrWrongOutType,
+		},
+		"Inputs and utxos length mismatch": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+					generateTestIn(avaxAssetID, 10, ids.Empty, ids.Empty, sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners, inputSigners, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositExpiredTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock bonded UTXOs": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, existingTxID),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute:  func(env caminoEnvironment) {},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock deposited UTXOs but with unlocked ins": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				in := generateTestInFromUTXO(utxos[0], sigIndices)
+				innerIn := &secp256k1fx.TransferInput{
+					Amt:   in.In.Amount(),
+					Input: secp256k1fx.Input{SigIndices: sigIndices},
+				}
+				in.In = innerIn
+				return []*avax.TransferableInput{in, generateTestInFromUTXO(utxos[1], sigIndices)}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute:  func(env caminoEnvironment) {},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock deposited UTXOs but with bonded ins": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				in := generateTestInFromUTXO(utxos[0], sigIndices)
+				out := utxos[0].Out.(*locked.Out)
+				innerIn := &locked.In{
+					IDs: locked.IDs{BondTxID: existingTxID},
+					TransferableIn: &secp256k1fx.TransferInput{
+						Amt:   out.Amount(),
+						Input: secp256k1fx.Input{SigIndices: sigIndices},
+					},
+				}
+				in.In = innerIn
+				return []*avax.TransferableInput{in, generateTestInFromUTXO(utxos[1], sigIndices)}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute:  func(env caminoEnvironment) {},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock some amount, before deposit's half period": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, 1, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-1, outputOwners, depositTxID, ids.Empty),
+			},
+			preExecute:  func(env caminoEnvironment) {},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock some amount, deposit expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-1, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, 1, outputOwners, depositTxID, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositExpiredTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock some amount of not owned utxos, deposit not ended": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, dummyOutputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, testUndepositAmount, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-testUndepositAmount, outputOwners, depositTxID, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositNotEndedTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock some amount, utxos and input amount mismatch, deposit ended but not expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				in := generateTestInFromUTXO(utxos[0], sigIndices)
+				out := utxos[0].Out.(*locked.Out)
+				innerIn := &locked.In{
+					IDs: utxos[0].Out.(*locked.Out).IDs,
+					TransferableIn: &secp256k1fx.TransferInput{
+						Amt:   out.Amount() + 1,
+						Input: secp256k1fx.Input{SigIndices: sigIndices},
+					},
+				}
+				in.In = innerIn
+				return []*avax.TransferableInput{in}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, testUndepositAmount, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-testUndepositAmount, outputOwners, depositTxID, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositEndedTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock some amount, deposit not ended": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: func() []*avax.TransferableOutput {
+				unlockableAmount := deposit.UnlockableAmount(depositOffer, uint64(depositNotEndedTime.Unix()))
+				return []*avax.TransferableOutput{
+					generateTestOut(avaxAssetID, unlockableAmount+1, outputOwners, ids.Empty, ids.Empty),
+					generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-unlockableAmount-1, outputOwners, depositTxID, ids.Empty),
+				}
+			}(),
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositNotEndedTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock some amount, deposit ended but not expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: func() []*avax.TransferableOutput {
+				unlockableAmount := deposit.UnlockableAmount(depositOffer, uint64(depositEndedTime.Unix()))
+				return []*avax.TransferableOutput{
+					generateTestOut(avaxAssetID, unlockableAmount+1, outputOwners, ids.Empty, ids.Empty),
+					generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-unlockableAmount-1, outputOwners, depositTxID, ids.Empty),
+				}
+			}(),
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositEndedTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"One deposit, two utxos with diff owners, consumed 1.5 utxo < unlockable ,produced as owner1": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, testUndepositAmount, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultCaminoValidatorWeight, dummyOutputOwners, depositTxID2, ids.Empty),
+				generateTestUTXO(ids.ID{3}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+					generateTestInFromUTXO(utxos[2], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, {}, inputSigners},
+			outs: func() []*avax.TransferableOutput {
+				unlockableAmount := deposit.UnlockableAmount(depositOffer, uint64(depositNotEndedTime.Unix()))
+				return []*avax.TransferableOutput{
+					generateTestOut(avaxAssetID, unlockableAmount, outputOwners, ids.Empty, ids.Empty),
+					generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-(unlockableAmount-testUndepositAmount), dummyOutputOwners, depositTxID2, ids.Empty),
+				}
+			}(),
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositNotEndedTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock all amount of not owned utxos, deposit expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, dummyOutputOwners, depositTxID, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositStartTime.Add(120 * time.Second))
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock all amount, utxos and input amount mismatch, deposit expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				in := generateTestInFromUTXO(utxos[0], sigIndices)
+				out := utxos[0].Out.(*locked.Out)
+				innerIn := &locked.In{
+					IDs: utxos[0].Out.(*locked.Out).IDs,
+					TransferableIn: &secp256k1fx.TransferInput{
+						Amt:   out.Amount() + 1,
+						Input: secp256k1fx.Input{SigIndices: sigIndices},
+					},
+				}
+				in.In = innerIn
+				return []*avax.TransferableInput{in}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositStartTime.Add(120 * time.Second))
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock all amount but also consume bonded utxo, deposit expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{1}, avaxAssetID, 10, outputOwners, ids.Empty, existingTxID),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, 10, outputOwners, ids.Empty, existingTxID),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositStartTime.Add(120 * time.Second))
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock deposit, one expired-not-owned and one active deposit": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, dummyOutputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID2, ids.Empty),
+				generateTestUTXO(ids.ID{3}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+					generateTestInFromUTXO(utxos[2], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, {}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, testUndepositAmount, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-testUndepositAmount, outputOwners, depositTxID2, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositExpiredTime)
+				// Add a second deposit to state
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				deposit := &deposits.Deposit{
+					DepositOfferID: genesisOffers[0].ID,
+					Duration:       100,
+					Amount:         defaultCaminoValidatorWeight,
+					Start:          uint64(depositStartTime.Unix()),
+				}
+				env.state.UpdateDeposit(depositTxID2, deposit)
+				err = env.state.Commit()
+				require.NoError(t, err)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Unlock deposit, one expired and one active-not-owned deposit": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultCaminoValidatorWeight, dummyOutputOwners, depositTxID2, ids.Empty),
+				generateTestUTXO(ids.ID{3}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+					generateTestInFromUTXO(utxos[2], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, {}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, testUndepositAmount, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-testUndepositAmount, outputOwners, depositTxID2, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositExpiredTime)
+				// Add a second deposit to state
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				deposit := &deposits.Deposit{
+					DepositOfferID: genesisOffers[0].ID,
+					Duration:       100,
+					Amount:         defaultCaminoValidatorWeight,
+					Start:          uint64(depositStartTime.Unix()),
+				}
+				env.state.UpdateDeposit(depositTxID2, deposit)
+				err = env.state.Commit()
+				require.NoError(t, err)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Producing more than consumed": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, testUndepositAmount, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, testUndepositAmount+1, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositNotEndedTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"No fee burning inputs are unlocked": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositExpiredTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"No fee burning inputs are deposited": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-testUndepositAmount, outputOwners, depositTxID, ids.Empty),
+				generateTestOut(avaxAssetID, testUndepositAmount, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositEndedTime)
+			},
+			expectedErr: errFlowCheckFailed,
+		},
+		"Happy path burn only fees": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{inputSigners, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute:  func(env caminoEnvironment) {},
+			expectedErr: nil,
+		},
+		"Happy path unlock all amount with creds provided, deposit expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositExpiredTime)
+			},
+			expectedErr: nil,
+		},
+		"Happy path unlock all amount, deposit expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositStartTime.Add(120 * time.Second))
+			},
+			expectedErr: nil,
+		},
+		"Happy path unlock some amount, deposit ended but not expired": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: func() []*avax.TransferableOutput {
+				unlockableAmount := deposit.UnlockableAmount(depositOffer, uint64(depositEndedTime.Unix()))
+				return []*avax.TransferableOutput{
+					generateTestOut(avaxAssetID, unlockableAmount, outputOwners, ids.Empty, ids.Empty),
+					generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-unlockableAmount, outputOwners, depositTxID, ids.Empty),
+				}
+			}(),
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositEndedTime)
+			},
+			expectedErr: nil,
+		},
+		"Happy path unlock some amount, deposit not ended": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: func() []*avax.TransferableOutput {
+				unlockableAmount := deposit.UnlockableAmount(depositOffer, uint64(depositNotEndedTime.Unix()))
+				return []*avax.TransferableOutput{
+					generateTestOut(avaxAssetID, unlockableAmount, outputOwners, ids.Empty, ids.Empty),
+					generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-unlockableAmount, outputOwners, depositTxID, ids.Empty),
+				}
+			}(),
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositNotEndedTime)
+			},
+			expectedErr: nil,
+		},
+		"Happy path unlock some amount, deposit not ended, fee change to new address": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultTxFee+10, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, inputSigners},
+			outs: func() []*avax.TransferableOutput {
+				unlockableAmount := deposit.UnlockableAmount(depositOffer, uint64(depositNotEndedTime.Unix()))
+				return []*avax.TransferableOutput{
+					generateTestOut(avaxAssetID, 10, dummyOutputOwners, ids.Empty, ids.Empty),
+					generateTestOut(avaxAssetID, unlockableAmount, outputOwners, ids.Empty, ids.Empty),
+					generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-unlockableAmount, outputOwners, depositTxID, ids.Empty),
+				}
+			}(),
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositNotEndedTime)
+			},
+			expectedErr: nil,
+		},
+		"Happy path unlock deposit, one expired deposit and one active": {
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID, ids.Empty),
+				generateTestUTXO(ids.ID{2}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, depositTxID2, ids.Empty),
+				generateTestUTXO(ids.ID{3}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateIns: func(utxos []*avax.UTXO) []*avax.TransferableInput {
+				return []*avax.TransferableInput{
+					generateTestInFromUTXO(utxos[0], sigIndices),
+					generateTestInFromUTXO(utxos[1], sigIndices),
+					generateTestInFromUTXO(utxos[2], sigIndices),
+				}
+			},
+			signers: [][]*crypto.PrivateKeySECP256K1R{{}, {}, inputSigners},
+			outs: []*avax.TransferableOutput{
+				generateTestOut(avaxAssetID, testUndepositAmount, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(avaxAssetID, defaultCaminoValidatorWeight-testUndepositAmount, outputOwners, depositTxID2, ids.Empty),
+			},
+			preExecute: func(env caminoEnvironment) {
+				env.state.SetTimestamp(depositExpiredTime)
+				// Add a second deposit to state
+				genesisOffers, err := env.state.GetAllDepositOffers()
+				require.NoError(t, err)
+				deposit := &deposits.Deposit{
+					DepositOfferID: genesisOffers[0].ID,
+					Duration:       100,
+					Amount:         defaultCaminoValidatorWeight,
+					Start:          uint64(depositStartTime.Unix()),
+				}
+				env.state.UpdateDeposit(depositTxID2, deposit)
+				err = env.state.Commit()
+				require.NoError(t, err)
+			},
+			expectedErr: nil,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+			env.ctx.Lock.Lock()
+			defer func() {
+				if err = shutdownCaminoEnvironment(env); err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			env.config.BanffTime = env.state.GetTimestamp()
+			env.state.SetTimestamp(depositStartTime)
+
+			genesisOffers, err := env.state.GetAllDepositOffers()
+			require.NoError(t, err)
+
+			// Add a deposit to state
+			deposit.DepositOfferID = genesisOffers[0].ID
+			env.state.UpdateDeposit(depositTxID, deposit)
+			err = env.state.Commit()
+			require.NoError(t, err)
+
+			var ins []*avax.TransferableInput
+			for _, utxo := range tt.utxos {
+				env.state.AddUTXO(utxo)
+			}
+			ins = append(ins, tt.generateIns(tt.utxos)...)
+
+			err = env.state.Commit()
+			require.NoError(t, err)
+
+			avax.SortTransferableInputsWithSigners(ins, tt.signers)
+			avax.SortTransferableOutputs(tt.outs, txs.Codec)
+
+			utx := &txs.UnlockDepositTx{
+				BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    env.ctx.NetworkID,
+					BlockchainID: env.ctx.ChainID,
+					Ins:          ins,
+					Outs:         tt.outs,
+				}},
+			}
+
+			tx, err := txs.NewSigned(utx, txs.Codec, tt.signers)
+			require.NoError(t, err)
+
+			tt.preExecute(*env)
+
+			onAcceptState, err := state.NewDiff(lastAcceptedID, env)
+			require.NoError(t, err)
+
+			executor := CaminoStandardTxExecutor{
+				StandardTxExecutor{
+					Backend: &env.backend,
+					State:   onAcceptState,
+					Tx:      tx,
+				},
+			}
+
+			err = tx.Unsigned.Visit(&executor)
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}

--- a/vms/platformvm/txs/executor/camino_visitor.go
+++ b/vms/platformvm/txs/executor/camino_visitor.go
@@ -8,14 +8,28 @@ import "github.com/ava-labs/avalanchego/vms/platformvm/txs"
 // Camino Visitor implementations
 // Standard
 func (e *StandardTxExecutor) AddAddressStateTx(*txs.AddAddressStateTx) error { return errWrongTxType }
+func (e *StandardTxExecutor) DepositTx(*txs.DepositTx) error                 { return errWrongTxType }
+func (e *StandardTxExecutor) UnlockDepositTx(*txs.UnlockDepositTx) error     { return errWrongTxType }
 
 // Proposal
 func (*ProposalTxExecutor) AddAddressStateTx(*txs.AddAddressStateTx) error { return errWrongTxType }
+func (*ProposalTxExecutor) DepositTx(*txs.DepositTx) error                 { return errWrongTxType }
+func (*ProposalTxExecutor) UnlockDepositTx(*txs.UnlockDepositTx) error     { return errWrongTxType }
 
 // Atomic
 func (*AtomicTxExecutor) AddAddressStateTx(*txs.AddAddressStateTx) error { return errWrongTxType }
+func (*AtomicTxExecutor) DepositTx(*txs.DepositTx) error                 { return errWrongTxType }
+func (*AtomicTxExecutor) UnlockDepositTx(*txs.UnlockDepositTx) error     { return errWrongTxType }
 
 // MemPool
 func (v *MempoolTxVerifier) AddAddressStateTx(tx *txs.AddAddressStateTx) error {
+	return v.standardTx(tx)
+}
+
+func (v *MempoolTxVerifier) DepositTx(tx *txs.DepositTx) error {
+	return v.standardTx(tx)
+}
+
+func (v *MempoolTxVerifier) UnlockDepositTx(tx *txs.UnlockDepositTx) error {
 	return v.standardTx(tx)
 }

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -13,8 +13,28 @@ func (i *issuer) AddAddressStateTx(*txs.AddAddressStateTx) error {
 	return nil
 }
 
+func (i *issuer) DepositTx(*txs.DepositTx) error {
+	i.m.addStakerTx(i.tx)
+	return nil
+}
+
+func (i *issuer) UnlockDepositTx(*txs.UnlockDepositTx) error {
+	i.m.addStakerTx(i.tx)
+	return nil
+}
+
 // Remover
 func (r *remover) AddAddressStateTx(*txs.AddAddressStateTx) error {
+	r.m.removeStakerTx(r.tx)
+	return nil
+}
+
+func (r *remover) DepositTx(*txs.DepositTx) error {
+	r.m.removeStakerTx(r.tx)
+	return nil
+}
+
+func (r *remover) UnlockDepositTx(*txs.UnlockDepositTx) error {
 	r.m.removeStakerTx(r.tx)
 	return nil
 }

--- a/vms/platformvm/txs/visitor.go
+++ b/vms/platformvm/txs/visitor.go
@@ -28,5 +28,6 @@ type Visitor interface {
 	TransformSubnetTx(*TransformSubnetTx) error
 	AddPermissionlessValidatorTx(*AddPermissionlessValidatorTx) error
 	AddPermissionlessDelegatorTx(*AddPermissionlessDelegatorTx) error
-	AddAddressStateTx(*AddAddressStateTx) error
+
+	CaminoVisitor
 }

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -27,6 +27,7 @@ import (
 var (
 	errInvalidTargetLockState    = errors.New("invalid target lock state")
 	errLockingLockedUTXO         = errors.New("utxo consumed for locking are already locked")
+	errUnlockingUnlockedUTXO     = errors.New("utxo consumed for unlocking are already unlocked")
 	errNotEnoughBalance          = errors.New("not enough balance to lock")
 	errWrongInType               = errors.New("wrong input type")
 	errWrongOutType              = errors.New("wrong output type")
@@ -39,6 +40,9 @@ var (
 	errAssetIDMismatch           = errors.New("input assetID is different from utxo asset id")
 	errLockIDsMismatch           = errors.New("input lock ids is different from utxo lock ids")
 	errLockAmountNotZero         = errors.New("lockAmount must be 0 for StateUnlocked")
+	errFailToGetDeposit          = errors.New("couldn't get deposit")
+	errUnlockedMoreThanAvailable = errors.New("unlocked more deposited tokens, than was available for unlock")
+	errNotConsumedDeposit        = errors.New("didn't consume whole deposit amount, but deposit is expired and can't be partially unlocked")
 )
 
 // Creates UTXOs from [outs] and adds them to the UTXO set.
@@ -72,6 +76,96 @@ func ProduceLocked(
 	}
 
 	return nil
+}
+
+type CaminoSpender interface {
+	// Lock the provided amount while deducting the provided fee.
+	// Arguments:
+	// - [keys] are the owners of the funds
+	// - [totalAmountToLock] is the amount of funds that are trying to be locked with [appliedLockState]
+	// - [totalAmountToBurn] is the amount of AVAX that should be burned
+	// Returns:
+	// - [inputs] the inputs that should be consumed to fund the outputs
+	// - [outputs] the outputs that should be returned to the UTXO set
+	// - [signers] the proof of ownership of the funds being moved
+	Lock(
+		keys []*crypto.PrivateKeySECP256K1R,
+		totalAmountToLock uint64,
+		totalAmountToBurn uint64,
+		appliedLockState locked.State,
+		changeAddr ids.ShortID,
+	) (
+		[]*avax.TransferableInput, // inputs
+		[]*avax.TransferableOutput, // outputs
+		[][]*crypto.PrivateKeySECP256K1R, // signers
+		error,
+	)
+
+	// Undeposit all deposited by [depositTxIDs] utxos owned by [keys]. Returned results are unsorted.
+	// Arguments:
+	// - [state] chainstate which will be used to fetch utxos and deposit data
+	// - [keys] are the owners of the deposits
+	// - [depositTxIDs] ids of deposit transactions
+	// Returns:
+	// - [inputs] unsorted inputs that should be consumed to fund the outputs
+	// - [outputs] unsorted outputs that should be returned to the UTXO set
+	// - [signers] the unsorted proof of ownership of the funds being moved
+	UnlockDeposit(
+		state state.Chain,
+		keys []*crypto.PrivateKeySECP256K1R,
+		depositTxIDs []ids.ID,
+	) (
+		[]*avax.TransferableInput, // inputs
+		[]*avax.TransferableOutput, // outputs
+		[][]*crypto.PrivateKeySECP256K1R, // signers
+		error,
+	)
+
+	Unlocker
+}
+
+type CaminoVerifier interface {
+	// Verify that lock [tx] is semantically valid.
+	// Arguments:
+	// - [ins] and [outs] are the inputs and outputs of [tx].
+	// - [creds] are the credentials of [tx], which allow [ins] to be spent.
+	// - [ins] must have at least [burnedAmount] more than the [outs].
+	// - [assetID] is id of allowed asset, ins/outs with other assets will return error
+	// - [appliedLockState] are lockState that was applied to [ins] lockState to produce [outs]
+	//
+	// Precondition: [tx] has already been syntactically verified.
+	VerifyLock(
+		tx txs.UnsignedTx,
+		utxoDB state.UTXOGetter,
+		ins []*avax.TransferableInput,
+		outs []*avax.TransferableOutput,
+		creds []verify.Verifiable,
+		burnedAmount uint64,
+		assetID ids.ID,
+		appliedLockState locked.State,
+	) error
+
+	// Verify that deposit unlock [tx] is semantically valid.
+	// Arguments:
+	// - [ins] and [outs] are the inputs and outputs of [tx].
+	// - [creds] are the credentials of [tx], which allow [ins] to be spent.
+	// - [burnedAmount] if any of deposits are still active, then unlocked inputs must have at least [burnedAmount] more than unlocked outs.
+	// - [assetID] is id of allowed asset, ins/outs with other assets will return error
+	// Returns:
+	// - map[depositTxID]unlockedAmount
+	//
+	// Precondition: [tx] has already been syntactically verified.
+	VerifyUnlockDeposit(
+		state state.Chain,
+		tx txs.UnsignedTx,
+		ins []*avax.TransferableInput,
+		outs []*avax.TransferableOutput,
+		creds []verify.Verifiable,
+		burnedAmount uint64,
+		assetID ids.ID,
+	) (map[ids.ID]uint64, error)
+
+	Unlocker
 }
 
 type Unlocker interface {
@@ -480,6 +574,140 @@ func (h *handler) unlockUTXOs(
 	return ins, outs, nil
 }
 
+func (h *handler) UnlockDeposit(
+	state state.Chain,
+	keys []*crypto.PrivateKeySECP256K1R,
+	depositTxIDs []ids.ID,
+) (
+	[]*avax.TransferableInput, // inputs
+	[]*avax.TransferableOutput, // outputs
+	[][]*crypto.PrivateKeySECP256K1R, // signers
+	error,
+) {
+	addrs := ids.NewShortSet(len(keys)) // The addresses controlled by [keys]
+	for _, key := range keys {
+		addrs.Add(key.PublicKey().Address())
+	}
+
+	depositTxSet := ids.NewSet(len(depositTxIDs))
+	for _, depositTxID := range depositTxIDs {
+		depositTxSet.Add(depositTxID)
+	}
+
+	// Minimum time this transaction will be issued at
+	currentTimestamp := uint64(h.clk.Time().Unix())
+
+	unlockableAmounts, err := getDepositUnlockableAmounts(
+		state, depositTxSet, currentTimestamp,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	utxos, err := state.LockedUTXOs(depositTxSet, addrs, locked.StateDeposited)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	kc := secp256k1fx.NewKeychain(keys...) // Keychain consumes UTXOs and creates new ones
+
+	ins := []*avax.TransferableInput{}
+	outs := []*avax.TransferableOutput{}
+	signers := [][]*crypto.PrivateKeySECP256K1R{}
+
+	for _, utxo := range utxos {
+		out, ok := utxo.Out.(*locked.Out)
+		if !ok {
+			// This output isn't locked
+			continue
+		} else if !out.IDs.Match(locked.StateDeposited, depositTxSet) {
+			// This output isn't deposited by one of give deposit tx ids
+			continue
+		}
+
+		unlockableAmount := unlockableAmounts[out.DepositTxID]
+		if unlockableAmount == 0 {
+			// This deposit tx doesn't have tokens available for unlock
+			continue
+		}
+
+		innerOut, ok := out.TransferableOut.(*secp256k1fx.TransferOutput)
+		if !ok {
+			// We only know how to clone secp256k1 outputs for now
+			continue
+		}
+
+		inIntf, inSigners, err := kc.Spend(innerOut, currentTimestamp)
+		if err != nil {
+			// We couldn't spend the output, so move on to the next one
+			continue
+		}
+
+		in, ok := inIntf.(avax.TransferableIn)
+		if !ok { // should never happen
+			h.ctx.Log.Warn("wrong input type",
+				zap.String("expectedType", "avax.TransferableIn"),
+				zap.String("actualType", fmt.Sprintf("%T", inIntf)),
+			)
+			continue
+		}
+
+		// Add the input to the consumed inputs
+		ins = append(ins, &avax.TransferableInput{
+			UTXOID: utxo.UTXOID,
+			Asset:  avax.Asset{ID: h.ctx.AVAXAssetID},
+			In: &locked.In{
+				IDs:            out.IDs,
+				TransferableIn: in,
+			},
+		})
+
+		signers = append(signers, inSigners)
+
+		remainingValue := in.Amount()
+		amountToUnlock := math.Min(unlockableAmount, remainingValue)
+		remainingValue -= amountToUnlock
+		unlockableAmounts[out.DepositTxID] -= amountToUnlock
+
+		if newLockIDs := out.Unlock(locked.StateDeposited); newLockIDs.IsLocked() {
+			outs = append(outs, &avax.TransferableOutput{
+				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
+				Out: &locked.Out{
+					IDs: newLockIDs,
+					TransferableOut: &secp256k1fx.TransferOutput{
+						Amt:          amountToUnlock,
+						OutputOwners: innerOut.OutputOwners,
+					},
+				},
+			})
+		} else {
+			outs = append(outs, &avax.TransferableOutput{
+				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
+				Out: &secp256k1fx.TransferOutput{
+					Amt:          amountToUnlock,
+					OutputOwners: innerOut.OutputOwners,
+				},
+			})
+		}
+
+		// This input had extra value, so some of it must be returned
+		if remainingValue > 0 {
+			outs = append(outs, &avax.TransferableOutput{
+				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
+				Out: &locked.Out{
+					IDs: out.IDs,
+					TransferableOut: &secp256k1fx.TransferOutput{
+						Amt:          remainingValue,
+						OutputOwners: innerOut.OutputOwners,
+					},
+				},
+			})
+		}
+	}
+
+	return ins, outs, signers, nil
+}
+
 func (h *handler) VerifyLock(
 	tx txs.UnsignedTx,
 	utxoDB state.UTXOGetter,
@@ -577,14 +805,14 @@ func (h *handler) VerifyLockUTXOs(
 			return errWrongUTXOOutType
 		}
 
-		lockIDs := locked.IDs{}
+		lockIDs := &locked.IDsEmpty
 		if lockedOut, ok := out.(*locked.Out); ok {
 			// utxo is already locked with appliedLockState, so it can't be locked it again
 			if lockedOut.IsLockedWith(appliedLockState) {
 				return errLockingLockedUTXO
 			}
 			out = lockedOut.TransferableOut
-			lockIDs = lockedOut.IDs
+			lockIDs = &lockedOut.IDs
 		}
 
 		in := input.In
@@ -594,7 +822,7 @@ func (h *handler) VerifyLockUTXOs(
 
 		if lockedIn, ok := in.(*locked.In); ok {
 			// This input is locked, but its LockIDs is wrong
-			if lockIDs != lockedIn.IDs {
+			if *lockIDs != lockedIn.IDs {
 				return errLockIDsMismatch
 			}
 			in = lockedIn.TransferableIn
@@ -643,9 +871,9 @@ func (h *handler) VerifyLockUTXOs(
 			return errWrongOutType
 		}
 
-		lockIDs := locked.IDs{}
+		lockIDs := &locked.IDsEmpty
 		if lockedOut, ok := out.(*locked.Out); ok {
-			lockIDs = lockedOut.IDs
+			lockIDs = &lockedOut.IDs
 			out = lockedOut.TransferableOut
 		}
 
@@ -705,6 +933,319 @@ func (h *handler) VerifyLockUTXOs(
 	}
 
 	return nil
+}
+
+func (h *handler) VerifyUnlockDeposit(
+	state state.Chain,
+	tx txs.UnsignedTx,
+	ins []*avax.TransferableInput,
+	outs []*avax.TransferableOutput,
+	creds []verify.Verifiable,
+	burnedAmount uint64,
+	assetID ids.ID,
+) (map[ids.ID]uint64, error) {
+	utxos := make([]*avax.UTXO, len(ins))
+	for index, input := range ins {
+		utxo, err := state.GetUTXO(input.InputID())
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to read consumed UTXO %s due to: %w",
+				&input.UTXOID,
+				err,
+			)
+		}
+		utxos[index] = utxo
+	}
+
+	return h.VerifyUnlockDepositedUTXOs(state, tx, utxos, ins, outs, creds, burnedAmount, assetID)
+}
+
+func (h *handler) VerifyUnlockDepositedUTXOs(
+	chainState state.Chain,
+	tx txs.UnsignedTx,
+	utxos []*avax.UTXO,
+	ins []*avax.TransferableInput,
+	outs []*avax.TransferableOutput,
+	creds []verify.Verifiable,
+	burnedAmount uint64,
+	assetID ids.ID,
+) (map[ids.ID]uint64, error) {
+	if len(ins) != len(creds) {
+		return nil, fmt.Errorf(
+			"there are %d inputs and %d credentials: %w",
+			len(ins),
+			len(creds),
+			errInputsCredentialsMismatch,
+		)
+	}
+
+	if len(ins) != len(utxos) {
+		return nil, fmt.Errorf(
+			"there are %d inputs and %d utxos: %w",
+			len(ins),
+			len(utxos),
+			errInputsUTXOSMismatch,
+		)
+	}
+
+	for _, cred := range creds {
+		if err := cred.Verify(); err != nil {
+			return nil, errWrongCredentials
+		}
+	}
+
+	type depositUnlock struct {
+		consumed uint64 // consumed amount
+		produced uint64 // produced amount
+	}
+	depositUnlocks := make(map[ids.ID]*depositUnlock) // depositTxID -> *depositUnlock
+
+	consumedUnlocked := uint64(0)
+	consumed := make(map[ids.ID]map[ids.ID]uint64) // ownerID -> bondTxID -> amount
+
+	currentTimestamp := uint64(chainState.GetTimestamp().Unix())
+
+	// iterate over ins, get utxos, fill the maps (consumed, depositUnlock)
+	for index, input := range ins {
+		utxo := utxos[index] // The UTXO consumed by [input]
+
+		if utxoAssetID := utxo.AssetID(); utxoAssetID != assetID {
+			return nil, fmt.Errorf(
+				"utxo %d has asset ID %s but expect %s: %w",
+				index,
+				utxoAssetID,
+				assetID,
+				errAssetIDMismatch,
+			)
+		}
+
+		if inputAssetID := input.AssetID(); inputAssetID != assetID {
+			return nil, fmt.Errorf(
+				"input %d has asset ID %s but expect %s: %w",
+				index,
+				inputAssetID,
+				assetID,
+				errAssetIDMismatch,
+			)
+		}
+
+		out := utxo.Out
+		lockIDs := &locked.IDsEmpty
+		isDeposited := false
+		if lockedOut, ok := out.(*locked.Out); ok {
+			// utxo isn't deposited, so it can't be unlocked
+			// bonded-not-deposited utxos are not allowed
+			if isDeposited = lockedOut.DepositTxID != ids.Empty; !isDeposited {
+				return nil, errUnlockingUnlockedUTXO
+			}
+			out = lockedOut.TransferableOut
+			lockIDs = &lockedOut.IDs
+		}
+
+		in := input.In
+		if lockedIn, ok := in.(*locked.In); ok {
+			// This input is locked, but its LockIDs is wrong
+			if *lockIDs != lockedIn.IDs {
+				return nil, errLockIDsMismatch
+			}
+			in = lockedIn.TransferableIn
+		} else if lockIDs.IsLocked() {
+			// The UTXO says it's locked, but this input, which consumes it,
+			// is not locked - this is invalid.
+			return nil, errLockedFundsNotMarkedAsLocked
+		}
+
+		consumedAmount := in.Amount()
+
+		if isDeposited {
+			// verifying that input amount equal to utxo amount
+			if innerOut, ok := out.(*secp256k1fx.TransferOutput); !ok || innerOut.Amt != consumedAmount {
+				return nil, fmt.Errorf("failed to verify transfer: utxo inner out isn't *secp256k1fx.TransferOutput or inner out amount != input.Am")
+			}
+
+			// calculating consumed amounts
+			ownerID, err := GetOwnerID(out)
+			if err != nil {
+				return nil, err
+			}
+
+			consumedOwnerAmounts, ok := consumed[ownerID]
+			if !ok {
+				consumedOwnerAmounts = make(map[ids.ID]uint64)
+				consumed[ownerID] = consumedOwnerAmounts
+			}
+
+			newAmount, err := math.Add64(consumedOwnerAmounts[lockIDs.BondTxID], consumedAmount)
+			if err != nil {
+				return nil, err
+			}
+			consumedOwnerAmounts[lockIDs.BondTxID] = newAmount
+
+			depUnlock, ok := depositUnlocks[lockIDs.DepositTxID]
+			if !ok {
+				depUnlock = &depositUnlock{}
+				depositUnlocks[lockIDs.DepositTxID] = depUnlock
+			}
+
+			newAmount, err = math.Add64(depUnlock.consumed, consumedAmount)
+			if err != nil {
+				return nil, err
+			}
+			depUnlock.consumed = newAmount
+		} else {
+			if err := h.fx.VerifyTransfer(tx, in, creds[index], out); err != nil {
+				return nil, fmt.Errorf("failed to verify transfer: %w", err)
+			}
+
+			// calculating consumed amounts
+			newAmount, err := math.Add64(consumedUnlocked, consumedAmount)
+			if err != nil {
+				return nil, err
+			}
+			consumedUnlocked = newAmount
+		}
+	}
+
+	// iterating over outs, checking produced amounts with consumed map
+	// filling deposit produced amounts
+
+	for _, output := range outs {
+		out := output.Out
+		lockIDs := &locked.IDsEmpty
+		lockedOut, isLocked := out.(*locked.Out)
+		if isLocked {
+			lockIDs = &lockedOut.IDs
+			out = lockedOut.TransferableOut
+		}
+
+		producedAmount := out.Amount()
+
+		ownerID, err := GetOwnerID(out)
+		if err != nil {
+			return nil, err
+		}
+
+		consumedOwnerAmounts, ok := consumed[ownerID]
+		if !ok {
+			consumedOwnerAmounts = make(map[ids.ID]uint64)
+			consumed[ownerID] = consumedOwnerAmounts
+		}
+
+		consumedAmount := consumedOwnerAmounts[lockIDs.BondTxID]
+		amountToRemoveFromConsumed := producedAmount
+
+		if consumedAmount < amountToRemoveFromConsumed {
+			if isLocked {
+				return nil, fmt.Errorf(
+					"address %s produces %d and consumes %d for lockIDs %+v with unlock '%s': %w",
+					ownerID,
+					producedAmount,
+					consumedAmount,
+					lockIDs,
+					locked.StateDeposited,
+					errWrongProducedAmount,
+				)
+			}
+
+			amountToRemoveFromConsumed = consumedAmount
+			amountToRemoveFromConsumedUnlocked := producedAmount - consumedAmount
+			if consumedUnlocked < amountToRemoveFromConsumedUnlocked {
+				return nil, fmt.Errorf(
+					"address %s produces %d and consumes %d unlocked and %d locked with %+v: %w",
+					ownerID,
+					producedAmount,
+					consumedUnlocked,
+					consumedAmount,
+					lockIDs,
+					errWrongProducedAmount,
+				)
+			}
+			consumedUnlocked -= amountToRemoveFromConsumedUnlocked
+		}
+		consumedOwnerAmounts[lockIDs.BondTxID] -= amountToRemoveFromConsumed
+
+		if depUnlock, ok := depositUnlocks[lockIDs.DepositTxID]; ok {
+			newAmount, err := math.Add64(depUnlock.produced, producedAmount)
+			if err != nil {
+				return nil, err
+			}
+			depUnlock.produced = newAmount
+		}
+	}
+
+	// this map will list how much tokens was unlocked from each deposit
+	unlockedAmount := make(map[ids.ID]uint64) // depositTxID -> amount
+	// if there are no deposits - its not system tx and we need to burn fee
+	needToBurn := len(depositUnlocks) == 0
+
+	for depositTxID, depUnlock := range depositUnlocks {
+		if depUnlock.consumed < depUnlock.produced {
+			return nil, errWrongProducedAmount
+		}
+
+		unlockedDepositAmount := depUnlock.consumed - depUnlock.produced
+
+		deposit, err := chainState.GetDeposit(depositTxID)
+		if err != nil {
+			return nil, err
+		}
+
+		depositOffer, err := chainState.GetDepositOffer(deposit.DepositOfferID)
+		if err != nil {
+			return nil, err
+		}
+
+		unlockableAmount := deposit.UnlockableAmount(
+
+			depositOffer,
+			currentTimestamp,
+		)
+
+		// if we don't need keys, than deposit is expired and must be fully unlocked
+		// that means that tx must fully consume remaining deposited tokens and
+		// produce them as unlocked
+		isExpired := deposit.IsExpired(depositOffer, currentTimestamp)
+
+		// if there are active deposit - its not system tx and we need to burn fee
+		if !isExpired {
+			needToBurn = true
+		}
+
+		if isExpired &&
+			(unlockedDepositAmount != unlockableAmount ||
+				depUnlock.consumed != unlockableAmount) {
+			return nil, fmt.Errorf("expired deposit (%s) unlockable amount (%d) isn't equal to consumed (%d) and produced (%d) amount: %w",
+				depositTxID,
+				unlockableAmount,
+				depUnlock.consumed,
+				depUnlock.produced,
+				errNotConsumedDeposit)
+		}
+
+		// checking that we unlocked no more, than was available for unlock
+		if unlockedDepositAmount > unlockableAmount {
+			return nil, fmt.Errorf("unlockedDepositAmount %d > %d unlockableAmount: %w",
+				unlockedDepositAmount,
+				unlockableAmount,
+				errUnlockedMoreThanAvailable)
+		}
+
+		unlockedAmount[depositTxID] = unlockedDepositAmount
+	}
+
+	// checking that we burned required amount
+
+	if needToBurn && consumedUnlocked < burnedAmount {
+		return nil, fmt.Errorf(
+			"asset %s burned %d unlocked, but needed to burn %d: %w",
+			assetID,
+			consumedUnlocked,
+			burnedAmount,
+			errNotBurnedEnough,
+		)
+	}
+
+	return unlockedAmount, nil
 }
 
 type innerSortUTXOs struct {
@@ -784,4 +1325,31 @@ func (sort *innerSortUTXOs) Swap(i, j int) { u := sort.utxos; u[j], u[i] = u[i],
 
 func sortUTXOs(utxos []*avax.UTXO, allowedAssetID ids.ID, lockState locked.State) {
 	sort.Sort(&innerSortUTXOs{utxos: utxos, allowedAssetID: allowedAssetID, lockState: lockState})
+}
+
+func getDepositUnlockableAmounts(
+	chainState state.Chain,
+	depositTxIDs ids.Set,
+	currentTimestamp uint64,
+) (map[ids.ID]uint64, error) {
+	unlockableAmounts := make(map[ids.ID]uint64, len(depositTxIDs))
+
+	for depositTxID := range depositTxIDs {
+		deposit, err := chainState.GetDeposit(depositTxID)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", errFailToGetDeposit, err)
+		}
+
+		depositOffer, err := chainState.GetDepositOffer(deposit.DepositOfferID)
+		if err != nil {
+			return nil, err
+		}
+
+		unlockableAmounts[depositTxID] = deposit.UnlockableAmount(
+			depositOffer,
+			currentTimestamp,
+		)
+	}
+
+	return unlockableAmounts, nil
 }

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -4,13 +4,13 @@
 package utxo
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"testing"
+	"time"
 
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/require"
-
-	db_manager "github.com/ava-labs/avalanchego/database/manager"
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
@@ -20,11 +20,16 @@ import (
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	db_manager "github.com/ava-labs/avalanchego/database/manager"
 )
 
 func TestUnlockUTXOs(t *testing.T) {
@@ -656,4 +661,682 @@ func TestVerifyLockUTXOs(t *testing.T) {
 			require.ErrorIs(t, err, test.expectedErr)
 		})
 	}
+}
+
+func TestGetDepositUnlockableAmounts(t *testing.T) {
+	config := defaultConfig()
+	ctx := snow.DefaultContextTest()
+	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
+	baseDB := versiondb.New(baseDBManager.Current().Database)
+	rewardsCalc := reward.NewCalculator(config.RewardConfig)
+	addr0 := ids.GenerateTestShortID()
+	addresses := ids.ShortSet{}
+	addresses.Add(addr0)
+
+	depositTxSet := ids.Set{}
+	testID := ids.GenerateTestID()
+	depositTxSet.Add(testID)
+
+	defaultState(config, ctx, baseDB, rewardsCalc)
+	tx := &dummyUnsignedTx{txs.BaseTx{}}
+	tx.Initialize([]byte{0})
+	outputOwners, _ := generateOwnersAndSig(tx)
+	now := time.Now()
+	depositedAmount := uint64(1000)
+	type args struct {
+		state        func(*gomock.Controller) state.Chain
+		depositTxIDs ids.Set
+		currentTime  uint64
+		addresses    ids.ShortSet
+	}
+	tests := map[string]struct {
+		args args
+		want map[ids.ID]uint64
+		err  error
+	}{
+		"Success retrieval of all unlockable amounts": {
+			args: args{
+				state: func(ctrl *gomock.Controller) state.Chain {
+					nowMinus20m := uint64(now.Add(-20 * time.Minute).Unix())
+					s := state.NewMockChain(ctrl)
+					deposit1 := deposit.Deposit{
+						DepositOfferID: testID,
+						Start:          nowMinus20m,
+						Duration:       uint32((10 * time.Minute).Seconds()),
+						Amount:         depositedAmount,
+					}
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((10 * time.Minute).Seconds()),
+						Start:                    nowMinus20m,
+					}, nil)
+					return s
+				},
+				depositTxIDs: depositTxSet,
+				currentTime:  uint64(now.Unix()),
+				addresses:    outputOwners.AddressesSet(),
+			},
+			want: map[ids.ID]uint64{testID: depositedAmount},
+		},
+		"Success retrieval of 50% unlockable amounts": {
+			args: args{
+				state: func(ctrl *gomock.Controller) state.Chain {
+					nowMinus20m := uint64(now.Add(-20 * time.Minute).Unix())
+					s := state.NewMockChain(ctrl)
+					deposit1 := deposit.Deposit{
+						DepositOfferID: testID,
+						Start:          nowMinus20m,
+						Duration:       uint32((20 * time.Minute).Seconds()),
+						Amount:         depositedAmount,
+					}
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((10 * time.Minute).Seconds()),
+						Start:                    nowMinus20m,
+					}, nil)
+					return s
+				},
+				depositTxIDs: depositTxSet,
+				currentTime:  uint64(now.Unix()),
+				addresses:    outputOwners.AddressesSet(),
+			},
+			want: map[ids.ID]uint64{testID: depositedAmount / 2},
+		},
+		"Failed to get deposit offer": {
+			args: args{
+				state: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetDeposit(testID).Return(&deposit.Deposit{DepositOfferID: testID}, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(nil, database.ErrNotFound)
+					return s
+				},
+				depositTxIDs: depositTxSet,
+				currentTime:  uint64(now.Unix()),
+			},
+			err: database.ErrNotFound,
+		},
+		"Failed to get deposit": {
+			args: args{
+				state: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetDeposit(gomock.Any()).Return(nil, errors.New("some_error"))
+					return s
+				},
+				depositTxIDs: depositTxSet,
+				currentTime:  uint64(now.Unix()),
+			},
+			err: fmt.Errorf("%w: %s", errFailToGetDeposit, "some_error"),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			got, err := getDepositUnlockableAmounts(test.args.state(ctrl), test.args.depositTxIDs, test.args.currentTime)
+
+			if test.err != nil {
+				require.ErrorContains(t, err, test.err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestUnlockDeposit(t *testing.T) {
+	fx := &secp256k1fx.Fx{}
+	err := fx.InitializeVM(&secp256k1fx.TestVM{})
+	require.NoError(t, err)
+	err = fx.Bootstrapped()
+	require.NoError(t, err)
+	ctx := snow.DefaultContextTest()
+
+	testID := ids.GenerateTestID()
+
+	testHandler := &handler{
+		ctx: ctx,
+		clk: &mockable.Clock{},
+		utxosReader: avax.NewUTXOState(
+			memdb.New(),
+			txs.Codec,
+		),
+		fx: fx,
+	}
+	txID := ids.GenerateTestID()
+	depositedAmount := uint64(2000)
+	outputOwners := defaultOwners()
+	depositedUTXOs := []*avax.UTXO{
+		generateTestUTXO(txID, ctx.AVAXAssetID, depositedAmount, outputOwners, testID, ids.Empty),
+	}
+
+	nowMinus10m := uint64(time.Now().Add(-10 * time.Minute).Unix())
+
+	type args struct {
+		state        func(*gomock.Controller) state.Chain
+		keys         []*crypto.PrivateKeySECP256K1R
+		depositTxIDs []ids.ID
+	}
+	sigIndices := []uint32{0}
+
+	tests := map[string]struct {
+		args  args
+		want  []*avax.TransferableInput
+		want1 []*avax.TransferableOutput
+		want2 [][]*crypto.PrivateKeySECP256K1R
+		err   error
+	}{
+		"Error retrieving unlockable amounts": {
+			args: args{
+				state: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					deposit1 := deposit.Deposit{
+						DepositOfferID: testID,
+						Start:          nowMinus10m,
+						Duration:       uint32((10 * time.Minute).Seconds()),
+					}
+					depositTxSet := ids.NewSet(1)
+					depositTxSet.Add(testID)
+
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((5 * time.Minute).Seconds()),
+						Start:                    nowMinus10m,
+					}, nil)
+					s.EXPECT().LockedUTXOs(depositTxSet, gomock.Any(), locked.StateDeposited).Return(nil, fmt.Errorf("%w: %s", state.ErrMissingParentState, testID))
+					return s
+				},
+				keys:         preFundedKeys,
+				depositTxIDs: []ids.ID{testID},
+			},
+			err: fmt.Errorf("%w: %s", state.ErrMissingParentState, testID),
+		},
+		"Successful unlock of 50% deposited funds": {
+			args: args{
+				state: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					deposit1 := deposit.Deposit{
+						DepositOfferID: testID,
+						Start:          nowMinus10m,
+						Duration:       uint32((10 * time.Minute).Seconds()),
+						Amount:         depositedAmount,
+					}
+					depositTxSet := ids.NewSet(1)
+					depositTxSet.Add(testID)
+
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((5 * time.Minute).Seconds()),
+						Start:                    nowMinus10m,
+					}, nil)
+					s.EXPECT().LockedUTXOs(depositTxSet, gomock.Any(), locked.StateDeposited).Return(depositedUTXOs, nil)
+					return s
+				},
+				keys:         []*crypto.PrivateKeySECP256K1R{preFundedKeys[0]},
+				depositTxIDs: []ids.ID{testID},
+			},
+			want: []*avax.TransferableInput{
+				generateTestInFromUTXO(depositedUTXOs[0], sigIndices),
+			},
+			want1: []*avax.TransferableOutput{
+				generateTestOut(ctx.AVAXAssetID, depositedAmount/2, outputOwners, ids.Empty, ids.Empty),
+				generateTestOut(ctx.AVAXAssetID, depositedAmount/2, outputOwners, testID, ids.Empty),
+			},
+			want2: [][]*crypto.PrivateKeySECP256K1R{{preFundedKeys[0]}},
+		},
+		"Successful full unlock": {
+			args: args{
+				state: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					deposit1 := deposit.Deposit{
+						DepositOfferID: testID,
+						Start:          nowMinus10m,
+						Duration:       uint32((9 * time.Minute).Seconds()),
+						Amount:         depositedAmount,
+					}
+					depositTxSet := ids.NewSet(1)
+					depositTxSet.Add(testID)
+
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((time.Minute).Seconds()),
+						Start:                    nowMinus10m,
+					}, nil)
+					s.EXPECT().LockedUTXOs(depositTxSet, gomock.Any(), locked.StateDeposited).Return(depositedUTXOs, nil)
+					return s
+				},
+				keys:         []*crypto.PrivateKeySECP256K1R{preFundedKeys[0]},
+				depositTxIDs: []ids.ID{testID},
+			},
+			want: []*avax.TransferableInput{
+				generateTestInFromUTXO(depositedUTXOs[0], sigIndices),
+			},
+			want1: []*avax.TransferableOutput{
+				generateTestOut(ctx.AVAXAssetID, depositedAmount, outputOwners, ids.Empty, ids.Empty),
+			},
+			want2: [][]*crypto.PrivateKeySECP256K1R{{preFundedKeys[0]}},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			got, got1, got2, err := testHandler.UnlockDeposit(tt.args.state(ctrl), tt.args.keys, tt.args.depositTxIDs)
+			if tt.err != nil {
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got, "Error asserting TransferableInputs: got = %v, want %v", got, tt.want)
+			require.Equal(t, tt.want1, got1, "Error asserting TransferableOutputs: got = %v, want %v", got1, tt.want2)
+			require.Equal(t, tt.want2, got2, "UnlockDeposit() got = %v, want %v", got2, tt.want2)
+		})
+	}
+}
+
+func TestVerifyUnlockDepositedUTXOs(t *testing.T) {
+	fx := &secp256k1fx.Fx{}
+	err := fx.InitializeVM(&secp256k1fx.TestVM{})
+	require.NoError(t, err)
+	err = fx.Bootstrapped()
+	require.NoError(t, err)
+	ctx := snow.DefaultContextTest()
+
+	testHandler := &handler{
+		ctx: ctx,
+		clk: &mockable.Clock{},
+		utxosReader: avax.NewUTXOState(
+			memdb.New(),
+			txs.Codec,
+		),
+		fx: fx,
+	}
+	tx := &dummyUnsignedTx{txs.BaseTx{}}
+	tx.Initialize([]byte{0})
+	var nilCreds *secp256k1fx.Credential
+	outputOwners, cred1 := generateOwnersAndSig(tx)
+	testID := ids.GenerateTestID()
+	sigIndices := []uint32{0}
+	utxoAmount := uint64(5)
+	depositedAmount := uint64(1000)
+	output := avax.TransferableOutput{
+		Asset: avax.Asset{ID: ctx.AVAXAssetID},
+		Out: &secp256k1fx.TransferOutput{
+			Amt:          depositedAmount,
+			OutputOwners: outputOwners,
+		},
+	}
+
+	now := time.Now()
+	nowMinus10m := uint64(now.Add(-10 * time.Minute).Unix())
+	type args struct {
+		chainState   func(ctrl *gomock.Controller) state.Chain
+		tx           txs.UnsignedTx
+		utxos        []*avax.UTXO
+		ins          []*avax.TransferableInput
+		outs         []*avax.TransferableOutput
+		creds        []verify.Verifiable
+		burnedAmount uint64
+		assetID      ids.ID
+	}
+	tests := map[string]struct {
+		args args
+		want map[ids.ID]uint64
+		err  error
+	}{
+		"Inputs Credentials Mismatch": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					return s
+				},
+				utxos: []*avax.UTXO{{}},
+				ins:   []*avax.TransferableInput{{}},
+				creds: []verify.Verifiable{cred1, cred1},
+			},
+			err: errInputsCredentialsMismatch,
+		},
+		"Number of inputs/utxos mismatch": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					return state.NewMockChain(ctrl)
+				},
+				utxos: []*avax.UTXO{{}, {}},
+				ins:   []*avax.TransferableInput{{}},
+				creds: []verify.Verifiable{cred1},
+			},
+			err: fmt.Errorf(
+				"there are %d inputs and %d utxos: %w", 1, 2, errInputsUTXOSMismatch),
+		},
+		"Wrong credentials": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					return state.NewMockChain(ctrl)
+				},
+				utxos: []*avax.UTXO{{}},
+				ins:   []*avax.TransferableInput{{}},
+				creds: []verify.Verifiable{nilCreds},
+			},
+			err: errWrongCredentials,
+		},
+		"Lock Ids mismatch / no lockedOut output": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					return s
+				},
+				utxos: []*avax.UTXO{generateTestUTXO(testID, ctx.AVAXAssetID, utxoAmount, outputOwners, ids.Empty, ids.Empty)},
+				ins:   []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, utxoAmount, testID, ids.Empty, sigIndices)},
+				creds: []verify.Verifiable{cred1},
+			},
+			err: errLockIDsMismatch,
+		},
+		"Utxo/AssetID mismatch": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					return s
+				},
+				tx: nil,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, 5, outputOwners, ids.Empty, testID),
+				},
+				ins:          []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, 100, ids.Empty, ids.Empty, sigIndices)},
+				outs:         nil,
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      testID,
+			},
+			err: fmt.Errorf("utxo %d has asset ID %s but expect %s: %w", 0, ctx.AVAXAssetID, testID, errAssetIDMismatch),
+		},
+		"Input/AssetID mismatch": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					return s
+				},
+				tx: nil,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, testID, 5, outputOwners, ids.Empty, testID),
+				},
+				ins:          []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, 100, ids.Empty, ids.Empty, sigIndices)},
+				outs:         nil,
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      testID,
+			},
+			err: errAssetIDMismatch,
+		},
+		"UTXO already unlocked": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					return s
+				},
+				tx: nil,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, 5, outputOwners, ids.Empty, testID),
+				},
+				ins:          []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, 100, ids.Empty, ids.Empty, sigIndices)},
+				outs:         nil,
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      ctx.AVAXAssetID,
+			},
+			err: errUnlockingUnlockedUTXO,
+		},
+		"Locked funds not marked as locked": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					return s
+				},
+				tx: nil,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, 5, outputOwners, testID, ids.Empty),
+				},
+				ins:          []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, 100, ids.Empty, ids.Empty, sigIndices)},
+				outs:         nil,
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      ctx.AVAXAssetID,
+			},
+			err: errLockedFundsNotMarkedAsLocked,
+		},
+		"Consumed/input amount mismatch": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					return s
+				},
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, utxoAmount, outputOwners, testID, ids.Empty),
+				},
+				ins:          []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, utxoAmount+1, testID, ids.Empty, sigIndices)},
+				outs:         nil,
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      ctx.AVAXAssetID,
+			},
+			err: fmt.Errorf("failed to verify transfer: utxo inner out isn't *secp256k1fx.TransferOutput or inner out amount != input.Am"),
+		},
+		"Insufficient amount to cover burn fees": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					deposit1 := deposit.Deposit{
+						DepositOfferID:      testID,
+						UnlockedAmount:      0,
+						ClaimedRewardAmount: 5000,
+						Start:               nowMinus10m,
+						Duration:            uint32((9 * time.Minute).Seconds()),
+						Amount:              1000,
+					}
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((time.Minute).Seconds()),
+						Start:                    nowMinus10m,
+					}, nil)
+					return s
+				},
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, utxoAmount, outputOwners, testID, ids.Empty),
+				},
+				ins:          []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, utxoAmount, testID, ids.Empty, sigIndices)},
+				outs:         nil,
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: utxoAmount + 1,
+				assetID:      ctx.AVAXAssetID,
+			},
+			err: errNotBurnedEnough,
+		},
+		"Unlocked more deposited tokens than available": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					deposit1 := deposit.Deposit{
+						DepositOfferID:      testID,
+						UnlockedAmount:      0,
+						ClaimedRewardAmount: 5000,
+						Start:               nowMinus10m,
+						Duration:            uint32((9 * time.Minute).Seconds()),
+						Amount:              depositedAmount,
+					}
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((time.Minute).Seconds()),
+						Start:                    nowMinus10m,
+					}, nil)
+					return s
+				},
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, depositedAmount+1, outputOwners, testID, ids.Empty),
+				},
+				ins:          []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, depositedAmount+1, testID, ids.Empty, sigIndices)},
+				outs:         []*avax.TransferableOutput{&output},
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      ctx.AVAXAssetID,
+			},
+			err: fmt.Errorf("unlockedDepositAmount %d > %d unlockableAmount: %w", depositedAmount+1, depositedAmount, errUnlockedMoreThanAvailable),
+		},
+		"Produces outputs exceed inputs": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					return s
+				},
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, depositedAmount, outputOwners, testID, ids.Empty),
+				},
+				ins: []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, depositedAmount, testID, ids.Empty, sigIndices)},
+				outs: []*avax.TransferableOutput{{
+					Asset: avax.Asset{ID: ctx.AVAXAssetID},
+					Out: &secp256k1fx.TransferOutput{
+						Amt:          depositedAmount + 1,
+						OutputOwners: outputOwners,
+					},
+				}},
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      ctx.AVAXAssetID,
+			},
+			err: errWrongProducedAmount,
+		},
+		"Consumed/produced amount mismatch": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					return s
+				},
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, utxoAmount, outputOwners, testID, ids.Empty),
+				},
+				ins: []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, utxoAmount, testID, ids.Empty, sigIndices)},
+				outs: []*avax.TransferableOutput{{
+					Asset: avax.Asset{ID: ctx.AVAXAssetID},
+					Out: &locked.Out{
+						IDs: locked.IDs{},
+						TransferableOut: &secp256k1fx.TransferOutput{
+							Amt:          utxoAmount + 1,
+							OutputOwners: outputOwners,
+						},
+					},
+				}},
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      ctx.AVAXAssetID,
+			},
+			err: errWrongProducedAmount,
+		},
+		"Partially consumed deposited amount": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					deposit1 := deposit.Deposit{
+						DepositOfferID:      testID,
+						UnlockedAmount:      0,
+						ClaimedRewardAmount: 5000,
+						Start:               nowMinus10m,
+						Duration:            uint32((8 * time.Minute).Seconds()),
+						Amount:              1000,
+					}
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((time.Minute).Seconds()),
+						Start:                    uint64(now.Add(-11 * time.Minute).Unix()),
+					}, nil)
+					return s
+				},
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, utxoAmount, outputOwners, testID, ids.Empty),
+				},
+				ins: []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, utxoAmount, testID, ids.Empty, sigIndices)},
+				outs: []*avax.TransferableOutput{{
+					Asset: avax.Asset{ID: ctx.AVAXAssetID},
+					Out: &locked.Out{
+						IDs: locked.IDs{},
+						TransferableOut: &secp256k1fx.TransferOutput{
+							Amt:          utxoAmount,
+							OutputOwners: outputOwners,
+						},
+					},
+				}},
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      ctx.AVAXAssetID,
+			},
+			err: errNotConsumedDeposit,
+		},
+		"Success": {
+			args: args{
+				chainState: func(ctrl *gomock.Controller) state.Chain {
+					s := state.NewMockChain(ctrl)
+					s.EXPECT().GetTimestamp().Return(now)
+					deposit1 := deposit.Deposit{
+						DepositOfferID: testID,
+						Start:          nowMinus10m,
+						Duration:       uint32((9 * time.Minute).Seconds()),
+						Amount:         1000,
+					}
+					s.EXPECT().GetDeposit(testID).Return(&deposit1, nil)
+					s.EXPECT().GetDepositOffer(testID).Return(&deposit.Offer{
+						UnlockHalfPeriodDuration: uint32((time.Minute).Seconds()),
+						Start:                    nowMinus10m,
+					}, nil)
+					return s
+				},
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generateTestUTXO(ids.ID{9, 9}, ctx.AVAXAssetID, utxoAmount, outputOwners, testID, ids.Empty),
+				},
+				ins:          []*avax.TransferableInput{generateTestIn(ctx.AVAXAssetID, utxoAmount, testID, ids.Empty, sigIndices)},
+				outs:         nil,
+				creds:        []verify.Verifiable{cred1},
+				burnedAmount: 0,
+				assetID:      ctx.AVAXAssetID,
+			},
+			want: map[ids.ID]uint64{testID: utxoAmount},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			got, err := testHandler.VerifyUnlockDepositedUTXOs(tt.args.chainState(ctrl), tt.args.tx, tt.args.utxos, tt.args.ins, tt.args.outs, tt.args.creds, tt.args.burnedAmount, tt.args.assetID)
+
+			if tt.err != nil {
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func defaultOwners() secp256k1fx.OutputOwners {
+	outputOwners := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{preFundedKeys[0].Address()},
+	}
+	return outputOwners
 }

--- a/vms/platformvm/utxo/handler.go
+++ b/vms/platformvm/utxo/handler.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
-	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -109,29 +108,7 @@ type Spender interface {
 		error,
 	)
 
-	// Lock the provided amount while deducting the provided fee.
-	// Arguments:
-	// - [keys] are the owners of the funds
-	// - [totalAmountToLock] is the amount of funds that are trying to be locked with [appliedLockState]
-	// - [totalAmountToBurn] is the amount of AVAX that should be burned
-	// Returns:
-	// - [inputs] the inputs that should be consumed to fund the outputs
-	// - [outputs] the outputs that should be returned to the UTXO set
-	// - [signers] the proof of ownership of the funds being moved
-	Lock(
-		keys []*crypto.PrivateKeySECP256K1R,
-		totalAmountToLock uint64,
-		totalAmountToBurn uint64,
-		appliedLockState locked.State,
-		changeAddr ids.ShortID,
-	) (
-		[]*avax.TransferableInput, // inputs
-		[]*avax.TransferableOutput, // outputs
-		[][]*crypto.PrivateKeySECP256K1R, // signers
-		error,
-	)
-
-	Unlocker
+	CaminoSpender
 }
 
 type Verifier interface {
@@ -174,28 +151,7 @@ type Verifier interface {
 		unlockedProduced map[ids.ID]uint64,
 	) error
 
-	// Verify that [tx] is semantically valid.
-	// [ins] and [outs] are the inputs and outputs of [tx].
-	// [creds] are the credentials of [tx], which allow [ins] to be spent.
-	// The [ins] must have at least [burnedAmount] more than the [outs].
-	// [assetID] is id of allowed asset, ins/outs with other assets will return error
-	// [appliedLockState] are lockState that was applied to [ins] lockState to produce [outs]
-	//
-	// Precondition: [tx] has already been syntactically verified.
-	//
-	// Note: [unlockedProduced] is modified by this method.
-	VerifyLock(
-		tx txs.UnsignedTx,
-		utxoDB state.UTXOGetter,
-		ins []*avax.TransferableInput,
-		outs []*avax.TransferableOutput,
-		creds []verify.Verifiable,
-		burnedAmount uint64,
-		assetID ids.ID,
-		appliedLockState locked.State,
-	) error
-
-	Unlocker
+	CaminoVerifier
 }
 
 type Handler interface {

--- a/vms/platformvm/utxo/mock_verifier.go
+++ b/vms/platformvm/utxo/mock_verifier.go
@@ -99,3 +99,18 @@ func (mr *MockVerifierMockRecorder) VerifySpendUTXOs(arg0, arg1, arg2, arg3, arg
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySpendUTXOs", reflect.TypeOf((*MockVerifier)(nil).VerifySpendUTXOs), arg0, arg1, arg2, arg3, arg4, arg5)
 }
+
+// VerifyUnlockDeposit mocks base method.
+func (m *MockVerifier) VerifyUnlockDeposit(arg0 state.Chain, arg1 txs.UnsignedTx, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID) (map[ids.ID]uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyUnlockDeposit", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret0, _ := ret[0].(map[ids.ID]uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyUnlockDeposit indicates an expected call of VerifyUnlockDeposit.
+func (mr *MockVerifierMockRecorder) VerifyUnlockDeposit(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUnlockDeposit", reflect.TypeOf((*MockVerifier)(nil).VerifyUnlockDeposit), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+}

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -110,7 +110,7 @@ type VM struct {
 	// sliding window of blocks that were recently accepted
 	recentlyAccepted window.Window[ids.ID]
 
-	txBuilder         txbuilder.Builder
+	txBuilder         txbuilder.CaminoBuilder
 	txExecutorBackend *txexecutor.Backend
 	manager           blockexecutor.Manager
 }
@@ -178,7 +178,7 @@ func (vm *VM) Initialize(
 	vm.uptimeManager = uptime.NewManager(vm.state)
 	vm.UptimeLockedCalculator.SetCalculator(&vm.bootstrapped, &ctx.Lock, vm.uptimeManager)
 
-	vm.txBuilder = txbuilder.New(
+	vm.txBuilder = txbuilder.NewCamino(
 		vm.ctx,
 		&vm.Config,
 		&vm.clock,

--- a/wallet/chain/p/camino_visitor.go
+++ b/wallet/chain/p/camino_visitor.go
@@ -12,7 +12,31 @@ func (b *backendVisitor) AddAddressStateTx(tx *txs.AddAddressStateTx) error {
 	return b.baseTx(&tx.BaseTx)
 }
 
+func (b *backendVisitor) DepositTx(tx *txs.DepositTx) error {
+	return b.baseTx(&tx.BaseTx)
+}
+
+func (b *backendVisitor) UnlockDepositTx(tx *txs.UnlockDepositTx) error {
+	return b.baseTx(&tx.BaseTx)
+}
+
 func (s *signerVisitor) AddAddressStateTx(tx *txs.AddAddressStateTx) error {
+	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
+	if err != nil {
+		return err
+	}
+	return s.sign(s.tx, txSigners)
+}
+
+func (s *signerVisitor) DepositTx(tx *txs.DepositTx) error {
+	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
+	if err != nil {
+		return err
+	}
+	return s.sign(s.tx, txSigners)
+}
+
+func (s *signerVisitor) UnlockDepositTx(tx *txs.UnlockDepositTx) error {
 	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is second PR for deposit system. It adds:
- new utxos handler methods: UnlockDeposit and VerifyUnlockDeposit
- DepositTx which uses specified deposit offer to locks tokens with "deposited" state
- UnlockDepositTx which consumes deposited utxos and produce undeposited outs`
- corresponding txs builder and executor methods
- deposits state
- integrational tests for new txs, unit tests for new funcs/methods
### DepositTx
Tx body contains depositOfferID, which will be used to get offer rules for tx validation. This offer will also define calculations for amount of claimable rewards.
When deposit tx is executed, it increases current supply of tokens by potential reward amount. If new supply is greater than max supply, then tx will be rejected.
### UnlockDepositTx
Bonded-and-not-deposited inputs are not allowed - there is no sense in using them in this tx.
Deposited inputs could be without signatures, undeposited outs must have the same owners as in consumed utxo.
If consumed utxos are deposited by expired deposit, then this tx must consume all utxos of this deposit.
Total amount of undeposited tokens for each deposit must be no more, than unlockable amount for this deposit at current chaintime.
### Co-authors
- @charalarg  (txs integrational tests)
- @knikos (unit tests)