### PR TITLE
Genesis build

### DIFF
--- a/genesis/camino_config.go
+++ b/genesis/camino_config.go
@@ -72,6 +72,7 @@ type CaminoAllocation struct {
 	ETHAddr             ids.ShortID          `json:"ethAddr"`
 	AVAXAddr            ids.ShortID          `json:"avaxAddr"`
 	XAmount             uint64               `json:"xAmount"`
+	AddressState        uint64               `json:"addressState"`
 	PlatformAllocations []PlatformAllocation `json:"platformAllocations"`
 }
 
@@ -79,7 +80,8 @@ func (a CaminoAllocation) Unparse(networkID uint32) (UnparsedCaminoAllocation, e
 	ua := UnparsedCaminoAllocation{
 		XAmount:             a.XAmount,
 		ETHAddr:             "0x" + hex.EncodeToString(a.ETHAddr.Bytes()),
-		PlatformAllocations: a.PlatformAllocations,
+		AddressState:        a.AddressState,
+		PlatformAllocations: make([]UnparsedPlatformAllocation, len(a.PlatformAllocations)),
 	}
 	avaxAddr, err := address.Format(
 		"X",
@@ -88,11 +90,42 @@ func (a CaminoAllocation) Unparse(networkID uint32) (UnparsedCaminoAllocation, e
 	)
 	ua.AVAXAddr = avaxAddr
 
+	for i, pa := range a.PlatformAllocations {
+		upa, err := pa.Unparse()
+		if err != nil {
+			return ua, err
+		}
+		ua.PlatformAllocations[i] = upa
+	}
+
 	return ua, err
 }
 
+func (a CaminoAllocation) Less(other CaminoAllocation) bool {
+	return a.XAmount < other.XAmount ||
+		(a.XAmount == other.XAmount && a.AVAXAddr.Less(other.AVAXAddr))
+}
+
 type PlatformAllocation struct {
-	Amount         uint64     `json:"amount"`
-	NodeID         ids.NodeID `json:"nodeID"`
-	DepositOfferID ids.ID     `json:"depositOfferID"`
+	Amount            uint64     `json:"amount"`
+	NodeID            ids.NodeID `json:"nodeID"`
+	ValidatorDuration uint64     `json:"validatorDuration"`
+	DepositOfferID    ids.ID     `json:"depositOfferID"`
+}
+
+func (a PlatformAllocation) Unparse() (UnparsedPlatformAllocation, error) {
+	ua := UnparsedPlatformAllocation{
+		Amount:            a.Amount,
+		ValidatorDuration: a.ValidatorDuration,
+	}
+
+	if a.NodeID != ids.EmptyNodeID {
+		ua.NodeID = a.NodeID.String()
+	}
+
+	if a.DepositOfferID != ids.Empty {
+		ua.DepositOfferID = a.DepositOfferID.String()
+	}
+
+	return ua, nil
 }

--- a/genesis/camino_unparsed_config.go
+++ b/genesis/camino_unparsed_config.go
@@ -52,16 +52,18 @@ func (uc UnparsedCamino) Parse() (Camino, error) {
 }
 
 type UnparsedCaminoAllocation struct {
-	ETHAddr             string               `json:"ethAddr"`
-	AVAXAddr            string               `json:"avaxAddr"`
-	XAmount             uint64               `json:"xAmount"`
-	PlatformAllocations []PlatformAllocation `json:"platformAllocations"`
+	ETHAddr             string                       `json:"ethAddr"`
+	AVAXAddr            string                       `json:"avaxAddr"`
+	XAmount             uint64                       `json:"xAmount"`
+	AddressState        uint64                       `json:"addressState"`
+	PlatformAllocations []UnparsedPlatformAllocation `json:"platformAllocations"`
 }
 
 func (ua UnparsedCaminoAllocation) Parse() (CaminoAllocation, error) {
 	a := CaminoAllocation{
 		XAmount:             ua.XAmount,
-		PlatformAllocations: ua.PlatformAllocations,
+		AddressState:        ua.AddressState,
+		PlatformAllocations: make([]PlatformAllocation, len(ua.PlatformAllocations)),
 	}
 
 	if len(ua.ETHAddr) < 2 {
@@ -87,6 +89,51 @@ func (ua UnparsedCaminoAllocation) Parse() (CaminoAllocation, error) {
 		return a, err
 	}
 	a.AVAXAddr = avaxAddr
+
+	for i, upa := range ua.PlatformAllocations {
+		pa, err := upa.Parse()
+		if err != nil {
+			return a, err
+		}
+		a.PlatformAllocations[i] = pa
+	}
+
+	return a, nil
+}
+
+type UnparsedPlatformAllocation struct {
+	Amount            uint64 `json:"amount"`
+	NodeID            string `json:"nodeID"`
+	ValidatorDuration uint64 `json:"validatorDuration"`
+	DepositOfferID    string `json:"depositOfferID"`
+}
+
+func (ua UnparsedPlatformAllocation) Parse() (PlatformAllocation, error) {
+	a := PlatformAllocation{
+		Amount:            ua.Amount,
+		ValidatorDuration: ua.ValidatorDuration,
+	}
+
+	depositOfferID := ids.Empty
+	if ua.DepositOfferID != "" {
+		parsedDepositOfferID, err := ids.FromString(ua.DepositOfferID)
+		if err != nil {
+			return a, err
+		}
+		depositOfferID = parsedDepositOfferID
+	}
+
+	nodeID := ids.EmptyNodeID
+	if ua.NodeID != "" {
+		parsedNodeID, err := ids.NodeIDFromString(ua.NodeID)
+		if err != nil {
+			return a, err
+		}
+		nodeID = parsedNodeID
+	}
+
+	a.NodeID = nodeID
+	a.DepositOfferID = depositOfferID
 
 	return a, nil
 }

--- a/genesis/genesis_camino.json
+++ b/genesis/genesis_camino.json
@@ -6,14 +6,47 @@
     "initialAdmin": "X-camino1m4nr983lhd4p4nfsqk3a6a9mejugnn73f83vuy",
     "depositOffers": [
       {
-        "start": 1668073842,
+        "interestRateNominator": 80000,
+        "start": 0,
         "end": 1699609842,
         "minAmount": 1,
-        "minDuration": 90,
-        "maxDuration": 90,
-        "unlockPeriodDuration": 60,
-        "noRewardsPeriodDuration": 30,
+        "minDuration": 94608000,
+        "maxDuration": 94608000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": 0
+      },
+      {
         "interestRateNominator": 0,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 126144000,
+        "maxDuration": 126144000,
+        "unlockPeriodDuration": 63072000,
+        "noRewardsPeriodDuration": 31536000,
+        "flags": 0
+      },
+      {
+        "interestRateNominator": 90000,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 126144000,
+        "maxDuration": 126144000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": 0
+      },
+      {
+        "interestRateNominator": 100000,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 157680000,
+        "maxDuration": 157680000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
         "flags": 0
       }
     ],
@@ -26,18 +59,18 @@
           {
             "amount": 100000000000000,
             "nodeID": "NodeID-PGHYeLVkU6ZVQEu8CuRBk6pQ2NJNAuzZ4",
-            "depositOfferID": "2cntH7zB6LDu1s4VZ9HiNiLWW4uCXN4SWv9Dd1fFxdCTb8Yw2g"
+            "validatorDuration": 100000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
           },
           {
             "amount": 10000000000000000,
-            "depositOfferID": "2cntH7zB6LDu1s4VZ9HiNiLWW4uCXN4SWv9Dd1fFxdCTb8Yw2g"
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
           }
         ]
       }
     ]
   },
