### PR TITLE
Add ClaimRewardTx for deposit

### DIFF
--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -18,4 +18,12 @@ type CaminoFx interface {
 	// can't spend the output based on the input and credential, a non-nil error
 	// should be returned. Multisig aliases supported.
 	VerifyMultisigTransfer(txIntf, inIntf, credIntf, utxoIntf, msigIntf interface{}) error
+
+	// VerifyPermission returns nil if credential [credIntf] proves that [controlGroup] assents to transaction [utx].
+	// [credIntf] signatures order doesn't matter, it could also contain unrelated signatures to [controlGroup].
+	VerifyPermissionUnordered(
+		utx secp256k1fx.UnsignedTx,
+		credIntf verify.Verifiable,
+		controlGroup interface{},
+	) error
 }

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -167,6 +167,20 @@ func (mr *MockFxMockRecorder) VerifyTransfer(arg0, arg1, arg2, arg3 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyTransfer", reflect.TypeOf((*MockFx)(nil).VerifyTransfer), arg0, arg1, arg2, arg3)
 }
 
+// VerifyPermissionUnordered mocks base method.
+func (m *MockFx) VerifyPermissionUnordered(arg0 secp256k1fx.UnsignedTx, arg1 verify.Verifiable, arg2 interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyPermissionUnordered", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyPermissionUnordered indicates an expected call of VerifyPermissionUnordered.
+func (mr *MockFxMockRecorder) VerifyPermissionUnordered(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyPermissionUnordered", reflect.TypeOf((*MockFx)(nil).VerifyPermissionUnordered), arg0, arg1, arg2)
+}
+
 // MockOwner is a mock of Owner interface.
 type MockOwner struct {
 	ctrl     *gomock.Controller

--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -16,7 +16,8 @@ type caminoTxMetrics struct {
 	numAddressStateTxs,
 	numDepositTxs,
 	numUnlockDepositTxs,
-	numRegisterNodeTx prometheus.Counter
+	numClaimRewardTxs,
+	numRegisterNodeTxs prometheus.Counter
 }
 
 func newCaminoTxMetrics(
@@ -35,7 +36,8 @@ func newCaminoTxMetrics(
 		numAddressStateTxs:  newTxMetric(namespace, "add_address_state", registerer, &errs),
 		numDepositTxs:       newTxMetric(namespace, "deposit", registerer, &errs),
 		numUnlockDepositTxs: newTxMetric(namespace, "unlock_deposit", registerer, &errs),
-		numRegisterNodeTx:   newTxMetric(namespace, "register_node", registerer, &errs),
+		numClaimRewardTxs:   newTxMetric(namespace, "claim_reward", registerer, &errs),
+		numRegisterNodeTxs:  newTxMetric(namespace, "register_node", registerer, &errs),
 	}
 	return m, errs.Err
 }
@@ -51,6 +53,10 @@ func (*txMetrics) DepositTx(*txs.DepositTx) error {
 }
 
 func (*txMetrics) UnlockDepositTx(*txs.UnlockDepositTx) error {
+	return nil
+}
+
+func (*txMetrics) ClaimRewardTx(*txs.ClaimRewardTx) error {
 	return nil
 }
 
@@ -75,7 +81,12 @@ func (m *caminoTxMetrics) UnlockDepositTx(*txs.UnlockDepositTx) error {
 	return nil
 }
 
+func (m *caminoTxMetrics) ClaimRewardTx(*txs.ClaimRewardTx) error {
+	m.numClaimRewardTxs.Inc()
+	return nil
+}
+
 func (m *caminoTxMetrics) RegisterNodeTx(*txs.RegisterNodeTx) error {
-	m.numRegisterNodeTx.Inc()
+	m.numRegisterNodeTxs.Inc()
 	return nil
 }

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validator"
@@ -27,6 +28,9 @@ var (
 
 	errKeyMissing       = errors.New("couldn't find key matching address")
 	errWrongNodeKeyType = errors.New("node key type isn't *crypto.PrivateKeySECP256K1R")
+	errTxIsNotCommitted = errors.New("tx is not committed")
+	errNotSECPOwner     = errors.New("owner is not *secp256k1fx.OutputOwners")
+	errWrongTxType      = errors.New("wrong transaction type")
 )
 
 type CaminoBuilder interface {
@@ -55,6 +59,13 @@ type CaminoTxBuilder interface {
 
 	NewUnlockDepositTx(
 		lockTxIDs []ids.ID,
+		keys []*crypto.PrivateKeySECP256K1R,
+		change *secp256k1fx.OutputOwners,
+	) (*txs.Tx, error)
+
+	NewClaimRewardTx(
+		depositTxIDs []ids.ID,
+		rewardAddress ids.ShortID,
 		keys []*crypto.PrivateKeySECP256K1R,
 		change *secp256k1fx.OutputOwners,
 	) (*txs.Tx, error)
@@ -347,6 +358,59 @@ func (b *caminoBuilder) NewUnlockDepositTx(
 	return tx, tx.SyntacticVerify(b.ctx)
 }
 
+func (b *caminoBuilder) NewClaimRewardTx(
+	depositTxIDs []ids.ID,
+	rewardAddress ids.ShortID,
+	keys []*crypto.PrivateKeySECP256K1R,
+	change *secp256k1fx.OutputOwners,
+) (*txs.Tx, error) {
+	ins, outs, signers, err := b.Lock(keys, 0, b.cfg.TxFee, locked.StateUnlocked, nil, change, 0)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
+	}
+
+	kc := secp256k1fx.NewKeychain(keys...)
+	depositSignersKC := secp256k1fx.NewKeychain()
+
+	for _, depositTxID := range depositTxIDs {
+		depositRewardsOwner, err := getDepositRewardsOwner(b.state, depositTxID)
+		if err != nil {
+			return nil, err
+		}
+
+		_, signers, able := kc.Match(depositRewardsOwner, b.clk.Unix())
+		if !able {
+			return nil, errKeyMissing
+		}
+
+		for _, signer := range signers {
+			depositSignersKC.Add(signer)
+		}
+	}
+
+	signers = append(signers, depositSignersKC.Keys)
+
+	utx := &txs.ClaimRewardTx{
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.ctx.NetworkID,
+			BlockchainID: b.ctx.ChainID,
+			Ins:          ins,
+			Outs:         outs,
+		}},
+		DepositTxs: depositTxIDs,
+		RewardsOwner: &secp256k1fx.OutputOwners{
+			Threshold: 1,
+			Addrs:     []ids.ShortID{rewardAddress},
+		},
+	}
+
+	tx, err := txs.NewSigned(utx, txs.Codec, signers)
+	if err != nil {
+		return nil, err
+	}
+	return tx, tx.SyntacticVerify(b.ctx)
+}
+
 func (b *caminoBuilder) NewRegisterNodeTx(
 	oldNodeID ids.NodeID,
 	newNodeID ids.NodeID,
@@ -431,4 +495,25 @@ func getSigners(
 		signers[i] = key
 	}
 	return signers, nil
+}
+
+func getDepositRewardsOwner(state state.Chain, depositTxID ids.ID) (*secp256k1fx.OutputOwners, error) {
+	signedDepositTx, txStatus, err := state.GetTx(depositTxID)
+	if err != nil {
+		return nil, err
+	}
+	if txStatus != status.Committed {
+		return nil, errTxIsNotCommitted
+	}
+	depositTx, ok := signedDepositTx.Unsigned.(*txs.DepositTx)
+	if !ok {
+		return nil, errWrongTxType
+	}
+
+	depositRewardsOwner, ok := depositTx.RewardsOwner.(*secp256k1fx.OutputOwners)
+	if !ok {
+		return nil, errNotSECPOwner
+	}
+
+	return depositRewardsOwner, nil
 }

--- a/vms/platformvm/txs/camino_claim_reward_tx.go
+++ b/vms/platformvm/txs/camino_claim_reward_tx.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
+)
+
+var (
+	_ UnsignedTx = (*ClaimRewardTx)(nil)
+
+	errNoDeposits           = errors.New("no deposit txs to claim reward from")
+	errNonUniqueDepositTxID = errors.New("non-unique deposit tx id")
+)
+
+// ClaimRewardTx is an unsigned claimRewardTx
+type ClaimRewardTx struct {
+	// Metadata, inputs and outputs
+	BaseTx `serialize:"true"`
+	// IDs of deposit txs which will be used to claim rewards
+	DepositTxs []ids.ID `serialize:"true"`
+	// Rewards will be minted to this owner, unless all of its fields has zero-values.
+	// If it is empty, rewards will be minted for depositTx.RewardsOwner.
+	RewardsOwner fx.Owner `serialize:"true" json:"rewardsOwner"`
+}
+
+// InitCtx sets the FxID fields in the inputs and outputs of this
+// [ClaimRewardTx]. Also sets the [ctx] to the given [vm.ctx] so that
+// the addresses can be json marshalled into human readable format
+func (tx *ClaimRewardTx) InitCtx(ctx *snow.Context) {
+	tx.BaseTx.InitCtx(ctx)
+	tx.RewardsOwner.InitCtx(ctx)
+}
+
+// SyntacticVerify returns nil if [tx] is valid
+func (tx *ClaimRewardTx) SyntacticVerify(ctx *snow.Context) error {
+	switch {
+	case tx == nil:
+		return ErrNilTx
+	case tx.SyntacticallyVerified: // already passed syntactic verification
+		return nil
+	case len(tx.DepositTxs) == 0:
+		return errNoDeposits
+	}
+
+	uniqueDeposits := set.NewSet[ids.ID](len(tx.DepositTxs))
+	for _, depositTxID := range tx.DepositTxs {
+		if _, ok := uniqueDeposits[depositTxID]; ok {
+			return errNonUniqueDepositTxID
+		}
+		uniqueDeposits.Add(depositTxID)
+	}
+
+	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {
+		return fmt.Errorf("failed to verify BaseTx: %w", err)
+	}
+	if err := verify.All(tx.RewardsOwner); err != nil {
+		return fmt.Errorf("failed to verify validator or rewards owner: %w", err)
+	}
+
+	// cache that this is valid
+	tx.SyntacticallyVerified = true
+	return nil
+}
+
+func (tx *ClaimRewardTx) Visit(visitor Visitor) error {
+	return visitor.ClaimRewardTx(tx)
+}

