### PR TITLE
Fix panix on SetAddressStateTX addition into the Mempool

### DIFF
--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -209,7 +209,7 @@ type SetAddressStateArgs struct {
 }
 
 // AddAdressState issues an AddAdressStateTx
-func (s *Service) SetAddressState(_ *http.Request, args *SetAddressStateArgs, response api.JSONTxID) error {
+func (s *Service) SetAddressState(_ *http.Request, args *SetAddressStateArgs, response *api.JSONTxID) error {
 	s.vm.ctx.Log.Debug("Platform: SetAddressState called")
 
 	keys, err := s.getKeystoreKeys(&args.JSONSpendHeader)

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -9,32 +9,32 @@ import (
 
 // Issuer
 func (i *issuer) AddAddressStateTx(*txs.AddAddressStateTx) error {
-	i.m.addStakerTx(i.tx)
+	i.m.addDecisionTx(i.tx)
 	return nil
 }
 
 func (i *issuer) DepositTx(*txs.DepositTx) error {
-	i.m.addStakerTx(i.tx)
+	i.m.addDecisionTx(i.tx)
 	return nil
 }
 
 func (i *issuer) UnlockDepositTx(*txs.UnlockDepositTx) error {
-	i.m.addStakerTx(i.tx)
+	i.m.addDecisionTx(i.tx)
 	return nil
 }
 
 // Remover
 func (r *remover) AddAddressStateTx(*txs.AddAddressStateTx) error {
-	r.m.removeStakerTx(r.tx)
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }
 
 func (r *remover) DepositTx(*txs.DepositTx) error {
-	r.m.removeStakerTx(r.tx)
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }
 
 func (r *remover) UnlockDepositTx(*txs.UnlockDepositTx) error {
-	r.m.removeStakerTx(r.tx)
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }


### PR DESCRIPTION
Multiple Fixes to make tesing kopernikus possible:
- the reply was not a pointer and thus it was not picked up by the reflection to create a JRPC method
- The new TXs added themselves to the Staker Mempool and the advanceTime tx assumed that all of the tx inside there were stakerTxs, but this invariant was broken and this a panic ensued.

