### PR TITLE
Validate camino config tests + camino genesis tests

### DIFF
--- a/genesis/camino_genesis_test.go
+++ b/genesis/camino_genesis_test.go
@@ -82,11 +82,7 @@ func TestValidateCaminoConfig(t *testing.T) {
 					return &thisConfig
 				}(),
 			},
-			err: fmt.Errorf(
-				"deposit offer starttime (%v) is not before its endtime (%v)",
-				2,
-				1,
-			),
+			err: fmt.Errorf(genesis.ErrDepositOfferStartTime, 2, 1),
 		},
 		"invalid deposit offer duplicate": {
 			args: args{
@@ -215,7 +211,8 @@ func TestBuildCaminoGenesis(t *testing.T) {
 	cfg := defaultConfig()
 
 	addrs := set.Set[ids.ShortID]{}
-	_, _, avaxAddrBytes, _ := address.Parse(initialAdmin)
+	_, _, avaxAddrBytes, err := address.Parse(initialAdmin)
+	require.NoError(t, err)
 	avaxAddr, _ := ids.ToShortID(avaxAddrBytes)
 	addrs.Add(avaxAddr)
 	outputOwners := secp256k1fx.OutputOwners{
@@ -281,7 +278,10 @@ func TestBuildCaminoGenesis(t *testing.T) {
 
 func getGenesisOffer(id ids.ID, offers []genesis.DepositOffer) genesis.DepositOffer {
 	for _, do := range offers {
-		doID, _ := do.ID()
+		doID, err := do.ID()
+		if err != nil {
+			panic(err)
+		}
 		if doID == id {
 			return do
 		}

--- a/genesis/camino_genesis_test.go
+++ b/genesis/camino_genesis_test.go
@@ -1,0 +1,290 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesis
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/avalanchego/database/memdb"
+	"github.com/ava-labs/avalanchego/database/versiondb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
+
+	_ "embed"
+)
+
+var (
+	defaultRewardConfig = reward.Config{
+		MaxConsumptionRate: .12 * reward.PercentDenominator,
+		MinConsumptionRate: .10 * reward.PercentDenominator,
+		MintingPeriod:      365 * 24 * time.Hour,
+		SupplyCap:          720 * units.MegaAvax,
+	}
+	initialAdmin     = "X-kopernikus1m4nr983lhd4p4nfsqk3a6a9mejugnn73cmp283"
+	expectedUtxoID1  = wrappers.IgnoreError(ids.FromString("2P2kTVUNMvzVWAgTbaML2DRqpD9pj5gWmxGiKZGDbotqBCHdqJ")).(ids.ID)
+	expectedUtxoID2  = wrappers.IgnoreError(ids.FromString("m3qqtnFG78HozeZ2kSS3pTLeo2SKxjTiR3DJvBd1eKyQTDcnZ")).(ids.ID)
+	expectedBondTxID = wrappers.IgnoreError(ids.FromString("2iMQED4CRfaUZcUgseM7vHXA7fcuwDvjYjq8BfJPTyGb84H8HN")).(ids.ID)
+)
+
+func TestValidateCaminoConfig(t *testing.T) {
+	type args struct {
+		config *Config
+	}
+	tests := map[string]struct {
+		args args
+		err  error
+	}{
+		"non-camino allocations / LockModeBondDeposit=false": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.LockModeBondDeposit = false
+					thisConfig.Allocations = []Allocation{{AVAXAddr: ids.GenerateTestShortID()}}
+					return &thisConfig
+				}(),
+			},
+		},
+		"non-camino allocations": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Allocations = []Allocation{{AVAXAddr: ids.GenerateTestShortID()}}
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("config.Allocations != 0"),
+		},
+		"invalid deposit offer / start date after before date": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					offer := KopernikusConfig.Camino.DepositOffers[0]
+					offer.Start = 2
+					offer.End = 1
+					offers := []genesis.DepositOffer{offer}
+					thisConfig.Camino.DepositOffers = offers
+					return &thisConfig
+				}(),
+			},
+			err: fmt.Errorf(
+				"deposit offer starttime (%v) is not before its endtime (%v)",
+				2,
+				1,
+			),
+		},
+		"invalid deposit offer duplicate": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.DepositOffers = append(thisConfig.Camino.DepositOffers, thisConfig.Camino.DepositOffers[0])
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("deposit offer duplicate"),
+		},
+		"allocation duplicate": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{thisConfig.Camino.Allocations[0]} // adding duplicate of 1st allocation into the array
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, KopernikusConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("allocation duplicate"),
+		},
+		"platform allocation duplicate": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					a := thisConfig.Camino.Allocations[0]
+					a.PlatformAllocations = []PlatformAllocation{KopernikusConfig.Camino.Allocations[0].PlatformAllocations[0]}
+					a.PlatformAllocations = append(a.PlatformAllocations, KopernikusConfig.Camino.Allocations[0].PlatformAllocations...)
+					thisConfig.Camino.Allocations = []CaminoAllocation{a}
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("platform allocation duplicate"),
+		},
+		"allocation / deposit offer mismatch": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{PlatformAllocations: []PlatformAllocation{{DepositOfferID: ids.GenerateTestID()}}}}
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, KopernikusConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("allocation deposit offer id doesn't match any offer"),
+		},
+		"staker ins't consortium member": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{PlatformAllocations: []PlatformAllocation{{NodeID: ids.GenerateTestNodeID()}}}}
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, KopernikusConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("staker ins't consortium member"),
+		},
+		"consortium member not kyc verified": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{AddressStates: AddressStates{ConsortiumMember: true}, PlatformAllocations: []PlatformAllocation{{NodeID: ids.GenerateTestNodeID()}}}}
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, KopernikusConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("consortium member not kyc verified"),
+		},
+		"wrong validator duration": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{AddressStates: AddressStates{ConsortiumMember: true, KYCVerified: true}, PlatformAllocations: []PlatformAllocation{{NodeID: ids.GenerateTestNodeID(), ValidatorDuration: 0}}}}
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, KopernikusConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("wrong validator duration"),
+		},
+		"repeated staker allocation": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{AddressStates: AddressStates{ConsortiumMember: true, KYCVerified: true}, PlatformAllocations: []PlatformAllocation{{NodeID: KopernikusConfig.Camino.Allocations[0].PlatformAllocations[0].NodeID, ValidatorDuration: 1}}}}
+					thisConfig.Camino.Allocations = append(thisConfig.Camino.Allocations, KopernikusConfig.Camino.Allocations...)
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("repeated staker allocation"),
+		},
+		"no staker allocations": {
+			args: args{
+				config: func() *Config {
+					thisConfig := KopernikusConfig
+					thisConfig.Camino.Allocations = []CaminoAllocation{{PlatformAllocations: []PlatformAllocation{}}}
+					return &thisConfig
+				}(),
+			},
+			err: errors.New("no staker allocations"),
+		},
+		"valid": {
+			args: args{
+				config: &KopernikusConfig,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateCaminoConfig(tt.args.config)
+
+			if tt.err != nil {
+				require.ErrorContains(t, err, tt.err.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestBuildCaminoGenesis(t *testing.T) {
+	ctx := snow.DefaultContextTest()
+	rewards := reward.NewCalculator(defaultRewardConfig)
+	ctx.NetworkID = constants.KopernikusID
+	baseDB := memdb.New()
+	db := versiondb.New(baseDB)
+	cfg := defaultConfig()
+
+	addrs := set.Set[ids.ShortID]{}
+	_, _, avaxAddrBytes, _ := address.Parse(initialAdmin)
+	avaxAddr, _ := ids.ToShortID(avaxAddrBytes)
+	addrs.Add(avaxAddr)
+	outputOwners := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{avaxAddr},
+	}
+	type args struct {
+		config *Config
+		hrp    string
+	}
+	tests := map[string]struct {
+		args          args
+		expectedUtxos map[ids.ID]*avax.UTXO
+		err           error
+	}{
+		"success - kopernikus": {
+			args: args{
+				config: &KopernikusConfig,
+				hrp:    constants.KopernikusHRP,
+			},
+			expectedUtxos: map[ids.ID]*avax.UTXO{
+				expectedUtxoID1: generateTestUTXO(expectedUtxoID1, ctx.AVAXAssetID, 2000000000000, outputOwners, expectedUtxoID1, expectedBondTxID),
+				expectedUtxoID2: generateTestUTXO(expectedUtxoID2, ctx.AVAXAssetID, 10000000000000000, outputOwners, expectedUtxoID2, ids.Empty),
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			genesisBytes, _, err := buildCaminoGenesis(tt.args.config, tt.args.hrp)
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+			s := defaultState(genesisBytes, cfg, ctx, db, rewards)
+
+			utxos, err := avax.GetAllUTXOs(s, addrs)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.expectedUtxos), len(utxos))
+			for _, utxo := range utxos {
+				require.Equal(t, tt.expectedUtxos[utxo.TxID].TxID, utxo.TxID)
+				require.Equal(t, tt.expectedUtxos[utxo.TxID].Out, utxo.Out)
+			}
+
+			offers, err := s.GetAllDepositOffers()
+			require.NoError(t, err)
+
+			genesisOffers := tt.args.config.Camino.DepositOffers
+
+			for _, offer := range offers {
+				require.Equal(t, getGenesisOffer(offer.ID, genesisOffers).Start, offer.Start)
+				require.Equal(t, getGenesisOffer(offer.ID, genesisOffers).End, offer.End)
+				require.Equal(t, uint64(1), offer.MinAmount)
+				require.GreaterOrEqual(t, wrappers.IgnoreError(math.Sub(offer.End, offer.Start)), uint64(offer.MinDuration))
+				require.Equal(t, offer.MinDuration, offer.MaxDuration)
+				require.Equal(t, offer.NoRewardsPeriodDuration*2, offer.UnlockPeriodDuration)
+				require.Equal(t, deposit.OfferFlagLocked, offer.Flags)
+			}
+		})
+	}
+}
+
+func getGenesisOffer(id ids.ID, offers []genesis.DepositOffer) genesis.DepositOffer {
+	for _, do := range offers {
+		doID, _ := do.ID()
+		if doID == id {
+			return do
+		}
+	}
+	return genesis.DepositOffer{}
+}

--- a/genesis/camino_helpers_test.go
+++ b/genesis/camino_helpers_test.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesis
+
+import (
+	"time"
+
+	"github.com/ava-labs/avalanchego/chains"
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/uptime"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/platformvm/metrics"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	defaultCaminoValidatorWeight = 2 * units.KiloAvax
+)
+
+var (
+	defaultMinStakingDuration = 24 * time.Hour
+	defaultMaxStakingDuration = 365 * 24 * time.Hour
+	defaultGenesisTime        = time.Date(1997, 1, 1, 0, 0, 0, 0, time.UTC)
+	defaultValidateStartTime  = defaultGenesisTime
+	defaultValidateEndTime    = defaultValidateStartTime.Add(10 * defaultMinStakingDuration)
+	defaultTxFee              = uint64(100)
+)
+
+func defaultConfig() *config.Config {
+	vdrs := validators.NewManager()
+	primaryVdrs := validators.NewSet()
+	_ = vdrs.Add(constants.PrimaryNetworkID, primaryVdrs)
+	return &config.Config{
+		Chains:                 chains.MockManager{},
+		UptimeLockedCalculator: uptime.NewLockedCalculator(),
+		Validators:             vdrs,
+		TxFee:                  defaultTxFee,
+		CreateSubnetTxFee:      100 * defaultTxFee,
+		CreateBlockchainTxFee:  100 * defaultTxFee,
+		MinValidatorStake:      defaultCaminoValidatorWeight,
+		MaxValidatorStake:      defaultCaminoValidatorWeight,
+		MinDelegatorStake:      1 * units.MilliAvax,
+		MinStakeDuration:       defaultMinStakingDuration,
+		MaxStakeDuration:       defaultMaxStakingDuration,
+		RewardConfig: reward.Config{
+			MaxConsumptionRate: .12 * reward.PercentDenominator,
+			MinConsumptionRate: .10 * reward.PercentDenominator,
+			MintingPeriod:      365 * 24 * time.Hour,
+			SupplyCap:          720 * units.MegaAvax,
+		},
+		ApricotPhase3Time: defaultValidateEndTime,
+		ApricotPhase5Time: defaultValidateEndTime,
+		BanffTime:         mockable.MaxTime,
+		CaminoConfig: config.CaminoConfig{
+			DaoProposalBondAmount: 100 * units.Avax,
+		},
+	}
+}
+
+func defaultState(
+	genesisBytes []byte,
+	cfg *config.Config,
+	ctx *snow.Context,
+	db database.Database,
+	rewards reward.Calculator,
+) state.State {
+	state, err := state.New(
+		db,
+		genesisBytes,
+		prometheus.NewRegistry(),
+		cfg,
+		ctx,
+		metrics.Noop,
+		rewards,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// persist and reload to init a bunch of in-memory stuff
+	state.SetHeight(0)
+	if err := state.Commit(); err != nil {
+		panic(err)
+	}
+	state.SetHeight( /*height*/ 0)
+	if err := state.Commit(); err != nil {
+		panic(err)
+	}
+
+	return state
+}
+
+func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.UTXO {
+	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
+		Amt:          amount,
+		OutputOwners: outputOwners,
+	}
+	if depositTxID != ids.Empty || bondTxID != ids.Empty {
+		out = &locked.Out{
+			IDs: locked.IDs{
+				DepositTxID: depositTxID,
+				BondTxID:    bondTxID,
+			},
+			TransferableOut: out,
+		}
+	}
+	testUTXO := &avax.UTXO{
+		UTXOID: avax.UTXOID{TxID: txID},
+		Asset:  avax.Asset{ID: assetID},
+		Out:    out,
+	}
+	testUTXO.InputID()
+	return testUTXO
+}

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
-var ErrDepositOfferStartTime = "deposit offer starttime (%v) is not before its endtime (%v)"
+var ErrOfferStartNotBeforeEnd = errors.New("deposit offer starttime is not before its endtime")
 
 // Camino genesis args
 type Camino struct {
@@ -63,7 +63,7 @@ func (offer DepositOffer) ID() (ids.ID, error) {
 
 func (offer DepositOffer) Verify() error {
 	if offer.Start >= offer.End {
-		return fmt.Errorf(ErrDepositOfferStartTime, offer.Start, offer.End)
+		return fmt.Errorf("%w: starttime %d, endtime %d", ErrOfferStartNotBeforeEnd, offer.Start, offer.End)
 	}
 
 	if offer.MinDuration > offer.MaxDuration {

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
+var ErrDepositOfferStartTime = "deposit offer starttime (%v) is not before its endtime (%v)"
+
 // Camino genesis args
 type Camino struct {
 	VerifyNodeSignature      bool                     `serialize:"true"`
@@ -61,11 +63,7 @@ func (offer DepositOffer) ID() (ids.ID, error) {
 
 func (offer DepositOffer) Verify() error {
 	if offer.Start >= offer.End {
-		return fmt.Errorf(
-			"deposit offer starttime (%v) is not before its endtime (%v)",
-			offer.Start,
-			offer.End,
-		)
+		return fmt.Errorf(ErrDepositOfferStartTime, offer.Start, offer.End)
 	}
 
 	if offer.MinDuration > offer.MaxDuration {


### PR DESCRIPTION
## Why this should be merged
Contains tests for the validation logic of the camino genesis config 
as well as tests for output generated by the camino specific buildGenesis logic.