--- a/vms/platformvm/txs/camino_visitor.go
+++ b/vms/platformvm/txs/camino_visitor.go
@@ -7,5 +7,6 @@ type CaminoVisitor interface {
 	AddressStateTx(*AddressStateTx) error
 	DepositTx(*DepositTx) error
 	UnlockDepositTx(*UnlockDepositTx) error
+	ClaimRewardTx(*ClaimRewardTx) error
 	RegisterNodeTx(*RegisterNodeTx) error
 }

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -115,6 +115,7 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&RegisterNodeTx{}),
 		targetCodec.RegisterCustomType(&BaseTx{}),
 		targetCodec.RegisterCustomType(&MultisigAliasTx{}),
+		targetCodec.RegisterCustomType(&ClaimRewardTx{}),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/golang/mock/gomock"
 
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
@@ -38,7 +39,7 @@ func TestCaminoEnv(t *testing.T) {
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
 	}
-	env := newCaminoEnvironment( /*postBanff*/ false, caminoGenesisConf)
+	env := newCaminoEnvironment( /*postBanff*/ false, true, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
 		err := shutdownCaminoEnvironment(env)
@@ -52,7 +53,7 @@ func TestCaminoStandardTxExecutorAddValidatorTx(t *testing.T) {
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
 	}
-	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+	env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
 		if err := shutdownCaminoEnvironment(env); err != nil {
@@ -296,7 +297,7 @@ func TestCaminoStandardTxExecutorAddSubnetValidatorTx(t *testing.T) {
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
 	}
-	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+	env := newCaminoEnvironment( /*postBanff*/ true, true, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
 		if err := shutdownCaminoEnvironment(env); err != nil {
@@ -578,7 +579,7 @@ func TestCaminoStandardTxExecutorAddValidatorTxBody(t *testing.T) {
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
 	}
-	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+	env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
 		if err := shutdownCaminoEnvironment(env); err != nil {
@@ -858,7 +859,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run("ExportTx "+name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				err := shutdownCaminoEnvironment(env)
@@ -908,7 +909,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 		})
 
 		t.Run("ImportTx "+name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				err := shutdownCaminoEnvironment(env)
@@ -936,7 +937,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 		})
 
 		t.Run("AddressStateTx "+name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				err := shutdownCaminoEnvironment(env)
@@ -963,7 +964,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 		})
 
 		t.Run("CreateChainTx "+name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				err := shutdownCaminoEnvironment(env)
@@ -989,7 +990,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 		})
 
 		t.Run("CreateSubnetTx "+name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				err := shutdownCaminoEnvironment(env)
@@ -1014,7 +1015,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 		})
 
 		t.Run("TransformSubnetTx "+name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				err := shutdownCaminoEnvironment(env)
@@ -1041,7 +1042,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 		})
 
 		t.Run("AddSubnetValidatorTx "+name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				err := shutdownCaminoEnvironment(env)
@@ -1075,7 +1076,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 		})
 
 		t.Run("RemoveSubnetValidatorTx "+name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				err := shutdownCaminoEnvironment(env)
@@ -1211,7 +1212,7 @@ func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoConfig)
+			env := newCaminoEnvironment( /*postBanff*/ true, true, tt.caminoConfig, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				if err := shutdownCaminoEnvironment(env); err != nil {
@@ -1281,7 +1282,7 @@ func TestCaminoRewardValidatorTx(t *testing.T) {
 		LockModeBondDeposit: true,
 	}
 
-	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+	env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	env.config.BanffTime = env.state.GetTimestamp()
 
@@ -1323,6 +1324,7 @@ func TestCaminoRewardValidatorTx(t *testing.T) {
 	}
 
 	tests := map[string]test{
+		// TODO@ ok case!
 		"Reward before end time": {
 			ins:        ins,
 			outs:       outs,
@@ -1353,7 +1355,7 @@ func TestCaminoRewardValidatorTx(t *testing.T) {
 			generateUTXOsAfterReward: func(txID ids.ID) []*avax.UTXO {
 				return utxosBeforeReward
 			},
-			expectedErr: errWrongNumberOfCredentials,
+			expectedErr: errWrongCredentialsNumber,
 		},
 		"Invalid inputs (one excess)": {
 			ins:        append(ins, &avax.TransferableInput{In: &secp256k1fx.TransferInput{}}),
@@ -1529,7 +1531,7 @@ func TestCaminoRewardValidatorTx(t *testing.T) {
 	})
 
 	// We need to start again the environment because the staker is already removed from the previous test
-	env = newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+	env = newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	env.config.BanffTime = env.state.GetTimestamp()
 
@@ -1554,7 +1556,7 @@ func TestAddAdressStateTxExecutor(t *testing.T) {
 		LockModeBondDeposit: true,
 	}
 
-	env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+	env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
 		err := shutdownCaminoEnvironment(env)
@@ -2448,7 +2450,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, tt.caminoGenesisConf)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, tt.caminoGenesisConf, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				if err := shutdownCaminoEnvironment(env); err != nil {
@@ -3053,7 +3055,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			env := newCaminoEnvironment( /*postBanff*/ true, caminoGenesisConf)
+			env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
 			env.ctx.Lock.Lock()
 			defer func() {
 				if err = shutdownCaminoEnvironment(env); err != nil {
@@ -3100,6 +3102,208 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 
 			err = tx.Unsigned.Visit(&executor)
 			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestCaminoStandardTxExecutorClaimRewardTx(t *testing.T) {
+	feeOwnerKey, feeOwnerAddr, feeOwner := generateKeyAndOwner(t)
+	rewardOwnerKey, _, rewardOwner := generateKeyAndOwner(t)
+	sigIndices := []uint32{0}
+	feeSigners := []*crypto.PrivateKeySECP256K1R{feeOwnerKey}
+	feeUTXO := generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee, feeOwner, ids.Empty, ids.Empty)
+	feeInput := generateTestInFromUTXO(feeUTXO, sigIndices)
+	depositTxID := ids.GenerateTestID()
+	timestamp := time.Now()
+
+	caminoGenesisConf := api.Camino{
+		VerifyNodeSignature: true,
+		LockModeBondDeposit: true,
+	}
+
+	baseState := func(c *gomock.Controller) *state.MockState {
+		s := state.NewMockState(c)
+		// shutdown
+		s.EXPECT().SetHeight(uint64(math.MaxUint64))
+		s.EXPECT().Commit()
+		s.EXPECT().Close()
+		return s
+	}
+
+	tests := map[string]struct {
+		state        func(*gomock.Controller, ids.ID) *state.MockDiff
+		baseState    func(*gomock.Controller, *state.MockState) *state.MockState
+		ins          []*avax.TransferableInput
+		signers      [][]*crypto.PrivateKeySECP256K1R
+		outs         []*avax.TransferableOutput
+		depositTxIDs []ids.ID
+		expectedErr  error
+	}{
+		"Stakeable ins": {
+			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				return s
+			},
+			ins: []*avax.TransferableInput{
+				generateTestStakeableIn(avaxAssetID, 1, uint64(defaultMinStakingDuration), sigIndices),
+			},
+			expectedErr: locked.ErrWrongInType,
+		},
+		"Stakeable outs": {
+			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				return s
+			},
+			ins: []*avax.TransferableInput{feeInput},
+			outs: []*avax.TransferableOutput{
+				generateTestStakeableOut(avaxAssetID, 1, uint64(defaultMinStakingDuration), feeOwner),
+			},
+			expectedErr: locked.ErrWrongOutType,
+		},
+		"Deposit not found": {
+			baseState: func(c *gomock.Controller, s *state.MockState) *state.MockState {
+				// utxo handler, used in fx VerifyMultisigTransfer method,
+				s.EXPECT().GetMultisigAlias(feeOwnerAddr).Return(nil, database.ErrNotFound)
+				return s
+			},
+			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
+				s.EXPECT().GetTimestamp().Return(timestamp)
+				s.EXPECT().GetTx(depositTxID).Return(nil, status.Unknown, database.ErrNotFound)
+				return s
+			},
+			ins:          []*avax.TransferableInput{feeInput},
+			signers:      [][]*crypto.PrivateKeySECP256K1R{feeSigners, {}},
+			depositTxIDs: []ids.ID{depositTxID},
+			expectedErr:  errDepositNotFound,
+		},
+		"Bad deposit credential": {
+			baseState: func(c *gomock.Controller, s *state.MockState) *state.MockState {
+				// utxo handler, used in fx VerifyMultisigTransfer method,
+				s.EXPECT().GetMultisigAlias(feeOwnerAddr).Return(nil, database.ErrNotFound)
+				return s
+			},
+			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
+				s.EXPECT().GetTimestamp().Return(timestamp)
+				s.EXPECT().GetTx(depositTxID).Return(
+					&txs.Tx{Unsigned: &txs.DepositTx{
+						RewardsOwner: &rewardOwner,
+					}},
+					status.Committed,
+					nil,
+				)
+				return s
+			},
+			ins:          []*avax.TransferableInput{feeInput},
+			signers:      [][]*crypto.PrivateKeySECP256K1R{feeSigners, {}},
+			depositTxIDs: []ids.ID{depositTxID},
+			expectedErr:  errDepositCredentialMissmatch,
+		},
+		"OK": {
+			baseState: func(c *gomock.Controller, s *state.MockState) *state.MockState {
+				// utxo handler, used in fx VerifyMultisigTransfer method,
+				s.EXPECT().GetMultisigAlias(feeOwnerAddr).Return(nil, database.ErrNotFound)
+				return s
+			},
+			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
+				s.EXPECT().GetTimestamp().Return(timestamp)
+				s.EXPECT().GetTx(depositTxID).Return(
+					&txs.Tx{Unsigned: &txs.DepositTx{
+						RewardsOwner: &rewardOwner,
+					}},
+					status.Committed,
+					nil,
+				)
+
+				depositOfferID := ids.GenerateTestID()
+
+				s.EXPECT().GetDeposit(depositTxID).Return(&deposits.Deposit{
+					DepositOfferID:      depositOfferID,
+					Start:               uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
+					Duration:            365 * 24 * 60 * 60,                        // 1 year
+					Amount:              10,
+					ClaimedRewardAmount: 0, // TODO@ add for complexity ?
+				}, nil)
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
+					NoRewardsPeriodDuration: 0,         // TODO@ add for complexity ?
+					InterestRateNominator:   1_000_000, // 100%
+				}, nil)
+
+				rewardUTXO := &avax.UTXO{
+					UTXOID: avax.UTXOID{
+						TxID:        txID,
+						OutputIndex: 0,
+					},
+					Asset: avax.Asset{ID: avaxAssetID},
+					Out: &secp256k1fx.TransferOutput{
+						Amt:          5, // expected claimable reward amount
+						OutputOwners: rewardOwner,
+					},
+				}
+
+				s.EXPECT().AddUTXO(rewardUTXO)
+				s.EXPECT().AddRewardUTXO(depositTxID, rewardUTXO)
+				s.EXPECT().DeleteUTXO(feeUTXO.InputID())
+				return s
+			},
+			ins:          []*avax.TransferableInput{feeInput},
+			signers:      [][]*crypto.PrivateKeySECP256K1R{feeSigners, {rewardOwnerKey}},
+			depositTxIDs: []ids.ID{depositTxID},
+			expectedErr:  nil,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			state := baseState(ctrl)
+			if tt.baseState != nil {
+				state = tt.baseState(ctrl, state)
+			}
+			env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, state)
+			defer require.NoError(shutdownCaminoEnvironment(env))
+			env.ctx.Lock.Lock()
+
+			// generating tx
+
+			avax.SortTransferableInputsWithSigners(tt.ins, tt.signers)
+			avax.SortTransferableOutputs(tt.outs, txs.Codec)
+
+			utx := &txs.ClaimRewardTx{
+				BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    env.backend.Ctx.NetworkID,
+					BlockchainID: env.backend.Ctx.ChainID,
+					Ins:          tt.ins,
+					Outs:         tt.outs,
+				}},
+				DepositTxs:   tt.depositTxIDs,
+				RewardsOwner: &secp256k1fx.OutputOwners{},
+			}
+
+			tx, err := txs.NewSigned(utx, txs.Codec, tt.signers)
+			require.NoError(err)
+
+			// testing
+
+			err = tx.Unsigned.Visit(&CaminoStandardTxExecutor{
+				StandardTxExecutor{
+					Backend: &env.backend,
+					State:   tt.state(ctrl, tx.ID()),
+					Tx:      tx,
+				},
+			})
+			require.ErrorIs(err, tt.expectedErr)
 		})
 	}
 }

