### PR TITLE
Omit empty values in platform allocations

### DIFF
--- a/genesis/camino_unparsed_config.go
+++ b/genesis/camino_unparsed_config.go
@@ -118,8 +118,8 @@ func (ua UnparsedCaminoAllocation) Parse() (CaminoAllocation, error) {
 
 type UnparsedPlatformAllocation struct {
 	Amount            uint64 `json:"amount"`
-	NodeID            string `json:"nodeID"`
-	ValidatorDuration uint64 `json:"validatorDuration"`
+	NodeID            string `json:"nodeID,omitempty"`
+	ValidatorDuration uint64 `json:"validatorDuration,omitempty"`
 	DepositOfferID    string `json:"depositOfferID"`
 }
 


### PR DESCRIPTION
## Why this should be merged
This fix omits empty values in generated genesis file and reduce the bloat.

## How this works
It omits empty fields by apply standard json marshalling tags on structure's fields

## How this was tested
New genesis file was generated. https://github.com/chain4travel/camino-node/pull/38/commits/92c5399777d727b1989f2ac1e78bdee0d3ee3cae