### PR TITLE
Fix small error in the SetAddressStateTxExecutor

### DIFF
--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -683,7 +683,7 @@ func (e *CaminoStandardTxExecutor) AddAddressStateTx(tx *txs.AddAddressStateTx) 
 	utxo.Produce(e.State, txID, tx.Outs)
 	// Set the new states if changed
 	if states != newStates {
-		e.State.SetAddressStates(tx.Address, states)
+		e.State.SetAddressStates(tx.Address, newStates)
 	}
 
 	return nil


### PR DESCRIPTION
## Why this should be merged
I fixes a small error which prevents updated states to be saved
## How this works
Just saving the correct value
## How this was tested
Debugger and subsequent TX that require a specific flag to be set