--- a/vms/platformvm/txs/executor/camino_visitor.go
+++ b/vms/platformvm/txs/executor/camino_visitor.go
@@ -21,6 +21,10 @@ func (*StandardTxExecutor) UnlockDepositTx(*txs.UnlockDepositTx) error {
 	return errWrongTxType
 }
 
+func (*StandardTxExecutor) ClaimRewardTx(*txs.ClaimRewardTx) error {
+	return errWrongTxType
+}
+
 func (*StandardTxExecutor) RegisterNodeTx(*txs.RegisterNodeTx) error {
 	return errWrongTxType
 }
@@ -36,6 +40,10 @@ func (*ProposalTxExecutor) DepositTx(*txs.DepositTx) error {
 }
 
 func (*ProposalTxExecutor) UnlockDepositTx(*txs.UnlockDepositTx) error {
+	return errWrongTxType
+}
+
+func (*ProposalTxExecutor) ClaimRewardTx(*txs.ClaimRewardTx) error {
 	return errWrongTxType
 }
 
@@ -57,6 +65,10 @@ func (*AtomicTxExecutor) UnlockDepositTx(*txs.UnlockDepositTx) error {
 	return errWrongTxType
 }
 
+func (*AtomicTxExecutor) ClaimRewardTx(*txs.ClaimRewardTx) error {
+	return errWrongTxType
+}
+
 func (*AtomicTxExecutor) RegisterNodeTx(*txs.RegisterNodeTx) error {
 	return errWrongTxType
 }
