### PR TITLE
Extended platformvm fx, fixes and tests for deposits

### DIFF
--- a/vms/platformvm/deposit/camino_deposit.go
+++ b/vms/platformvm/deposit/camino_deposit.go
@@ -73,15 +73,17 @@ func (deposit *Deposit) StartTime() time.Time {
 	return time.Unix(int64(deposit.Start), 0)
 }
 
-func (deposit *Deposit) IsExpired(
-	timestamp uint64,
-) bool {
-	depositEndTime, err := math.Add64(deposit.Start, uint64(deposit.Duration))
+func (deposit *Deposit) EndTime() time.Time {
+	return deposit.StartTime().Add(time.Duration(deposit.Duration) * time.Second)
+}
+
+func (deposit *Deposit) IsExpired(timestamp uint64) bool {
+	depositEndTimestamp, err := math.Add64(deposit.Start, uint64(deposit.Duration))
 	if err != nil {
-		// if err (overflow), than depositEndTime >= unlockTime
+		// if err (overflow), than depositEndTimestamp > timestamp
 		return false
 	}
-	return depositEndTime < timestamp
+	return depositEndTimestamp <= timestamp
 }
 
 // Returns amount of tokens that can be unlocked from [deposit] at [unlockTime] (seconds).

--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package fx
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+type CaminoFx interface {
+	// Recovers signers addresses from [verifies] credentials for [utx] transaction
+	RecoverAddresses(utx secp256k1fx.UnsignedTx, verifies []verify.Verifiable) (set.Set[ids.ShortID], error)
+}

--- a/vms/platformvm/fx/fx.go
+++ b/vms/platformvm/fx/fx.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -37,6 +47,7 @@ type Fx interface {
 	// CreateOutput creates a new output with the provided control group worth
 	// the specified amount
 	CreateOutput(amount uint64, controlGroup interface{}) (interface{}, error)
+	CaminoFx
 }
 
 type Owner interface {

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -10,7 +10,11 @@ package fx
 import (
 	reflect "reflect"
 
+	ids "github.com/ava-labs/avalanchego/ids"
 	snow "github.com/ava-labs/avalanchego/snow"
+	set "github.com/ava-labs/avalanchego/utils/set"
+	verify "github.com/ava-labs/avalanchego/vms/components/verify"
+	secp256k1fx "github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -120,6 +124,21 @@ func (m *MockFx) VerifyTransfer(arg0, arg1, arg2, arg3 interface{}) error {
 func (mr *MockFxMockRecorder) VerifyTransfer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyTransfer", reflect.TypeOf((*MockFx)(nil).VerifyTransfer), arg0, arg1, arg2, arg3)
+}
+
+// RecoverAddresses mocks base method.
+func (m *MockFx) RecoverAddresses(arg0 secp256k1fx.UnsignedTx, arg1 []verify.Verifiable) (set.Set[ids.ShortID], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecoverAddresses", arg0, arg1)
+	ret0, _ := ret[0].(set.Set[ids.ShortID])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RecoverAddresses indicates an expected call of RecoverAddresses.
+func (mr *MockFxMockRecorder) RecoverAddresses(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecoverAddresses", reflect.TypeOf((*MockFx)(nil).RecoverAddresses), arg0, arg1)
 }
 
 // MockOwner is a mock of Owner interface.

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -221,18 +221,9 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 	// adding deposit offers
 
 	for _, genesisOffer := range g.Camino.DepositOffers {
-		offer := &deposit.Offer{
-			InterestRateNominator:   genesisOffer.InterestRateNominator,
-			Start:                   genesisOffer.Start,
-			End:                     genesisOffer.End,
-			MinAmount:               genesisOffer.MinAmount,
-			MinDuration:             genesisOffer.MinDuration,
-			MaxDuration:             genesisOffer.MaxDuration,
-			UnlockPeriodDuration:    genesisOffer.UnlockPeriodDuration,
-			NoRewardsPeriodDuration: genesisOffer.NoRewardsPeriodDuration,
-			Flags:                   genesisOffer.Flags,
-		}
-		if err := offer.SetID(); err != nil {
+		genesisOffer := genesisOffer
+		offer, err := ParseDepositOfferFromGenesisOffer(&genesisOffer)
+		if err != nil {
 			return err
 		}
 

--- a/vms/platformvm/state/camino_deposit_offer.go
+++ b/vms/platformvm/state/camino_deposit_offer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 )
 
 func (cs *caminoState) AddDepositOffer(offer *deposit.Offer) {
@@ -89,4 +90,22 @@ func (cs *caminoState) writeDepositOffers() error {
 		}
 	}
 	return nil
+}
+
+func ParseDepositOfferFromGenesisOffer(genesisOffer *genesis.DepositOffer) (*deposit.Offer, error) {
+	offer := &deposit.Offer{
+		InterestRateNominator:   genesisOffer.InterestRateNominator,
+		Start:                   genesisOffer.Start,
+		End:                     genesisOffer.End,
+		MinAmount:               genesisOffer.MinAmount,
+		MinDuration:             genesisOffer.MinDuration,
+		MaxDuration:             genesisOffer.MaxDuration,
+		UnlockPeriodDuration:    genesisOffer.UnlockPeriodDuration,
+		NoRewardsPeriodDuration: genesisOffer.NoRewardsPeriodDuration,
+		Flags:                   genesisOffer.Flags,
+	}
+	if err := offer.SetID(); err != nil {
+		return nil, err
+	}
+	return offer, nil
 }


### PR DESCRIPTION
This PR:
- Extends platformVM fx in order to replace fx type casting
- Fixes deposit isExpired function
- Adds missed syntactic checks to transaction executions
- Cleans up (and fixes) unlock deposit tests to support changes in deposit offers / deposits and added syntactic checks, adds/removes some test cases