-  "startTime": 1647388800,
-  "initialStakeDuration": 31536000,
+  "startTime": 1670956381,
   "initialStakeDurationOffset": 5400,
   "cChainGenesis": "{\"config\":{\"chainId\":500,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
   "message": "Travel around the world!"

--- a/genesis/genesis_columbus.json
+++ b/genesis/genesis_columbus.json
@@ -6,14 +6,47 @@
     "initialAdmin": "X-columbus1m4nr983lhd4p4nfsqk3a6a9mejugnn73ju0gav",
     "depositOffers": [
       {
-        "start": 1668073842,
+        "interestRateNominator": 80000,
+        "start": 0,
         "end": 1699609842,
         "minAmount": 1,
-        "minDuration": 60,
-        "maxDuration": 60,
-        "unlockPeriodDuration": 60,
-        "noRewardsPeriodDuration": 0,
+        "minDuration": 94608000,
+        "maxDuration": 94608000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": 0
+      },
+      {
         "interestRateNominator": 0,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 126144000,
+        "maxDuration": 126144000,
+        "unlockPeriodDuration": 63072000,
+        "noRewardsPeriodDuration": 31536000,
+        "flags": 0
+      },
+      {
+        "interestRateNominator": 90000,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 126144000,
+        "maxDuration": 126144000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": 0
+      },
+      {
+        "interestRateNominator": 100000,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 157680000,
+        "maxDuration": 157680000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
         "flags": 0
       }
     ],
