### PR TITLE
MSig aliases verification with duplicated definitions

### DIFF
--- a/genesis/camino_genesis.go
+++ b/genesis/camino_genesis.go
@@ -124,9 +124,9 @@ func validateCaminoConfig(config *Config) error {
 	}
 
 	// validate msig aliases
-	genesisTxID := ids.Empty
-	for _, msig := range config.Camino.InitialMultisigAddresses {
-		if err := msig.Verify(genesisTxID); err != nil {
+	for idx, msig := range config.Camino.InitialMultisigAddresses {
+		rowTxID := ids.FromInt(uint64(idx))
+		if err := msig.Verify(rowTxID); err != nil {
 			return fmt.Errorf("wrong msig alias definition: %w", err)
 		}
 	}

--- a/ids/camino_id.go
+++ b/ids/camino_id.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package ids
+
+import "encoding/binary"
+
+// FromInt converts an int to an ID
+//
+// Examples:
+//
+//	FromInt(0).Hex() == "0000000000000000000000000000000000000000000000000000000000000000"
+//	FromInt(1).Hex() == "0000000000000000000000000000000000000000000000000000000000000001"
+//	FromInt(math.MaxUint64).Hex() == "000000000000000000000000000000000000000000000000ffffffffffffffff"
+func FromInt(idx uint64) ID {
+	bytes := ID{}
+	binary.BigEndian.PutUint64(bytes[24:], idx)
+
+	return bytes
+}


### PR DESCRIPTION
## Why this should be merged

For the genesis we want to have different multisig aliases for the different control groups even if these contains the same addresses + threshold. 
This makes us to change the `TxID` which for genesis was `ids.EmptyID`

## How this works

It itroduces helper method `ID.FromInt(uint64)` and `TxID` is now computed from the alias definition index in the array.

## How this was tested
