### PR TITLE
swapped order of genesis sync: first goes avax, then camino

### DIFF
--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1480,11 +1480,11 @@ func (s *state) init(genesisBytes []byte) error {
 		return err
 	}
 
-	if err := s.caminoState.SyncGenesis(s, genesisState); err != nil {
+	if err := s.syncGenesis(genesisBlock, genesisState); err != nil {
 		return err
 	}
 
-	if err := s.syncGenesis(genesisBlock, genesisState); err != nil {
+	if err := s.caminoState.SyncGenesis(s, genesisState); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Camino state genesis sync overwrite supply, because avax state genesis sync adds avax validator rewards to supply - we don't want them.
Avax state genesis sync also overwrites supply, and this is no good, because camino state genesis sync adds deposit rewards to supply - we do want them.
This PR changes the order of avax/camino state genesis sync funcs execution - camino will be executed last.