@@ -26,18 +59,18 @@
           {
             "amount": 100000000000000,
             "nodeID": "NodeID-EAm6xyzP8mGm6VMSEoeV3L6dUP1YYnjCr",
-            "depositOfferID": "2sA67xkBTMZjWatccPca4q4emptk1Qqns4eJXFtYPb4pK6EVqF"
+            "validatorDuration": 100000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
           },
           {
             "amount": 10000000000000000,
-            "depositOfferID": "2sA67xkBTMZjWatccPca4q4emptk1Qqns4eJXFtYPb4pK6EVqF"
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
           }
         ]
       }
     ]
   },
-  "startTime": 1647388800,
-  "initialStakeDuration": 31536000,
+  "startTime": 1670956381,
   "initialStakeDurationOffset": 5400,
   "cChainGenesis": "{\"config\":{\"chainId\":501,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
   "message": "Have a nice trip!"

--- a/genesis/genesis_kopernikus.json
+++ b/genesis/genesis_kopernikus.json
@@ -6,14 +6,47 @@
     "initialAdmin": "X-kopernikus1m4nr983lhd4p4nfsqk3a6a9mejugnn73cmp283",
     "depositOffers": [
       {
-        "start": 1668073842,
+        "interestRateNominator": 80000,
+        "start": 0,
         "end": 1699609842,
         "minAmount": 1,
-        "minDuration": 60,
-        "maxDuration": 60,
-        "unlockPeriodDuration": 60,
-        "noRewardsPeriodDuration": 0,
+        "minDuration": 94608000,
+        "maxDuration": 94608000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": 0
+      },
+      {
         "interestRateNominator": 0,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 126144000,
+        "maxDuration": 126144000,
+        "unlockPeriodDuration": 63072000,
+        "noRewardsPeriodDuration": 31536000,
+        "flags": 0
+      },
+      {
+        "interestRateNominator": 90000,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 126144000,
+        "maxDuration": 126144000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": 0
+      },
+      {
+        "interestRateNominator": 100000,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 157680000,
+        "maxDuration": 157680000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
         "flags": 0
       }
     ],
@@ -26,19 +59,19 @@
           {
             "amount": 2000000000000,
             "nodeID": "NodeID-EAm6xyzP8mGm6VMSEoeV3L6dUP1YYnjCr",
-            "depositOfferID": "2sA67xkBTMZjWatccPca4q4emptk1Qqns4eJXFtYPb4pK6EVqF"
+            "validatorDuration": 100000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
           },
           {
             "amount": 10000000000000000,
-            "depositOfferID": "2sA67xkBTMZjWatccPca4q4emptk1Qqns4eJXFtYPb4pK6EVqF"
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
           }
         ]
       }
     ]
   },
