### PR TITLE
Peak3d/pvmapi

### DIFF
--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -164,6 +164,10 @@ type GetConfigurationReply struct {
 	SupplyCap utilsjson.Uint64 `json:"supplyCap"`
 	// The codec version used for serializing
 	CodecVersion utilsjson.Uint16 `json:"codecVersion"`
+	// Camino VerifyNodeSignature
+	VerifyNodeSignature bool `json:"verifyNodeSignature"`
+	// Camino LockModeBondDeposit
+	LockModeBondDeposit bool `json:"lockModeBondDeposit"`
 }
 
 // GetMinStake returns the minimum staking amount in nAVAX.
@@ -200,6 +204,13 @@ func (s *CaminoService) GetConfiguration(_ *http.Request, _ *struct{}, reply *Ge
 
 	// Codec information
 	reply.CodecVersion = utilsjson.Uint16(txs.Version)
+
+	caminoConfig, err := s.vm.state.CaminoConfig()
+	if err != nil {
+		return err
+	}
+	reply.VerifyNodeSignature = caminoConfig.VerifyNodeSignature
+	reply.LockModeBondDeposit = caminoConfig.LockModeBondDeposit
 
 	return nil
 }

--- a/vms/platformvm/camino_service_test.go
+++ b/vms/platformvm/camino_service_test.go
@@ -153,13 +153,13 @@ func TestGetCaminoBalance(t *testing.T) {
 			expectedBalance := json.Uint64(defaultBalance + tt.bonded + tt.deposited + tt.depositedBonded)
 
 			if !tt.camino.LockModeBondDeposit {
-				response := responseWrapper.GetBalanceResponse
+				response := responseWrapper.avax
 				require.Equal(t, json.Uint64(defaultBalance), response.Balance, "Wrong balance. Expected %d ; Returned %d", json.Uint64(defaultBalance), response.Balance)
 				require.Equal(t, json.Uint64(0), response.LockedStakeable, "Wrong locked stakeable balance. Expected %d ; Returned %d", 0, response.LockedStakeable)
 				require.Equal(t, json.Uint64(0), response.LockedNotStakeable, "Wrong locked not stakeable balance. Expected %d ; Returned %d", 0, response.LockedNotStakeable)
 				require.Equal(t, json.Uint64(defaultBalance), response.Unlocked, "Wrong unlocked balance. Expected %d ; Returned %d", defaultBalance, response.Unlocked)
 			} else {
-				response := responseWrapper.GetBalanceResponseV2
+				response := responseWrapper.camino
 				require.Equal(t, json.Uint64(defaultBalance+tt.bonded+tt.deposited+tt.depositedBonded), response.Balances[avaxAssetID], "Wrong balance. Expected %d ; Returned %d", expectedBalance, response.Balances[avaxAssetID])
 				require.Equal(t, json.Uint64(tt.deposited), response.DepositedOutputs[avaxAssetID], "Wrong deposited balance. Expected %d ; Returned %d", tt.deposited, response.DepositedOutputs[avaxAssetID])
 				require.Equal(t, json.Uint64(tt.depositedBonded), response.DepositedBondedOutputs[avaxAssetID], "Wrong depositedBonded balance. Expected %d ; Returned %d", tt.depositedBonded, response.DepositedBondedOutputs[avaxAssetID])


### PR DESCRIPTION
This PR addresses 2 topics related to PVM API:

1. Fix: GetBalance doesn't return UTXO IDs even they are collected.
Cleanup: of GetBalanceReply which to resolve linter warning because of duplicate Balance field

2. Provide VerifyNodeSignature  and LockModeBondDeposit in GetConfigurationReply to allow clients building proper TX