### PR TITLE
Feature/camino config testing

### DIFF
--- a/genesis/camino_config_test.go
+++ b/genesis/camino_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package genesis
 
 import (
@@ -14,15 +17,17 @@ import (
 var (
 	nodeID         = ids.GenerateTestNodeID()
 	depositOfferID = ids.GenerateTestID()
+	shortID2       = ids.GenerateTestShortID()
 )
 
 func TestUnparse(t *testing.T) {
 	type fields struct {
-		VerifyNodeSignature bool
-		LockModeBondDeposit bool
-		InitialAdmin        ids.ShortID
-		DepositOffers       []genesis.DepositOffer
-		Allocations         []CaminoAllocation
+		VerifyNodeSignature      bool
+		LockModeBondDeposit      bool
+		InitialAdmin             ids.ShortID
+		DepositOffers            []genesis.DepositOffer
+		Allocations              []CaminoAllocation
+		InitialMultisigAddresses []genesis.MultisigAlias
 	}
 	type args struct {
 		networkID uint32
@@ -41,16 +46,21 @@ func TestUnparse(t *testing.T) {
 				InitialAdmin:        sampleShortID,
 				DepositOffers:       nil,
 				Allocations: []CaminoAllocation{{
-					ETHAddr:      sampleShortID,
-					AVAXAddr:     sampleShortID,
-					XAmount:      1,
-					AddressState: 1,
+					ETHAddr:       sampleShortID,
+					AVAXAddr:      sampleShortID,
+					XAmount:       1,
+					AddressStates: AddressStates{},
 					PlatformAllocations: []PlatformAllocation{{
 						Amount:            1,
 						NodeID:            nodeID,
 						ValidatorDuration: 1,
 						DepositOfferID:    depositOfferID,
 					}},
+				}},
+				InitialMultisigAddresses: []genesis.MultisigAlias{{
+					Alias:     sampleShortID,
+					Threshold: 1,
+					Addresses: []ids.ShortID{shortID2},
 				}},
 			},
 			want: UnparsedCamino{
@@ -59,10 +69,10 @@ func TestUnparse(t *testing.T) {
 				InitialAdmin:        "X-" + wrappers.IgnoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
 				DepositOffers:       nil,
 				Allocations: []UnparsedCaminoAllocation{{
-					ETHAddr:      "0x" + hex.EncodeToString(sampleShortID.Bytes()),
-					AVAXAddr:     "X-" + wrappers.IgnoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
-					XAmount:      1,
-					AddressState: 1,
+					ETHAddr:       "0x" + hex.EncodeToString(sampleShortID.Bytes()),
+					AVAXAddr:      "X-" + wrappers.IgnoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
+					XAmount:       1,
+					AddressStates: AddressStates{},
 					PlatformAllocations: []UnparsedPlatformAllocation{{
 						Amount:            1,
 						NodeID:            nodeID.String(),
@@ -70,17 +80,23 @@ func TestUnparse(t *testing.T) {
 						DepositOfferID:    depositOfferID.String(),
 					}},
 				}},
+				InitialMultisigAddresses: []UnparsedMultisigAlias{{
+					Alias:     wrappers.IgnoreError(address.Format(configChainIDAlias, "local", sampleShortID.Bytes())).(string),
+					Threshold: 1,
+					Addresses: []string{wrappers.IgnoreError(address.Format(configChainIDAlias, "local", shortID2.Bytes())).(string)},
+				}},
 			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := Camino{
-				VerifyNodeSignature: tt.fields.VerifyNodeSignature,
-				LockModeBondDeposit: tt.fields.LockModeBondDeposit,
-				InitialAdmin:        tt.fields.InitialAdmin,
-				DepositOffers:       tt.fields.DepositOffers,
-				Allocations:         tt.fields.Allocations,
+				VerifyNodeSignature:      tt.fields.VerifyNodeSignature,
+				LockModeBondDeposit:      tt.fields.LockModeBondDeposit,
+				InitialAdmin:             tt.fields.InitialAdmin,
+				DepositOffers:            tt.fields.DepositOffers,
+				Allocations:              tt.fields.Allocations,
+				InitialMultisigAddresses: tt.fields.InitialMultisigAddresses,
 			}
 			got, err := c.Unparse(tt.args.networkID)
 

--- a/genesis/camino_config_test.go
+++ b/genesis/camino_config_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/stretchr/testify/require"
 )
 
 var (
-	nodeID         = ids.NodeID(ids.GenerateTestShortID())
+	nodeID         = ids.GenerateTestNodeID()
 	depositOfferID = ids.GenerateTestID()
 )
 
@@ -55,11 +56,11 @@ func TestUnparse(t *testing.T) {
 			want: UnparsedCamino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				InitialAdmin:        "X-" + ignoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
+				InitialAdmin:        "X-" + wrappers.IgnoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
 				DepositOffers:       nil,
 				Allocations: []UnparsedCaminoAllocation{{
 					ETHAddr:      "0x" + hex.EncodeToString(sampleShortID.Bytes()),
-					AVAXAddr:     "X-" + ignoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
+					AVAXAddr:     "X-" + wrappers.IgnoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
 					XAmount:      1,
 					AddressState: 1,
 					PlatformAllocations: []UnparsedPlatformAllocation{{

--- a/genesis/camino_config_test.go
+++ b/genesis/camino_config_test.go
@@ -1,0 +1,94 @@
+package genesis
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	nodeID         = ids.NodeID(ids.GenerateTestShortID())
+	depositOfferID = ids.GenerateTestID()
+)
+
+func TestUnparse(t *testing.T) {
+	type fields struct {
+		VerifyNodeSignature bool
+		LockModeBondDeposit bool
+		InitialAdmin        ids.ShortID
+		DepositOffers       []genesis.DepositOffer
+		Allocations         []CaminoAllocation
+	}
+	type args struct {
+		networkID uint32
+	}
+	tests := map[string]struct {
+		fields fields
+		args   args
+		want   UnparsedCamino
+		err    error
+	}{
+		"success": {
+			args: args{networkID: 12345},
+			fields: fields{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				InitialAdmin:        sampleShortID,
+				DepositOffers:       nil,
+				Allocations: []CaminoAllocation{{
+					ETHAddr:      sampleShortID,
+					AVAXAddr:     sampleShortID,
+					XAmount:      1,
+					AddressState: 1,
+					PlatformAllocations: []PlatformAllocation{{
+						Amount:            1,
+						NodeID:            nodeID,
+						ValidatorDuration: 1,
+						DepositOfferID:    depositOfferID,
+					}},
+				}},
+			},
+			want: UnparsedCamino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				InitialAdmin:        "X-" + ignoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
+				DepositOffers:       nil,
+				Allocations: []UnparsedCaminoAllocation{{
+					ETHAddr:      "0x" + hex.EncodeToString(sampleShortID.Bytes()),
+					AVAXAddr:     "X-" + ignoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
+					XAmount:      1,
+					AddressState: 1,
+					PlatformAllocations: []UnparsedPlatformAllocation{{
+						Amount:            1,
+						NodeID:            nodeID.String(),
+						ValidatorDuration: 1,
+						DepositOfferID:    depositOfferID.String(),
+					}},
+				}},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := Camino{
+				VerifyNodeSignature: tt.fields.VerifyNodeSignature,
+				LockModeBondDeposit: tt.fields.LockModeBondDeposit,
+				InitialAdmin:        tt.fields.InitialAdmin,
+				DepositOffers:       tt.fields.DepositOffers,
+				Allocations:         tt.fields.Allocations,
+			}
+			got, err := c.Unparse(tt.args.networkID)
+
+			if tt.err != nil {
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/genesis/camino_helpers_test.go
+++ b/genesis/camino_helpers_test.go
@@ -1,5 +1,0 @@
-package genesis
-
-func ignoreError(val any, err error) interface{} { //nolint:revive
-	return val
-}

--- a/genesis/camino_helpers_test.go
+++ b/genesis/camino_helpers_test.go
@@ -1,0 +1,5 @@
+package genesis
+
+func ignoreError(val any, err error) interface{} { //nolint:revive
+	return val
+}

--- a/genesis/camino_unparsed_config.go
+++ b/genesis/camino_unparsed_config.go
@@ -5,6 +5,7 @@ package genesis
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -12,7 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 )
 
-var errCannotParseInitialAdmin = "cannot parse initialAdmin from genesis: %w"
+var errCannotParseInitialAdmin = errors.New("cannot parse initialAdmin from genesis")
 
 type UnparsedCamino struct {
 	VerifyNodeSignature      bool                       `json:"verifyNodeSignature"`
@@ -34,11 +35,11 @@ func (uc UnparsedCamino) Parse() (Camino, error) {
 
 	_, _, avaxAddrBytes, err := address.Parse(uc.InitialAdmin)
 	if err != nil {
-		return c, fmt.Errorf(errCannotParseInitialAdmin, err)
+		return c, fmt.Errorf("%w: %v", errCannotParseInitialAdmin, err)
 	}
 	avaxAddr, err := ids.ToShortID(avaxAddrBytes)
 	if err != nil {
-		return c, fmt.Errorf(errCannotParseInitialAdmin, err)
+		return c, fmt.Errorf("%w: %v", errCannotParseInitialAdmin, err)
 	}
 	c.InitialAdmin = avaxAddr
 

--- a/genesis/camino_unparsed_config_test.go
+++ b/genesis/camino_unparsed_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package genesis
 
 import (
@@ -26,11 +29,12 @@ var (
 
 func TestParse(t *testing.T) {
 	type fields struct {
-		VerifyNodeSignature bool
-		LockModeBondDeposit bool
-		InitialAdmin        string
-		DepositOffers       []genesis.DepositOffer
-		Allocations         []UnparsedCaminoAllocation
+		VerifyNodeSignature   bool
+		LockModeBondDeposit   bool
+		InitialAdmin          string
+		DepositOffers         []genesis.DepositOffer
+		Allocations           []UnparsedCaminoAllocation
+		UnparsedMultisigAlias []UnparsedMultisigAlias
 	}
 	tests := map[string]struct {
 		fields fields
@@ -129,6 +133,11 @@ func TestParse(t *testing.T) {
 						DepositOfferID:    sampleID.String(),
 					}},
 				}},
+				UnparsedMultisigAlias: []UnparsedMultisigAlias{{
+					Alias:     wrappers.IgnoreError(address.Format(configChainIDAlias, "local", sampleShortID.Bytes())).(string),
+					Threshold: 1,
+					Addresses: []string{wrappers.IgnoreError(address.Format(configChainIDAlias, "local", shortID2.Bytes())).(string)},
+				}},
 			},
 			want: Camino{
 				VerifyNodeSignature: true,
@@ -148,17 +157,23 @@ func TestParse(t *testing.T) {
 						DepositOfferID:    sampleID,
 					}},
 				}},
+				InitialMultisigAddresses: []genesis.MultisigAlias{{
+					Alias:     sampleShortID,
+					Threshold: 1,
+					Addresses: []ids.ShortID{shortID2},
+				}},
 			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			uc := UnparsedCamino{
-				VerifyNodeSignature: tt.fields.VerifyNodeSignature,
-				LockModeBondDeposit: tt.fields.LockModeBondDeposit,
-				InitialAdmin:        tt.fields.InitialAdmin,
-				DepositOffers:       tt.fields.DepositOffers,
-				Allocations:         tt.fields.Allocations,
+				VerifyNodeSignature:      tt.fields.VerifyNodeSignature,
+				LockModeBondDeposit:      tt.fields.LockModeBondDeposit,
+				InitialAdmin:             tt.fields.InitialAdmin,
+				DepositOffers:            tt.fields.DepositOffers,
+				Allocations:              tt.fields.Allocations,
+				InitialMultisigAddresses: tt.fields.UnparsedMultisigAlias,
 			}
 			got, err := uc.Parse()
 

--- a/genesis/camino_unparsed_config_test.go
+++ b/genesis/camino_unparsed_config_test.go
@@ -1,0 +1,138 @@
+package genesis
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	sampleID                   = ids.GenerateTestID()
+	sampleShortID              = ids.GenerateTestShortID()
+	addressWithInvalidFormat   = ids.GenerateTestShortID().String()
+	addressWithInvalidChecksum = "X-camino1859dz2uwazfgahey3j53ef2kqrans0c8htcu8n"
+	xAddress                   = "X-camino1859dz2uwazfgahey3j53ef2kqrans0c8htcu7n"
+	cAddress                   = "C-camino1859dz2uwazfgahey3j53ef2kqrans0c8htcu7n"
+	toShortID                  = ignoreError(ids.ToShortID([]byte(cAddress))).(ids.ShortID)
+)
+
+func TestParse(t *testing.T) {
+	type fields struct {
+		VerifyNodeSignature bool
+		LockModeBondDeposit bool
+		InitialAdmin        string
+		DepositOffers       []genesis.DepositOffer
+		Allocations         []UnparsedCaminoAllocation
+	}
+	tests := map[string]struct {
+		fields fields
+		want   Camino
+		err    error
+	}{
+		"Invalid address - no prefix": {
+			fields: fields{
+				InitialAdmin: addressWithInvalidFormat,
+			},
+			err: errCannotParseInitialAdmin,
+		},
+		"Invalid address - bad checksum": {
+			fields: fields{
+				InitialAdmin: addressWithInvalidChecksum,
+			},
+			err: errCannotParseInitialAdmin,
+		},
+		"Invalid allocation - missing eth address": {
+			fields: fields{
+				InitialAdmin: xAddress,
+				Allocations:  []UnparsedCaminoAllocation{{}},
+			},
+			err: errInvalidETHAddress,
+		},
+		"Invalid allocation - invalid eth address": {
+			fields: fields{
+				InitialAdmin: xAddress,
+				Allocations: []UnparsedCaminoAllocation{{
+					ETHAddr: ids.GenerateTestShortID().String(),
+				}},
+			},
+			err: errors.New("encoding/hex: invalid byte"),
+		},
+		"Invalid allocation - invalid avax address": {
+			fields: fields{
+				InitialAdmin: xAddress,
+				Allocations: []UnparsedCaminoAllocation{{
+					ETHAddr:  "0x" + hex.EncodeToString(toShortID.Bytes()),
+					AVAXAddr: addressWithInvalidFormat,
+				}},
+			},
+			err: errors.New("no separator found in address"),
+		},
+		"Valid allocation": {
+			fields: fields{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				InitialAdmin:        xAddress,
+				DepositOffers:       nil,
+				Allocations: []UnparsedCaminoAllocation{{
+					ETHAddr:  "0x" + hex.EncodeToString(toShortID.Bytes()),
+					AVAXAddr: xAddress,
+					PlatformAllocations: []UnparsedPlatformAllocation{{
+						Amount:            1,
+						NodeID:            "NodeID-" + sampleShortID.String(),
+						ValidatorDuration: 1,
+						DepositOfferID:    sampleID.String(),
+					}},
+				}},
+			},
+			want: Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				InitialAdmin:        toAvaxAddr(xAddress),
+				DepositOffers:       nil,
+				Allocations: []CaminoAllocation{{
+					ETHAddr: func() ids.ShortID {
+						i, _ := ids.ShortFromString("0x" + hex.EncodeToString(toShortID.Bytes()))
+						return i
+					}(),
+					AVAXAddr: toAvaxAddr(xAddress),
+					PlatformAllocations: []PlatformAllocation{{
+						Amount:            1,
+						NodeID:            ids.NodeID(sampleShortID),
+						ValidatorDuration: 1,
+						DepositOfferID:    sampleID,
+					}},
+				}},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			uc := UnparsedCamino{
+				VerifyNodeSignature: tt.fields.VerifyNodeSignature,
+				LockModeBondDeposit: tt.fields.LockModeBondDeposit,
+				InitialAdmin:        tt.fields.InitialAdmin,
+				DepositOffers:       tt.fields.DepositOffers,
+				Allocations:         tt.fields.Allocations,
+			}
+			got, err := uc.Parse()
+
+			if tt.err != nil {
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func toAvaxAddr(id string) ids.ShortID {
+	_, _, avaxAddrBytes, _ := address.Parse(id)
+	avaxAddr, _ := ids.ToShortID(avaxAddrBytes)
+	return avaxAddr
+}

--- a/utils/wrappers/camino_errors.go
+++ b/utils/wrappers/camino_errors.go
@@ -1,0 +1,5 @@
+package wrappers
+
+func IgnoreError(val any, err error) interface{} { //nolint:revive
+	return val
+}

--- a/utils/wrappers/camino_errors.go
+++ b/utils/wrappers/camino_errors.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package wrappers
 
 func IgnoreError(val any, err error) interface{} { //nolint:revive

--- a/vms/platformvm/state/camino_helpers_test.go
+++ b/vms/platformvm/state/camino_helpers_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+func generateBaseTx(assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *txs.BaseTx {
+	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
+		Amt:          amount,
+		OutputOwners: outputOwners,
+	}
+	if depositTxID != ids.Empty || bondTxID != ids.Empty {
+		out = &locked.Out{
+			IDs: locked.IDs{
+				DepositTxID: depositTxID,
+				BondTxID:    bondTxID,
+			},
+			TransferableOut: out,
+		}
+	}
+
+	return &txs.BaseTx{
+		BaseTx: avax.BaseTx{
+			Outs: []*avax.TransferableOutput{
+				{
+					Asset: avax.Asset{ID: assetID},
+					Out:   out,
+				},
+			},
+		},
+	}
+}

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -1,0 +1,219 @@
+package state
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/version"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/golang/mock/gomock"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	db_manager "github.com/ava-labs/avalanchego/database/manager"
+)
+
+var (
+	id           = ids.GenerateTestID()
+	id2          = ids.GenerateTestID()
+	shortID      = ids.GenerateTestShortID()
+	shortID2     = ids.GenerateTestShortID()
+	initialAdmin = ids.GenerateTestShortID()
+)
+
+func TestSyncGenesis(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	s, _ := newInitializedState(require)
+
+	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
+
+	outputOwners := secp256k1fx.OutputOwners{
+		Addrs: []ids.ShortID{shortID},
+	}
+	outputOwners2 := secp256k1fx.OutputOwners{
+		Addrs: []ids.ShortID{shortID2},
+	}
+
+	depositTxs := []*txs.Tx{
+		{
+			Unsigned: &txs.DepositTx{
+				BaseTx:          *generateBaseTx(id, 1, outputOwners, ids.Empty, ids.Empty),
+				DepositOfferID:  id,
+				DepositDuration: 1,
+				RewardsOwner:    &outputOwners,
+			},
+			Creds: nil,
+		},
+		{
+			Unsigned: &txs.DepositTx{
+				BaseTx:          *generateBaseTx(id, 2, outputOwners2, ids.Empty, ids.Empty),
+				DepositOfferID:  id2,
+				DepositDuration: 2,
+				RewardsOwner:    &outputOwners2,
+			},
+			Creds: nil,
+		},
+	}
+	depositTxs[0].Initialize(utils.RandomBytes(16), utils.RandomBytes(16))
+	depositTxs[1].Initialize(utils.RandomBytes(16), utils.RandomBytes(16))
+
+	depositOffers := []deposit.Offer{
+		{
+			InterestRateNominator:   1,
+			Start:                   2,
+			End:                     3,
+			MinAmount:               4,
+			MinDuration:             5,
+			MaxDuration:             6,
+			UnlockPeriodDuration:    7,
+			NoRewardsPeriodDuration: 8,
+			Flags:                   9,
+		}, {
+			InterestRateNominator:   2,
+			Start:                   3,
+			End:                     4,
+			MinAmount:               5,
+			MinDuration:             6,
+			MaxDuration:             7,
+			UnlockPeriodDuration:    8,
+			NoRewardsPeriodDuration: 9,
+			Flags:                   10,
+		},
+	}
+
+	type args struct {
+		s *state
+		g *genesis.State
+	}
+	tests := map[string]struct {
+		cs      caminoState
+		args    args
+		want    caminoDiff
+		prepare func(cd caminoDiff)
+		err     error
+	}{
+		"successful addition of address states, deposits and deposit offers": {
+			args: args{
+				s: s.(*state),
+				g: defaultGenesisState([]genesis.AddressState{
+					{
+						Address: initialAdmin,
+						State:   txs.AddressStateRoleAdminBit,
+					},
+					{
+						Address: shortID,
+						State:   txs.AddressStateRoleValidatorBit,
+					},
+				}, depositTxs),
+			},
+			cs: *wrappers.IgnoreError(newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())).(*caminoState),
+			want: caminoDiff{
+				modifiedAddressStates: map[ids.ShortID]uint64{initialAdmin: txs.AddressStateRoleAdminBit, shortID: txs.AddressStateRoleValidatorBit},
+				modifiedDepositOffers: map[ids.ID]*deposit.Offer{},
+				modifiedDeposits: map[ids.ID]*deposit.Deposit{
+					depositTxs[0].ID(): {
+						DepositOfferID: depositTxs[0].Unsigned.(*txs.DepositTx).DepositOfferID,
+						Amount:         1,
+					},
+					depositTxs[1].ID(): {
+						DepositOfferID: depositTxs[1].Unsigned.(*txs.DepositTx).DepositOfferID,
+						Amount:         2,
+					},
+				},
+			},
+			prepare: func(cd caminoDiff) {
+				for _, v := range depositOffers {
+					v := v
+					v.SetID()                           //nolint:errcheck
+					cd.modifiedDepositOffers[v.ID] = &v //nolint:nolintlint
+				}
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tt.prepare(tt.want)
+			err := tt.cs.SyncGenesis(tt.args.s, tt.args.g)
+
+			if tt.err != nil {
+				require.ErrorIs(tt.err, err)
+				return
+			}
+			require.NoError(err)
+
+			for k, d := range tt.want.modifiedDeposits {
+				require.Equal(d.DepositOfferID, tt.cs.modifiedDeposits[k].DepositOfferID)
+				require.Equal(d.Amount, tt.cs.modifiedDeposits[k].Amount)
+			}
+			for i, o := range tt.want.modifiedDepositOffers {
+				require.Equal(o, tt.cs.modifiedDepositOffers[i])
+			}
+			require.Truef(reflect.DeepEqual(tt.want.modifiedAddressStates, tt.cs.caminoDiff.modifiedAddressStates), "\ngot: %v\nwant: %v", tt.want.modifiedAddressStates, tt.cs.caminoDiff.modifiedAddressStates)
+		})
+	}
+}
+
+func defaultGenesisState(addresses []genesis.AddressState, deposits []*txs.Tx) *genesis.State {
+	return &genesis.State{
+		UTXOs: []*avax.UTXO{
+			{
+				UTXOID: avax.UTXOID{
+					TxID:        initialTxID,
+					OutputIndex: 0,
+				},
+				Asset: avax.Asset{ID: initialTxID},
+				Out: &secp256k1fx.TransferOutput{
+					Amt: units.Schmeckle,
+				},
+			},
+		},
+		Validators: []*txs.Tx{
+			{},
+		},
+		Chains: []*txs.Tx{
+			{},
+		},
+		Timestamp:     uint64(initialTime.Unix()),
+		InitialSupply: units.Schmeckle + units.Avax,
+		Camino: genesis.Camino{
+			AddressStates: addresses,
+			InitialAdmin:  initialAdmin,
+			Deposits:      deposits,
+			DepositOffers: []genesis.DepositOffer{
+				{
+					InterestRateNominator:   1,
+					Start:                   2,
+					End:                     3,
+					MinAmount:               4,
+					MinDuration:             5,
+					MaxDuration:             6,
+					UnlockPeriodDuration:    7,
+					NoRewardsPeriodDuration: 8,
+					Flags:                   9,
+				},
+				{
+					InterestRateNominator:   2,
+					Start:                   3,
+					End:                     4,
+					MinAmount:               5,
+					MinDuration:             6,
+					MaxDuration:             7,
+					UnlockPeriodDuration:    8,
+					NoRewardsPeriodDuration: 9,
+					Flags:                   10,
+				},
+			},
+		},
+	}
+}

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package state
 
 import (


### PR DESCRIPTION
## Why this should be merged
Contains new tests for logic regarding parsing/unparsing camino config as well as syncGenesis functionality.

## What was tested
genesis/camino_unparsed_config.go -> Parse()
genesis/camino_config.go -> Unparse()
vms/platformvm/state/camino.go -> SyncGenesis()