-  "startTime": 1647388800,
-  "initialStakeDuration": 31536000,
-  "initialStakeDurationOffset": 5400,
+  "startTime": 1670956381,
+  "initialStakeDurationOffset": 0,
   "cChainGenesis": "{\"config\":{\"chainId\":502},\"initialAdmin\":\"0x0000000000000000000000000000000000000000\", \"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
   "message": "Have a nice trip!"
 }

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -208,7 +208,7 @@ func TestGenesisFromFile(t *testing.T) {
 		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
-			expected:     "2a251a6382744c6aec83e7436c8a6df11a2832f0d3a880b1965a2c2fdd02e048",
+			expected:     "d4f2a5c61c872d9c0db56c642117d53e87b0018983f7f58ab33194de0859fc91",
 		},
 		"custom (networkID mismatch)": {
 			networkID:    9999,
@@ -290,7 +290,7 @@ func TestGenesisFromFlag(t *testing.T) {
 		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
-			expected:     "2a251a6382744c6aec83e7436c8a6df11a2832f0d3a880b1965a2c2fdd02e048",
+			expected:     "d4f2a5c61c872d9c0db56c642117d53e87b0018983f7f58ab33194de0859fc91",
 		},
 		"custom (networkID mismatch)": {
 			networkID:    9999,
@@ -362,27 +362,27 @@ func TestGenesis(t *testing.T) {
 	}{
 		{
 			networkID:  constants.MainnetID,
-			expectedID: "9JeAFYT7DVEw8uWR7P1zDYHbvBL5UcxctnbAPjXkWRHNUUBja",
+			expectedID: "24VPjSXZnwmDiBqJZFcw4yf3XcJNJ2kasfReckKqwD3QQfmDt",
 		},
 		{
 			networkID:  constants.FujiID,
-			expectedID: "2i5egGn51M1nAGX2KiD3g9kbRcsmpHC4jShXAm5n27NDFk6sZv",
+			expectedID: "ZPnZsX9qzL2FusY23MsLBEyHiyR89yTXbZKMmh2HFTezQHw42",
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2hqwxp4niNCNWaLz4ZbFUv549byoNhXFzMpJn9smrwFdS7mjY8",
+			expectedID: "24Nkb3SH2pSEMLgDpExjwVYAJVgeshtwD3KazWSGauG6VLi73J",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "2qmzqdCuxSSRSRNnMrYnr33ruaQsSEahZkgoHLtPoty2Ej65HF",
+			expectedID: "9s74BvVXQG6uQi6AWFFRKeX5wELffXX4s8JVB19eLrGXMRDzW",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "p5enNqHQtaA7n5LExeKBgLbps2cPtKExF3a8ZXJzLAkD95SnQ",
+			expectedID: "2mn7eZPQhKDEvYmwYLiG1cq4aYUhD1AZWkkYzNpVat9xD2ubM2",
 		},
 		{
 			networkID:  constants.LocalID,
-			expectedID: "2VWzpErXk7iddpznuKmv2sEAMfkK4oSf5GGdghhxJZ11TBtgBx",
+			expectedID: "w7ZJ9oiPu82cem7gcHB877nr2m2f7wF49XwDqWm7tyk8e37Fe",
 		},
 	}
 	for _, test := range tests {
@@ -413,7 +413,7 @@ func TestVMGenesis(t *testing.T) {
 			vmTest: []vmTest{
 				{
 					vmID:       constants.AVMID,
-					expectedID: "VNnyDgLANxKoJHLmyuWGoxRTacXNXveKPonNUNp1UR3qzwHYR",
+					expectedID: "yMQo4UEa2Gkk6aSmifkUuBsystV1iu1NppatvoYz6yCDnRjiq",
 				},
 				{
 					vmID:       constants.EVMID,
@@ -426,7 +426,7 @@ func TestVMGenesis(t *testing.T) {
 			vmTest: []vmTest{
 				{
 					vmID:       constants.AVMID,
-					expectedID: "2ZUEVCqFhALPFEdMy3BPF1XHjsvGMad1PAr1gwGygJUQaSAJii",
+					expectedID: "2UfVve1WKfaF7xXsAUdxgsjZ7JWKW9pPfbqptwkrzJXZWh7q4N",
 				},
 				{
 					vmID:       constants.EVMID,
@@ -439,7 +439,7 @@ func TestVMGenesis(t *testing.T) {
 			vmTest: []vmTest{
 				{
 					vmID:       constants.AVMID,
-					expectedID: "2CRHgEWXpWvrNPFpj9ESNZreyWyBMmowwB4B9c1Wq3UiSZRTbA",
+					expectedID: "2BWFGEyhc738dK4yRfPPreotmuWjcf6LidPf2wRp7CXVKWJC47",
 				},
 				{
 					vmID:       constants.EVMID,
@@ -497,15 +497,15 @@ func TestAVAXAssetID(t *testing.T) {
 	}{
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2MqFg8DwzdqNSUZuAMfSjw4TnY6QbaYjCgbTN23XvoSU1vUzZx",
+			expectedID: "2LgYQ5nWZgiwYFVpSoDPma5e3A4GsehYsbCge9eH8Z1149Ca5b",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "oG2bd1RmLSPAyWBe1URq13rwM7QefTnmTMmTvvP3jwHNouTiJ",
+			expectedID: "2avucpjrQFQ4vLXqujshRf9eGjFNnmkTixwAcYfCSj5wzSTmTE",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "nAYMaFpGCdLugSTH9vnUgsAsNfUNeFFuWnpzjRxmz9pYiDFh5",
+			expectedID: "4wAxCU6qDsfifowLXhJBf3MUAkeWChr4BCtpvknWXnetnJ85s",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/api/camino.go
+++ b/vms/platformvm/api/camino.go
@@ -26,6 +26,7 @@ type Camino struct {
 	VerifyNodeSignature bool                   `json:"verifyNodeSignature"`
 	LockModeBondDeposit bool                   `json:"lockModeBondDeposit"`
 	InitialAdmin        ids.ShortID            `json:"initialAdmin"`
+	AddressStates       []genesis.AddressState `json:"addressStates"`
 	DepositOffers       []genesis.DepositOffer `json:"depositOffers"`
 	ValidatorDeposits   [][]ids.ID             `json:"validatorDeposits"`
 	UTXODeposits        []ids.ID               `json:"utxoDeposits"`
@@ -36,6 +37,7 @@ func (c Camino) ParseToGenesis() genesis.Camino {
 		VerifyNodeSignature: c.VerifyNodeSignature,
 		LockModeBondDeposit: c.LockModeBondDeposit,
 		InitialAdmin:        c.InitialAdmin,
+		AddressStates:       c.AddressStates,
 		DepositOffers:       c.DepositOffers,
 	}
 }

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -209,7 +209,7 @@ type SetAddressStateArgs struct {
 }
 
 // AddAdressState issues an AddAdressStateTx
-func (s *Service) SetAddressState(_ *http.Request, args *SetAddressStateArgs, response api.JSONTxID) error {
+func (s *Service) SetAddressState(_ *http.Request, args *SetAddressStateArgs, response *api.JSONTxID) error {
 	s.vm.ctx.Log.Debug("Platform: SetAddressState called")
 
 	keys, err := s.getKeystoreKeys(&args.JSONSpendHeader)

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -15,11 +15,17 @@ import (
 
 // Camino genesis args
 type Camino struct {
-	VerifyNodeSignature bool           `serialize:"true" json:"verifyNodeSignature"`
-	LockModeBondDeposit bool           `serialize:"true" json:"lockModeBondDeposit"`
-	InitialAdmin        ids.ShortID    `serialize:"true" json:"initialAdmin"`
-	DepositOffers       []DepositOffer `serialize:"true" json:"depositOffers"`
-	Deposits            []*txs.Tx      `serialize:"true" json:"deposits"`
+	VerifyNodeSignature bool           `serialize:"true"`
+	LockModeBondDeposit bool           `serialize:"true"`
+	InitialAdmin        ids.ShortID    `serialize:"true"`
+	AddressStates       []AddressState `serialize:"true"`
+	DepositOffers       []DepositOffer `serialize:"true"`
+	Deposits            []*txs.Tx      `serialize:"true"`
+}
+
+type AddressState struct {
+	Address ids.ShortID `serialize:"true" json:"address"`
+	State   uint64      `serialize:"true" json:"state"`
 }
 
 type DepositOffer struct {

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -9,32 +9,32 @@ import (
 
 // Issuer
 func (i *issuer) AddAddressStateTx(*txs.AddAddressStateTx) error {
-	i.m.addStakerTx(i.tx)
+	i.m.addDecisionTx(i.tx)
 	return nil
 }
 
 func (i *issuer) DepositTx(*txs.DepositTx) error {
-	i.m.addStakerTx(i.tx)
+	i.m.addDecisionTx(i.tx)
 	return nil
 }
 
 func (i *issuer) UnlockDepositTx(*txs.UnlockDepositTx) error {
-	i.m.addStakerTx(i.tx)
+	i.m.addDecisionTx(i.tx)
 	return nil
 }
 
 // Remover
 func (r *remover) AddAddressStateTx(*txs.AddAddressStateTx) error {
-	r.m.removeStakerTx(r.tx)
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }
 
 func (r *remover) DepositTx(*txs.DepositTx) error {
-	r.m.removeStakerTx(r.tx)
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }
 
 func (r *remover) UnlockDepositTx(*txs.UnlockDepositTx) error {
-	r.m.removeStakerTx(r.tx)
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }


### PR DESCRIPTION
This PR does:
- adds `addresState` field to camino allocations in genesis, which then will be passed to initial state.
- fixes missed x-chain allocations processing on genesis generation
- adds UnparsedPlatformAllocation in order to support empty strings as empty ids
- adds `validatorDuration` to platformAllocation, so each initial validator can have its own staking period duration
- fixes bugs: stakers tx mempool crash on advance time, setAddressState rpc handler reply
### Co-authors:
@DerTiedemann (bugfixes)