### PR TITLE
Peak3d/fixes

### DIFF
--- a/api/info/service.go
+++ b/api/info/service.go
@@ -42,6 +42,8 @@ type Info struct {
 
 type Parameters struct {
 	Version                       *version.Application
+	GitVersion                    string
+	GitCommit                     string
 	NodeID                        ids.NodeID
 	NodePOP                       *signer.ProofOfPossession
 	NetworkID                     uint32
@@ -95,7 +97,10 @@ type GetNodeVersionReply struct {
 	Version            string            `json:"version"`
 	DatabaseVersion    string            `json:"databaseVersion"`
 	RPCProtocolVersion json.Uint32       `json:"rpcProtocolVersion"`
+	SdkGitCommit       string            `json:"sdkGitCommit"`
+	SdkGitVersion      string            `json:"sdkGitVersion"`
 	GitCommit          string            `json:"gitCommit"`
+	GitVersion         string            `json:"gitVersion"`
 	VMVersions         map[string]string `json:"vmVersions"`
 }
 
@@ -111,7 +116,10 @@ func (i *Info) GetNodeVersion(_ *http.Request, _ *struct{}, reply *GetNodeVersio
 	reply.Version = i.Version.String()
 	reply.DatabaseVersion = version.CurrentDatabase.String()
 	reply.RPCProtocolVersion = json.Uint32(version.RPCChainVMProtocol)
-	reply.GitCommit = version.GitCommit
+	reply.SdkGitCommit = version.GitCommit
+	reply.SdkGitVersion = version.GitVersion
+	reply.GitCommit = i.Parameters.GitCommit
+	reply.GitVersion = i.Parameters.GitVersion
 	reply.VMVersions = vmVersions
 	return nil
 }

--- a/version/constants.go
+++ b/version/constants.go
@@ -28,8 +28,9 @@ const RPCChainVMProtocol uint = 20
 
 // These are globals that describe network upgrades and node versions
 var (
-	// GitCommit will be set with -X during build step
-	GitCommit string
+	// GitCommit and GitVersion will be set with -X during build step
+	GitCommit  string = "unknown"
+	GitVersion string = "unknown"
 
 	Current = &Semantic{
 		Major: 0,


### PR DESCRIPTION
## Why this should be merged
1.) The info:GetNodeVersion now returns separated git information for camino-node and caminogo
2.) The Camino genesis flags on P-Chain has to be written into DB to make them persistent.
Because we know that depositbondmode and nodesignature flags will never change for our primary network, we write them only once.