@@ -72,6 +84,10 @@ func (v *MempoolTxVerifier) DepositTx(tx *txs.DepositTx) error {
 }
 
 func (v *MempoolTxVerifier) UnlockDepositTx(tx *txs.UnlockDepositTx) error {
+	return v.standardTx(tx)
+}
+
+func (v *MempoolTxVerifier) ClaimRewardTx(tx *txs.ClaimRewardTx) error {
 	return v.standardTx(tx)
 }
 

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -24,6 +24,11 @@ func (i *issuer) UnlockDepositTx(*txs.UnlockDepositTx) error {
 	return nil
 }
 
+func (i *issuer) ClaimRewardTx(*txs.ClaimRewardTx) error {
+	i.m.addDecisionTx(i.tx)
+	return nil
+}
+
 func (i *issuer) RegisterNodeTx(*txs.RegisterNodeTx) error {
 	i.m.addDecisionTx(i.tx)
 	return nil
@@ -42,6 +47,11 @@ func (r *remover) DepositTx(*txs.DepositTx) error {
 }
 
 func (r *remover) UnlockDepositTx(*txs.UnlockDepositTx) error {
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
+	return nil
+}
+
+func (r *remover) ClaimRewardTx(*txs.ClaimRewardTx) error {
 	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -1310,7 +1310,7 @@ func (h *handler) isMultisigTransferOutput(out verify.State) bool {
 	// ! because currently there is no support for adding new msig aliases after genesis,
 	// ! we assume that state diffs won't contain any changes to msig aliases state
 	// ! that must be changed later
-	state, ok := h.utxosReader.(state.State)
+	state, ok := h.utxosReader.(state.CaminoDiff)
 	if !ok {
 		return false
 	}

--- a/vms/secp256k1fx/camino_fx_test.go
+++ b/vms/secp256k1fx/camino_fx_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package secp256k1fx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ava-labs/avalanchego/codec/linearcodec"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/hashing"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyPermissionUnordered(t *testing.T) {
+	tx := &TestTx{}
+
+	key1, addr1 := generateKey(t)
+	key2, addr2 := generateKey(t)
+
+	tests := map[string]struct {
+		tx          UnsignedTx
+		owner       interface{}
+		signers     []*crypto.PrivateKeySECP256K1R
+		expectedErr error
+	}{
+		"OK, 1 addr": {
+			tx:      tx,
+			signers: []*crypto.PrivateKeySECP256K1R{key1},
+			owner: &OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{addr1},
+			},
+		},
+		"OK, 2 addr": {
+			tx:      tx,
+			signers: []*crypto.PrivateKeySECP256K1R{key2, key1},
+			owner: &OutputOwners{
+				Threshold: 2,
+				Addrs:     []ids.ShortID{addr1, addr2},
+			},
+		},
+		"Fail: to few sigs": {
+			tx:      tx,
+			signers: []*crypto.PrivateKeySECP256K1R{key1},
+			owner: &OutputOwners{
+				Threshold: 2,
+				Addrs:     []ids.ShortID{addr1, addr2},
+			},
+			expectedErr: errTooFewSigners,
+		},
+		"Fail: wrong sig": {
+			tx:      tx,
+			signers: []*crypto.PrivateKeySECP256K1R{key2},
+			owner: &OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{addr1},
+			},
+			expectedErr: errTooFewSigners,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			fx := defaultFx(t)
+
+			// generating credential
+
+			txHash := hashing.ComputeHash256(tt.tx.Bytes())
+			cred := &Credential{Sigs: make([][crypto.SECP256K1RSigLen]byte, len(tt.signers))}
+
+			for i, key := range tt.signers {
+				sig, err := key.SignHash(txHash)
+				require.NoError(err)
+				copy(cred.Sigs[i][:], sig)
+			}
+
+			// testing
+
+			err := fx.VerifyPermissionUnordered(tt.tx, cred, tt.owner)
+			require.ErrorIs(err, tt.expectedErr)
+		})
+	}
+}
+
+func defaultFx(t *testing.T) *Fx {
+	require := require.New(t)
+	vm := TestVM{
+		Codec: linearcodec.NewDefault(),
+		Log:   logging.NoLog{},
+	}
+	date := time.Date(2019, time.January, 19, 16, 25, 17, 3, time.UTC)
+	vm.Clk.Set(date)
+	fx := Fx{}
+	require.NoError(fx.Initialize(&vm))
+	require.NoError(fx.Bootstrapping())
+	require.NoError(fx.Bootstrapped())
+	return &fx
+}
+
+func generateKey(t *testing.T) (*crypto.PrivateKeySECP256K1R, ids.ShortID) {
+	require := require.New(t)
+	secpFactory := crypto.FactorySECP256K1R{}
+	key, err := secpFactory.NewPrivateKey()
+	require.NoError(err)
+
+	secpKey, ok := key.(*crypto.PrivateKeySECP256K1R)
+	require.True(ok)
+
+	return secpKey, secpKey.Address()
+}

