### PR TITLE
Add validator consortium member

### DIFF
--- a/genesis/camino_config.go
+++ b/genesis/camino_config.go
@@ -82,7 +82,7 @@ type CaminoAllocation struct {
 	ETHAddr             ids.ShortID          `json:"ethAddr"`
 	AVAXAddr            ids.ShortID          `json:"avaxAddr"`
 	XAmount             uint64               `json:"xAmount"`
-	AddressState        uint64               `json:"addressState"`
+	AddressStates       AddressStates        `json:"addressStates"`
 	PlatformAllocations []PlatformAllocation `json:"platformAllocations"`
 }
 
@@ -90,7 +90,7 @@ func (a CaminoAllocation) Unparse(networkID uint32) (UnparsedCaminoAllocation, e
 	ua := UnparsedCaminoAllocation{
 		XAmount:             a.XAmount,
 		ETHAddr:             "0x" + hex.EncodeToString(a.ETHAddr.Bytes()),
-		AddressState:        a.AddressState,
+		AddressStates:       a.AddressStates,
 		PlatformAllocations: make([]UnparsedPlatformAllocation, len(a.PlatformAllocations)),
 	}
 	avaxAddr, err := address.Format(
@@ -159,4 +159,9 @@ func (uma *UnparsedMultisigAlias) Unparse(ma genesis.MultisigAlias, networkID ui
 	uma.Threshold = ma.Threshold
 
 	return nil
+}
+
+type AddressStates struct {
+	ConsortiumMember bool `json:"consortiumMember"`
+	KYCVerified      bool `json:"kycVerified"`
 }

--- a/genesis/camino_unparsed_config.go
+++ b/genesis/camino_unparsed_config.go
@@ -64,14 +64,14 @@ type UnparsedCaminoAllocation struct {
 	ETHAddr             string                       `json:"ethAddr"`
 	AVAXAddr            string                       `json:"avaxAddr"`
 	XAmount             uint64                       `json:"xAmount"`
-	AddressState        uint64                       `json:"addressState"`
+	AddressStates       AddressStates                `json:"addressStates"`
 	PlatformAllocations []UnparsedPlatformAllocation `json:"platformAllocations"`
 }
 
 func (ua UnparsedCaminoAllocation) Parse() (CaminoAllocation, error) {
 	a := CaminoAllocation{
 		XAmount:             ua.XAmount,
-		AddressState:        ua.AddressState,
+		AddressStates:       ua.AddressStates,
 		PlatformAllocations: make([]PlatformAllocation, len(ua.PlatformAllocations)),
 	}
 

--- a/genesis/genesis_camino.json
+++ b/genesis/genesis_camino.json
@@ -55,6 +55,10 @@
         "ethAddr": "0x0000000000000000000000000000000000000000",
         "avaxAddr": "X-camino1m4nr983lhd4p4nfsqk3a6a9mejugnn73f83vuy",
         "xAmount": 989998000000000000,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
         "platformAllocations": [
           {
             "amount": 100000000000000,

--- a/genesis/genesis_columbus.json
+++ b/genesis/genesis_columbus.json
@@ -55,6 +55,10 @@
         "ethAddr": "0x0000000000000000000000000000000000000000",
         "avaxAddr": "X-columbus1m4nr983lhd4p4nfsqk3a6a9mejugnn73ju0gav",
         "xAmount": 989998000000000000,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
         "platformAllocations": [
           {
             "amount": 100000000000000,

--- a/genesis/genesis_kopernikus.json
+++ b/genesis/genesis_kopernikus.json
@@ -55,6 +55,10 @@
         "ethAddr": "0x0000000000000000000000000000000000000000",
         "avaxAddr": "X-kopernikus1m4nr983lhd4p4nfsqk3a6a9mejugnn73cmp283",
         "xAmount": 989998000000000000,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
         "platformAllocations": [
           {
             "amount": 2000000000000,

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,15 +370,15 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "HXVGhkaNMtPSp4Vbyi39FZw3UXeS17caxvQokRdzsgq3YeKpf",
+			expectedID: "2dKZjCY2DaFYGtz55XeSoSMPbbCu7mwjz4fg5FdRzKr24Dz4T8",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "QAscCpVoWHv9sWhdU5LW1vFvnF8nDFX1jD63X2W8Yk1mQMCmN",
+			expectedID: "AFXPkskaxMoq1oUNd11ePwSeHNBJLxzbb1EpoTKWszSempu7e",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "2DJUE85jeNLu3h4WkfHJSiFZbf8aeCTTsCLUYuc2TW52pmrp9y",
+			expectedID: "UJf5MUfYWoiinfpJAtkkd6iuH8u6EtkW2te7o1xDkhCnBEhR8",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/camino_helpers_test.go
+++ b/vms/platformvm/camino_helpers_test.go
@@ -146,6 +146,7 @@ func newCaminoGenesisWithUTXOs(caminoGenesisConfig api.Camino, genesisUTXOs []ap
 
 	caminoGenesisConfig.UTXODeposits = make([]ids.ID, len(genesisUTXOs))
 	caminoGenesisConfig.ValidatorDeposits = make([][]ids.ID, len(keys))
+	caminoGenesisConfig.ValidatorConsortiumMembers = make([]ids.ShortID, len(keys))
 
 	genesisValidators := make([]api.PermissionlessValidator, len(keys))
 	for i, key := range keys {
@@ -169,6 +170,7 @@ func newCaminoGenesisWithUTXOs(caminoGenesisConfig api.Camino, genesisUTXOs []ap
 			}},
 		}
 		caminoGenesisConfig.ValidatorDeposits[i] = make([]ids.ID, 1)
+		caminoGenesisConfig.ValidatorConsortiumMembers[i] = key.Address()
 	}
 
 	buildGenesisArgs := api.BuildGenesisArgs{

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -385,6 +385,7 @@ func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf api.Camino) []b
 
 	caminoGenesisConf.UTXODeposits = make([]ids.ID, len(genesisUTXOs))
 	caminoGenesisConf.ValidatorDeposits = make([][]ids.ID, len(caminoPreFundedKeys))
+	caminoGenesisConf.ValidatorConsortiumMembers = make([]ids.ShortID, len(caminoPreFundedKeys))
 
 	genesisValidators := make([]api.PermissionlessValidator, len(caminoPreFundedKeys))
 	for i, key := range caminoPreFundedKeys {
@@ -409,6 +410,7 @@ func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf api.Camino) []b
 			DelegationFee: reward.PercentDenominator,
 		}
 		caminoGenesisConf.ValidatorDeposits[i] = make([]ids.ID, 1)
+		caminoGenesisConf.ValidatorConsortiumMembers[i] = key.Address()
 	}
 
 	buildGenesisArgs := api.BuildGenesisArgs{

--- a/vms/platformvm/txs/camino_add_validator_test.go
+++ b/vms/platformvm/txs/camino_add_validator_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/nodeid"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
-	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validator"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
@@ -123,8 +122,8 @@ func TestCaminoAddValidatorTxSyntacticVerify(t *testing.T) {
 						Threshold: 1,
 						Addrs:     []ids.ShortID{ids.ShortEmpty},
 					},
-					DelegationShares: reward.PercentDenominator,
 				},
+				ConsortiumMemberAddress: caminoPreFundedKeys[0].PublicKey().Address(),
 			}
 
 			utx = tt.preExecute(t, utx)

--- a/vms/platformvm/txs/camino_address_state_tx.go
+++ b/vms/platformvm/txs/camino_address_state_tx.go
@@ -21,15 +21,18 @@ const (
 	AddressStateRoleValidatorBit = uint64(0b100)
 	AddressStateRoleBits         = uint64(0b111)
 
-	AddressStateKycVerified = 32
-	AddressStateKycExpired  = 33
-	AddressStateConsortium  = 34
-	AddressStateKycBits     = uint64(0b11100000000000000000000000000000000)
+	AddressStateKycVerified    = uint8(32)
+	AddressStateKycVerifiedBit = uint64(0b00100000000000000000000000000000000)
+	AddressStateKycExpired     = uint8(33)
+	AddressStateKycExpiredBit  = uint64(0b01000000000000000000000000000000000)
+	AddressStateConsortium     = uint8(34)
+	AddressStateConsortiumBit  = uint64(0b10000000000000000000000000000000000)
+	AddressStateKycBits        = uint64(0b11100000000000000000000000000000000)
 
-	AddressStateValidator     = 38
+	AddressStateValidator     = uint8(38)
 	AddressStateValidatorBits = uint64(0b100000000000000000000000000000000000000)
 
-	AddressStateMax       = 63
+	AddressStateMax       = uint8(63)
 	AddressStateValidBits = AddressStateRoleBits | AddressStateKycBits
 )
 

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -280,6 +280,7 @@ func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf api.Camino) []b
 
 	caminoGenesisConf.UTXODeposits = make([]ids.ID, len(genesisUTXOs))
 	caminoGenesisConf.ValidatorDeposits = make([][]ids.ID, len(caminoPreFundedKeys))
+	caminoGenesisConf.ValidatorConsortiumMembers = make([]ids.ShortID, len(caminoPreFundedKeys))
 
 	genesisValidators := make([]api.PermissionlessValidator, len(caminoPreFundedKeys))
 	for i, key := range caminoPreFundedKeys {
@@ -304,6 +305,7 @@ func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf api.Camino) []b
 			DelegationFee: reward.PercentDenominator,
 		}
 		caminoGenesisConf.ValidatorDeposits[i] = make([]ids.ID, 1)
+		caminoGenesisConf.ValidatorConsortiumMembers[i] = key.Address()
 	}
 
 	buildGenesisArgs := api.BuildGenesisArgs{
@@ -332,7 +334,7 @@ func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf api.Camino) []b
 	return genesisBytes
 }
 
-func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.UTXO {
+func generateTestUTXO(txID ids.ID, outputIndex int, assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.UTXO {
 	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
 		Amt:          amount,
 		OutputOwners: outputOwners,
@@ -347,9 +349,12 @@ func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners s
 		}
 	}
 	testUTXO := &avax.UTXO{
-		UTXOID: avax.UTXOID{TxID: txID},
-		Asset:  avax.Asset{ID: assetID},
-		Out:    out,
+		UTXOID: avax.UTXOID{
+			TxID:        txID,
+			OutputIndex: uint32(outputIndex),
+		},
+		Asset: avax.Asset{ID: assetID},
+		Out:   out,
 	}
 	testUTXO.InputID()
 	return testUTXO


### PR DESCRIPTION
All validators should be consortium members.
This PR changes addValidatorTx, so it will specify consortium member address owning this validator. Transactions execution then will check if this address is actually consortium member and will also check, that transaction is signed by this address.
Because this adds new arg to transaction creation, this PR also modifies genesis add validator transactions generation, updates affected tests, adds new service rpc handler to camino service and adds new method to caminoBuilder that support this arg.
This PR also fixes bugs:
- 0 validator stake transactions created by rpc handler - now it uses fixed validator stake amount
- untyped AddressState constants allowed some invalid tests to exist, now they no more
- camino reward validator tests minor bugs with utxo outputIndex and owners