### PR TITLE
Genesis camino local configuration

### DIFF
--- a/genesis/camino_genesis_test.go
+++ b/genesis/camino_genesis_test.go
@@ -1,0 +1,209 @@
+package genesis
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/hashing"
+	"github.com/ava-labs/avalanchego/utils/perms"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/stretchr/testify/require"
+
+	_ "embed"
+)
+
+//go:embed genesis_camino_local.json
+var customCaminoGenesisConfigJSON []byte
+
+func TestValidateCaminoConfig(t *testing.T) {
+	type args struct {
+		config *Config
+	}
+	tests := map[string]struct {
+		args args
+		err  error
+	}{
+		"non-camino allocations / LockModeBondDeposit=false": {
+			args: args{
+				config: func() *Config {
+					thisConfig := CaminoLocalConfig
+					thisConfig.Camino.LockModeBondDeposit = false
+					thisConfig.Allocations = []Allocation{{AVAXAddr: ids.GenerateTestShortID()}}
+					return &thisConfig
+				}(),
+			},
+		},
+		"non-camino allocations": {
+			args: args{
+				config: func() *Config {
+					thisConfig := CaminoLocalConfig
+					thisConfig.Allocations = []Allocation{{AVAXAddr: ids.GenerateTestShortID()}}
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("config.Allocations != 0"),
+		},
+		"invalid deposit offer / start date after before date": {
+			args: args{
+				config: func() *Config {
+					thisConfig := CaminoLocalConfig
+					offer := CaminoLocalConfig.Camino.DepositOffers[0]
+					offer.Start = 2
+					offer.End = 1
+					offers := []genesis.DepositOffer{offer}
+					thisConfig.Camino.DepositOffers = offers
+					return &thisConfig
+				}(),
+			},
+			err: fmt.Errorf(
+				"deposit offer starttime (%v) is not before its endtime (%v)",
+				2,
+				1,
+			),
+		},
+		"invalid deposit offer duplicate": {
+			args: args{
+				config: func() *Config {
+					thisConfig := CaminoLocalConfig
+					thisConfig.Camino.DepositOffers = append(thisConfig.Camino.DepositOffers, thisConfig.Camino.DepositOffers[0])
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("deposit offer duplicate"),
+		},
+		"allocation / deposit offer mismatch": {
+			args: args{
+				config: func() *Config {
+					thisConfig := CaminoLocalConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{PlatformAllocations: []PlatformAllocation{{DepositOfferID: ids.GenerateTestID()}}}}
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, CaminoLocalConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("allocation deposit offer id doesn't match any offer"),
+		},
+		"wrong validator duration": {
+			args: args{
+				config: func() *Config {
+					thisConfig := CaminoLocalConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{PlatformAllocations: []PlatformAllocation{{NodeID: ids.GenerateTestNodeID(), ValidatorDuration: 0}}}}
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, CaminoLocalConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("wrong validator duration"),
+		},
+		"repeated staker allocation": {
+			args: args{
+				config: func() *Config {
+					thisConfig := CaminoLocalConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{PlatformAllocations: []PlatformAllocation{{NodeID: CaminoLocalConfig.Camino.Allocations[0].PlatformAllocations[0].NodeID, ValidatorDuration: 1}}}}
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, CaminoLocalConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("repeated staker allocation"),
+		},
+		"no staker allocations": {
+			args: args{
+				config: func() *Config {
+					thisConfig := CaminoLocalConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{PlatformAllocations: []PlatformAllocation{}}}
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("no staker allocations"),
+		},
+		"valid": {
+			args: args{
+				config: &CaminoLocalConfig,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateCaminoConfig(tt.args.config)
+
+			if tt.err != nil {
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCaminoGenesisFromFile(t *testing.T) {
+	tests := map[string]struct {
+		networkID       uint32
+		customConfig    []byte
+		missingFilepath string
+		err             string
+		expected        string
+	}{
+		"camino local error": {
+			networkID:    constants.CaminoLocalID,
+			customConfig: customCaminoGenesisConfigJSON,
+			err:          fmt.Sprintf("cannot override genesis config for standard network %s (%d)", constants.CaminoLocalName, constants.CaminoLocalID),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// test loading of genesis from file
+
+			require := require.New(t)
+			var customFile string
+			if len(test.customConfig) > 0 {
+				customFile = filepath.Join(t.TempDir(), "config.json")
+				require.NoError(perms.WriteFile(customFile, test.customConfig, perms.ReadWrite))
+			}
+
+			if len(test.missingFilepath) > 0 {
+				customFile = test.missingFilepath
+			}
+
+			genesisBytes, _, err := FromFile(test.networkID, customFile)
+			if len(test.err) > 0 {
+				require.Error(err)
+				require.Contains(err.Error(), test.err)
+				return
+			}
+			require.NoError(err)
+
+			genesisHash := fmt.Sprintf("%x", hashing.ComputeHash256(genesisBytes))
+			require.Equal(test.expected, genesisHash, "genesis hash mismatch")
+
+			_, err = genesis.Parse(genesisBytes)
+			require.NoError(err)
+		})
+	}
+}
+
+func TestCaminoGenesis(t *testing.T) {
+	tests := []struct {
+		networkID  uint32
+		expectedID string
+	}{
+		{
+			networkID:  constants.CaminoLocalID,
+			expectedID: "2CtW9s71PCG6vNahuT16aXZo5RQ1MnD9EE8dyjmAC1K4BNabJV",
+		},
+	}
+	for _, test := range tests {
+		t.Run(constants.NetworkIDToNetworkName[test.networkID], func(t *testing.T) {
+			require := require.New(t)
+
+			config := GetConfig(test.networkID)
+			genesisBytes, _, err := FromConfig(config)
+			require.NoError(err)
+
+			var genesisID ids.ID = hashing.ComputeHash256Array(genesisBytes)
+			require.Equal(test.expectedID, genesisID.String())
+		})
+	}
+}

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -191,6 +191,10 @@ var (
 	// LocalConfig is the config that should be used to generate a local
 	// genesis.
 	LocalConfig Config
+
+	// CaminoLocalConfig is the config that should be used to generate a local
+	// camino genesis.
+	CaminoLocalConfig Config
 )
 
 func init() {
@@ -198,6 +202,7 @@ func init() {
 	unparsedColumbusConfig := UnparsedConfig{}
 	unparsedKopernikusConfig := UnparsedConfig{}
 	unparsedLocalConfig := UnparsedConfig{}
+	unparsedCaminoLocalConfig := UnparsedConfig{}
 
 	errs := wrappers.Errs{}
 	errs.Add(
@@ -205,6 +210,7 @@ func init() {
 		json.Unmarshal(columbusGenesisConfigJSON, &unparsedColumbusConfig),
 		json.Unmarshal(kopernikusGenesisConfigJSON, &unparsedKopernikusConfig),
 		json.Unmarshal(localGenesisConfigJSON, &unparsedLocalConfig),
+		json.Unmarshal(localCaminoGenesisConfigJSON, &unparsedCaminoLocalConfig),
 	)
 	if errs.Errored() {
 		panic(errs.Err)
@@ -226,6 +232,10 @@ func init() {
 	errs.Add(err)
 	LocalConfig = localConfig
 
+	caminoLocalConfig, err := unparsedCaminoLocalConfig.Parse()
+	errs.Add(err)
+	CaminoLocalConfig = caminoLocalConfig
+
 	if errs.Errored() {
 		panic(errs.Err)
 	}
@@ -241,6 +251,8 @@ func GetConfig(networkID uint32) *Config {
 		return &KopernikusConfig
 	case constants.LocalID:
 		return &LocalConfig
+	case constants.CaminoLocalID:
+		return &CaminoLocalConfig
 	default:
 		tempConfig := LocalConfig
 		tempConfig.NetworkID = networkID

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -204,7 +204,7 @@ func validateConfig(networkID uint32, config *Config) error {
 //  2. The asset ID of AVAX
 func FromFile(networkID uint32, filepath string) ([]byte, ids.ID, error) {
 	switch networkID {
-	case constants.MainnetID, constants.CaminoID, constants.TestnetID, constants.LocalID:
+	case constants.MainnetID, constants.CaminoID, constants.TestnetID, constants.LocalID, constants.CaminoLocalID:
 		return nil, ids.ID{}, fmt.Errorf(
 			"cannot override genesis config for standard network %s (%d)",
 			constants.NetworkName(networkID),
@@ -244,7 +244,7 @@ func FromFile(networkID uint32, filepath string) ([]byte, ids.ID, error) {
 //     (ie the genesis state of the network)
 //  2. The asset ID of AVAX
 func FromFlag(networkID uint32, genesisContent string) ([]byte, ids.ID, error) {
-	if constants.IsActiveNetwork(networkID) || networkID == constants.LocalID {
+	if constants.IsActiveNetwork(networkID) || networkID == constants.LocalID || networkID == constants.CaminoLocalID {
 		return nil, ids.ID{}, fmt.Errorf(
 			"cannot override genesis config for standard network %s (%d)",
 			constants.NetworkName(networkID),

--- a/genesis/genesis_camino_local.go
+++ b/genesis/genesis_camino_local.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesis
+
+import (
+	"time"
+
+	_ "embed"
+
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+)
+
+// PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE => P-local1g65uqn6t77p656w64023nh8nd9updzmxyymev2
+
+var (
+	//go:embed genesis_camino_local.json
+	localCaminoGenesisConfigJSON []byte
+
+	// ColumbusParams are the params used for columbus network
+	CaminoLocalParams = Params{
+		TxFeeConfig: TxFeeConfig{
+			TxFee:                 units.MilliAvax,
+			CreateAssetTxFee:      units.MilliAvax,
+			CreateSubnetTxFee:     100 * units.MilliAvax,
+			CreateBlockchainTxFee: 100 * units.MilliAvax,
+		},
+		StakingConfig: StakingConfig{
+			UptimeRequirement: .8, // 80%
+			MinValidatorStake: 100 * units.KiloAvax,
+			MaxValidatorStake: 100 * units.KiloAvax,
+			MinDelegatorStake: 25 * units.Avax,
+			MinDelegationFee:  20000, // 2%
+			MinStakeDuration:  24 * time.Hour,
+			MaxStakeDuration:  365 * 24 * time.Hour,
+			RewardConfig: reward.Config{
+				MaxConsumptionRate: .12 * reward.PercentDenominator,
+				MinConsumptionRate: .10 * reward.PercentDenominator,
+				MintingPeriod:      365 * 24 * time.Hour,
+				SupplyCap:          1000 * units.MegaAvax,
+			},
+			CaminoConfig: config.CaminoConfig{
+				DaoProposalBondAmount: 100 * units.Avax,
+			},
+		},
+	}
+)

--- a/genesis/genesis_camino_local.go
+++ b/genesis/genesis_camino_local.go
@@ -19,7 +19,7 @@ var (
 	//go:embed genesis_camino_local.json
 	localCaminoGenesisConfigJSON []byte
 
-	// ColumbusParams are the params used for columbus network
+	// CaminoLocalParams are the params used for camino local network
 	CaminoLocalParams = Params{
 		TxFeeConfig: TxFeeConfig{
 			TxFee:                 units.MilliAvax,

--- a/genesis/genesis_camino_local.json
+++ b/genesis/genesis_camino_local.json
@@ -1,0 +1,71 @@
+{
+  "networkID": 54321,
+  "camino": {
+    "verifyNodeSignature": true,
+    "lockModeBondDeposit": true,
+    "initialAdmin": "X-local1g65uqn6t77p656w64023nh8nd9updzmxyymev2",
+    "depositOffers": [
+      {
+        "interestRateNominator": 80000,
+        "start": 0,
+        "end": 1699609842,
+        "minAmount": 1,
+        "minDuration": 94608000,
+        "maxDuration": 94608000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": 0
+      }
+    ],
+    "allocations": [
+      {
+        "ethAddr": "0x1f0e5c64afdf53175f78846f7125776e76fa8f34",
+        "avaxAddr": "X-local1g65uqn6t77p656w64023nh8nd9updzmxyymev2",
+        "xAmount": 989990000000000000,
+        "platformAllocations": [
+          {
+            "amount": 2000000000000,
+            "nodeID": "NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL",
+            "validatorDuration": 100000000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
+          },
+          {
+            "amount": 2000000000000,
+            "nodeID": "NodeID-D1LbWvUf9iaeEyUbTYYtYq4b7GaYR5tnJ",
+            "validatorDuration": 100000000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
+          },
+          {
+            "amount": 2000000000000,
+            "nodeID": "NodeID-PM2LqrGsxudhZSP49upMonevbQvnvAciv",
+            "validatorDuration": 100000000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
+          },
+          {
+            "amount": 2000000000000,
+            "nodeID": "NodeID-5ZUdznHckQcqucAnNf3vzXnPF97tfRtfn",
+            "validatorDuration": 100000000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
+          },
+          {
+            "amount": 2000000000000,
+            "nodeID": "NodeID-EoYFkbokZEukfWrUovo74YkTFnAMaqTG7",
+            "validatorDuration": 100000000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
+          },
+          {
+            "amount": 10000000000000000,
+            "depositOfferID": "LE47SR1obzixrgRavzwgJhZ6w93PyJwq1XLYcgcCKofKjviB7"
+          },
+          {
+            "amount": 10000000000000000
+          }
+        ]
+      }
+    ]
+  },
+  "startTime": 1671096963,
+  "initialStakeDurationOffset": 5400,
+  "cChainGenesis": "{\"config\":{\"chainId\":43112},\"initialAdmin\":\"0x0000000000000000000000000000000000000000\", \"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
+  "message": "Have a nice trip!"
+}

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -61,6 +61,10 @@ func TestValidateConfig(t *testing.T) {
 			networkID: 12345,
 			config:    &LocalConfig,
 		},
+		"camino local": {
+			networkID: 54321,
+			config:    &CaminoLocalConfig,
+		},
 		"camino (networkID mismatch)": {
 			networkID: 999,
 			config:    &CaminoConfig,

--- a/genesis/params.go
+++ b/genesis/params.go
@@ -78,6 +78,8 @@ func GetTxFeeConfig(networkID uint32) TxFeeConfig {
 		return CaminoParams.TxFeeConfig
 	case constants.ColumbusID:
 		return ColumbusParams.TxFeeConfig
+	case constants.CaminoLocalID:
+		return CaminoLocalParams.TxFeeConfig
 	default:
 		return LocalParams.TxFeeConfig
 	}
@@ -89,6 +91,8 @@ func GetStakingConfig(networkID uint32) StakingConfig {
 		return CaminoParams.StakingConfig
 	case constants.ColumbusID:
 		return ColumbusParams.StakingConfig
+	case constants.CaminoLocalID:
+		return CaminoLocalParams.StakingConfig
 	default:
 		return LocalParams.StakingConfig
 	}

--- a/utils/constants/network_ids.go
+++ b/utils/constants/network_ids.go
@@ -30,28 +30,31 @@ const (
 	ColumbusID   uint32 = 1001
 	KopernikusID uint32 = 1002
 
-	TestnetID  uint32 = ColumbusID
-	UnitTestID uint32 = 10
-	LocalID    uint32 = 12345
+	TestnetID     uint32 = ColumbusID
+	UnitTestID    uint32 = 10
+	LocalID       uint32 = 12345
+	CaminoLocalID uint32 = 54321
 
 	MainnetName = "mainnet"
 	FujiName    = "fuji"
 
-	CaminoName     = "camino"
-	ColumbusName   = "columbus"
-	KopernikusName = "kopernikus"
-	TestnetName    = "testnet"
-	UnitTestName   = "testing"
-	LocalName      = "local"
+	CaminoName      = "camino"
+	ColumbusName    = "columbus"
+	KopernikusName  = "kopernikus"
+	TestnetName     = "testnet"
+	UnitTestName    = "testing"
+	LocalName       = "local"
+	CaminoLocalName = "caminolocal"
 
-	MainnetHRP    = "avax"
-	FujiHRP       = "fuji"
-	CaminoHRP     = "camino"
-	ColumbusHRP   = "columbus"
-	KopernikusHRP = "kopernikus"
-	UnitTestHRP   = "testing"
-	LocalHRP      = "local"
-	FallbackHRP   = "custom"
+	MainnetHRP     = "avax"
+	FujiHRP        = "fuji"
+	CaminoHRP      = "camino"
+	ColumbusHRP    = "columbus"
+	KopernikusHRP  = "kopernikus"
+	UnitTestHRP    = "testing"
+	LocalHRP       = "local"
+	CaminoLocalHRP = "local"
+	FallbackHRP    = "custom"
 )
 
 // Variables to be exported
@@ -60,33 +63,36 @@ var (
 	PlatformChainID  = ids.Empty
 
 	NetworkIDToNetworkName = map[uint32]string{
-		MainnetID:    MainnetName,
-		FujiID:       FujiName,
-		CaminoID:     CaminoName,
-		ColumbusID:   ColumbusName,
-		KopernikusID: KopernikusName,
-		UnitTestID:   UnitTestName,
-		LocalID:      LocalName,
+		MainnetID:     MainnetName,
+		FujiID:        FujiName,
+		CaminoID:      CaminoName,
+		ColumbusID:    ColumbusName,
+		KopernikusID:  KopernikusName,
+		UnitTestID:    UnitTestName,
+		LocalID:       LocalName,
+		CaminoLocalID: CaminoLocalName,
 	}
 	NetworkNameToNetworkID = map[string]uint32{
-		MainnetName:    MainnetID,
-		FujiName:       FujiID,
-		CaminoName:     CaminoID,
-		ColumbusName:   ColumbusID,
-		KopernikusName: KopernikusID,
-		TestnetName:    TestnetID,
-		UnitTestName:   UnitTestID,
-		LocalName:      LocalID,
+		MainnetName:     MainnetID,
+		FujiName:        FujiID,
+		CaminoName:      CaminoID,
+		ColumbusName:    ColumbusID,
+		KopernikusName:  KopernikusID,
+		TestnetName:     TestnetID,
+		UnitTestName:    UnitTestID,
+		LocalName:       LocalID,
+		CaminoLocalName: CaminoLocalID,
 	}
 
 	NetworkIDToHRP = map[uint32]string{
-		MainnetID:    MainnetHRP,
-		FujiID:       FujiHRP,
-		CaminoID:     CaminoHRP,
-		ColumbusID:   ColumbusHRP,
-		KopernikusID: KopernikusHRP,
-		UnitTestID:   UnitTestHRP,
-		LocalID:      LocalHRP,
+		MainnetID:     MainnetHRP,
+		FujiID:        FujiHRP,
+		CaminoID:      CaminoHRP,
+		ColumbusID:    ColumbusHRP,
+		KopernikusID:  KopernikusHRP,
+		UnitTestID:    UnitTestHRP,
+		LocalID:       LocalHRP,
+		CaminoLocalID: CaminoLocalHRP,
 	}
 	NetworkHRPToNetworkID = map[string]uint32{
 		MainnetHRP:    MainnetID,


### PR DESCRIPTION
## Description ##
This RP introduces a new networkID in the configurations (caminoLocal) and a new genesis file in order to be able to setup a local network with the latest genesis changes. In order to run the `camino-node` according to the `genesis-camino-local.json` the `network-id` argument should be set as shown here `--network-id=caminoLocal`.