--- a/wallet/chain/p/camino_visitor.go
+++ b/wallet/chain/p/camino_visitor.go
@@ -22,6 +22,10 @@ func (b *backendVisitor) UnlockDepositTx(tx *txs.UnlockDepositTx) error {
 	return b.baseTx(&tx.BaseTx)
 }
 
+func (b *backendVisitor) ClaimRewardTx(tx *txs.ClaimRewardTx) error {
+	return b.baseTx(&tx.BaseTx)
+}
+
 func (b *backendVisitor) RegisterNodeTx(tx *txs.RegisterNodeTx) error {
 	return b.baseTx(&tx.BaseTx)
 }
@@ -45,6 +49,14 @@ func (s *signerVisitor) DepositTx(tx *txs.DepositTx) error {
 }
 
 func (s *signerVisitor) UnlockDepositTx(tx *txs.UnlockDepositTx) error {
+	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
+	if err != nil {
+		return err
+	}
+	return sign(s.tx, txSigners)
+}
+
+func (s *signerVisitor) ClaimRewardTx(tx *txs.ClaimRewardTx) error {
 	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR adds claimRewardTx, which mint reward outputs for specified deposit transactions.

ClaimRewardTx must have additional credential for deposit transactions. This credential must contain signatures for all deposit transaction reward owners, order doesn't matter.

Reward outputs will be owned by claimRewardTx.RewardOwner, unless its empty. If it is empty, reward output will be owned by depositTx.RewardOwner.