### PR TITLE
Add Spend rpc handler, that handles ins/outs generation

### DIFF
--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -33,6 +33,7 @@ var (
 type CaminoBuilder interface {
 	Builder
 	CaminoTxBuilder
+	utxo.Spender
 }
 
 type CaminoTxBuilder interface {


### PR DESCRIPTION
This PR adds rpc handler to platformVM service, that handles inputs/outputs generation for lock tokens operation.
`"method": "platform.spend"`
It takes following arguments (values are just for example):
```
    "params": {
        "lockMode": 1, // 0 - only burning, 1 - deposit, 2 - bond
        "amountToLock": 10, // amount of tokens, that will be locked
        "amountToBurn": 1, // amount of tokens, that will be burned (fee, for example)
        "from": [
            "{{p-chain-addr}}"
        ],
        "changeAddr": "{{p-chain-addr}}",
        "encoding": "hex"
    }
```
and returns reply
```
    "result": {
        "ins": "0x0000000000010000000000000000000000000000000000000000000000000000000000000000000000019ded9af5fd55860a607a3b198b70f1f6f5557bbbad71ceb3933b2c559642ff8000000005002386f26fc10000000000010000000064c0cb24",
        "outs": "0x0000000000029ded9af5fd55860a607a3b198b70f1f6f5557bbbad71ceb3933b2c559642ff8000000007002386f26fc0fff5000000000000000000000001000000014ac77d43e4526f5b1c62ab9c1d3e52ab52d5a1469ded9af5fd55860a607a3b198b70f1f6f5557bbbad71ceb3933b2c559642ff80000020017468697320747820696400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007000000000000000a000000000000000000000001000000014ac77d43e4526f5b1c62ab9c1d3e52ab52d5a1469fb64d5c"
    }
```