### PR TITLE
Genesis bytes

### DIFF
--- a/api/info/camino_client.go
+++ b/api/info/camino_client.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package info
+
+import (
+	"context"
+
+	"github.com/ava-labs/avalanchego/utils/rpc"
+)
+
+func (c *client) GetGenesisBytes(ctx context.Context, options ...rpc.Option) ([]byte, error) {
+	res := &GetGenesisBytesReply{}
+	err := c.requester.SendRequest(ctx, "info.getGenesisBytes", struct{}{}, res, options...)
+	return res.GenesisBytes, err
+}

--- a/api/info/camino_service.go
+++ b/api/info/camino_service.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package info
+
+import "net/http"
+
+// GetGenesisBytesReply contains the response metadata for GetGenesisBytes
+type GetGenesisBytesReply struct {
+	GenesisBytes []byte `json:"genesisBytes"`
+}
+
+// GetGenesisBytes returns genesis bytes
+func (i *Info) GetGenesisBytes(_ *http.Request, _ *struct{}, reply *GetGenesisBytesReply) error {
+	i.log.Debug("Info: GetGenesisBytes called")
+	reply.GenesisBytes = i.GenesisBytes
+	return nil
+}

--- a/api/info/client.go
+++ b/api/info/client.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -26,6 +36,7 @@ type Client interface {
 	GetTxFee(context.Context, ...rpc.Option) (*GetTxFeeResponse, error)
 	Uptime(context.Context, ids.ID, ...rpc.Option) (*UptimeResponse, error)
 	GetVMs(context.Context, ...rpc.Option) (map[ids.ID][]string, error)
+	GetGenesisBytes(context.Context, ...rpc.Option) ([]byte, error)
 }
 
 // Client implementation for an Info API Client

--- a/api/info/service.go
+++ b/api/info/service.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -57,6 +67,7 @@ type Parameters struct {
 	AddSubnetValidatorFee         uint64
 	AddSubnetDelegatorFee         uint64
 	VMManager                     vms.Manager
+	GenesisBytes                  []byte
 }
 
 // NewService returns a new admin API service

--- a/genesis/camino_genesis.go
+++ b/genesis/camino_genesis.go
@@ -264,14 +264,14 @@ func buildPGenesis(config *Config, hrp string, xGenesisBytes []byte, xGenesisDat
 			})
 		}
 
+		allocationAddress, err := address.FormatBech32(hrp, allocation.AVAXAddr.Bytes())
+		if err != nil {
+			return nil, ids.Empty, err
+		}
+
 		for _, platformAllocation := range allocation.PlatformAllocations {
 			if platformAllocation.Amount == 0 {
 				return nil, ids.Empty, errEmptyAllocation
-			}
-
-			allocationAddress, err := address.FormatBech32(hrp, allocation.AVAXAddr.Bytes())
-			if err != nil {
-				return nil, ids.Empty, err
 			}
 
 			allocationMessage, err := formatting.Encode(defaultEncoding, allocation.ETHAddr.Bytes())

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -170,7 +170,7 @@ type GetConfigurationReply struct {
 	LockModeBondDeposit bool `json:"lockModeBondDeposit"`
 }
 
-// GetMinStake returns the minimum staking amount in nAVAX.
+// GetConfiguration returns platformVM configuration
 func (s *CaminoService) GetConfiguration(_ *http.Request, _ *struct{}, reply *GetConfigurationReply) error {
 	s.vm.ctx.Log.Debug("Platform: GetConfiguration called")
 

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -280,7 +280,7 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 		cs.SetMultisigOwner(owner)
 	}
 
-	return nil
+	return s.write(false, 0)
 }
 
 func (cs *caminoState) Load() error {


### PR DESCRIPTION
This PR adds GetGenesisBytes to info api, request will return node config genesis bytes.

This PR also adds missing write to camino sync genesis. AVAX state init does write in 2 steps: first they write genesis state except some validators stuff (controlled by bool arg) in sync genesis, then they write everything else in Commit(). Camino sync genesis was missing that 1st step. For consistency, this PR adds this additional write to camino sync genesis.

And some small clean-up.