### PR TITLE
NodeID to consortium member mapping

### DIFF
--- a/database/linkeddb/linkeddb.go
+++ b/database/linkeddb/linkeddb.go
@@ -111,6 +111,9 @@ func (ldb *linkedDB) Put(key, value []byte) error {
 
 	// The key isn't currently in the list, so we should add it as the head.
 	newHead := node{Value: utils.CopyBytes(value)}
+	// Make a copy of the key to prevent range changes
+	key = utils.CopyBytes(key)
+
 	if headKey, err := ldb.getHeadKey(); err == nil {
 		// The list currently has a head, so we need to update the old head.
 		oldHead, err := ldb.getNode(headKey)

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -208,7 +208,7 @@ func TestGenesisFromFile(t *testing.T) {
 		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
-			expected:     "9f9b1c4bfec02a9e84fe84ba301ba5b6f7b998513f78b3553994d51407a272aa",
+			expected:     "04068ee6f095f09017f3d914f4f1a25c04d7c1a1518f3db48f97040a7d9f005c",
 		},
 		"custom (networkID mismatch)": {
 			networkID:    9999,
@@ -290,7 +290,7 @@ func TestGenesisFromFlag(t *testing.T) {
 		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
-			expected:     "9f9b1c4bfec02a9e84fe84ba301ba5b6f7b998513f78b3553994d51407a272aa",
+			expected:     "04068ee6f095f09017f3d914f4f1a25c04d7c1a1518f3db48f97040a7d9f005c",
 		},
 		"custom (networkID mismatch)": {
 			networkID:    9999,
@@ -362,27 +362,27 @@ func TestGenesis(t *testing.T) {
 	}{
 		{
 			networkID:  constants.MainnetID,
-			expectedID: "2EHjnR6PRAxP1SREMZ7jZtHjWRwEZiM1y9hjuBybqNcXzdtnoC",
+			expectedID: "2eP2teFA41Pb61nQyQYJY38onkCqkrJDPSVeQz8v9ahbEma18S",
 		},
 		{
 			networkID:  constants.FujiID,
-			expectedID: "2ZncKBHRaJos8sNTtzMSchyJyXkTcbXSp4XUgXGxM1YrG6RGg9",
+			expectedID: "2fAKF9ph6o4jxr12QVWmbww8dVfkNKepBt547QFEJ5eyD9x2Z9",
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "h3HmDix7Ae6D11tDZ5yMLpkbgp6QoUc5t3pDPJhGBSy1DT4U2",
+			expectedID: "2p4kjWwHPxHdLUf4DPfdgTDi9TUNphLL2jJmy5LdRRzqecqvxH",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "Qozm2WUb67QNpqyKJS2ACbvjYRp1TywVw4Ega4G781Y1i7gCU",
+			expectedID: "MXCF5iu2oy7exb7CRJQf1krydFTz7GeAbTZSbotNNdFKeDFan",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "2B6D49SF4BJr9yM9NsH4HqrErW4NMu4DsGVAgdgU7YHnJhFJfo",
+			expectedID: "zsgqQgQWSze7mqSQEBaEQJRVQPYBEM7UwczCXmvzDakGCdW2Y",
 		},
 		{
 			networkID:  constants.LocalID,
-			expectedID: "MKWhG4ceud3WPBTTpWdzTW4e31DQrEns4Nr5R92afDYp3gegd",
+			expectedID: "294HrmVEniYX2mrvLjww9AmpV9NZnFhEi6eRrCsAzxZ2PkvdVb",
 		},
 	}
 	for _, test := range tests {

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -15,12 +15,10 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/logging"
-	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/keystore"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"go.uber.org/zap"
 
@@ -284,126 +282,6 @@ func (s *CaminoService) GetAddressStateTx(_ *http.Request, args *GetAddressState
 	return nil
 }
 
-// CaminoAddValidatorArgs are the arguments to AddCaminoValidator
-type CaminoAddValidatorArgs struct {
-	// User, password, from addrs, change addr, staker, rewardAddress
-	AddValidatorArgs
-	// Address of consortium member, who runs the node
-	ConsortiumMember string `json:"consortiumMember"`
-}
-
-// AddValidator creates and signs and issues a transaction to add a validator to
-// the primary network
-func (s *CaminoService) AddValidator(_ *http.Request, args *CaminoAddValidatorArgs, reply *api.JSONTxIDChangeAddr) error {
-	s.vm.ctx.Log.Debug("Platform: AddCaminoValidator called")
-
-	caminoConfig, err := s.vm.state.CaminoConfig()
-	if err != nil {
-		return err
-	}
-
-	if !caminoConfig.LockModeBondDeposit {
-		return s.Service.AddValidator(nil, &args.AddValidatorArgs, reply)
-	}
-
-	now := s.vm.clock.Time()
-	minAddStakerTime := now.Add(minAddStakerDelay)
-	minAddStakerUnix := utilsjson.Uint64(minAddStakerTime.Unix())
-	maxAddStakerTime := now.Add(executor.MaxFutureStartTime)
-	maxAddStakerUnix := utilsjson.Uint64(maxAddStakerTime.Unix())
-
-	if args.StartTime == 0 {
-		args.StartTime = minAddStakerUnix
-	}
-
-	switch {
-	case args.RewardAddress == "":
-		return errNoRewardAddress
-	case args.StartTime < minAddStakerUnix:
-		return errStartTimeTooSoon
-	case args.StartTime > maxAddStakerUnix:
-		return errStartTimeTooLate
-	case args.DelegationFeeRate < 0 || args.DelegationFeeRate > 100:
-		return errInvalidDelegationRate
-	}
-
-	// Parse the node ID
-	var nodeID ids.NodeID
-	if args.NodeID == ids.EmptyNodeID { // If ID unspecified, use this node's ID
-		nodeID = s.vm.ctx.NodeID
-	} else {
-		nodeID = args.NodeID
-	}
-
-	// Parse the from addresses
-	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, args.From)
-	if err != nil {
-		return err
-	}
-
-	// Parse the reward address
-	rewardAddress, err := avax.ParseServiceAddress(s.addrManager, args.RewardAddress)
-	if err != nil {
-		return fmt.Errorf("problem while parsing reward address: %w", err)
-	}
-
-	// Parse the consortium member address
-	consortiumMemberAddress, err := avax.ParseServiceAddress(s.addrManager, args.ConsortiumMember)
-	if err != nil {
-		return fmt.Errorf("problem while parsing consortium member address: %w", err)
-	}
-
-	user, err := keystore.NewUserFromKeystore(s.vm.ctx.Keystore, args.Username, args.Password)
-	if err != nil {
-		return err
-	}
-	defer user.Close()
-
-	// Get the user's keys
-	privKeys, err := keystore.GetKeychain(user, fromAddrs)
-	if err != nil {
-		return fmt.Errorf("couldn't get addresses controlled by the user: %w", err)
-	}
-
-	// Parse the change address.
-	if len(privKeys.Keys) == 0 {
-		return errNoKeys
-	}
-	changeAddr := privKeys.Keys[0].PublicKey().Address() // By default, use a key controlled by the user
-	if args.ChangeAddr != "" {
-		changeAddr, err = avax.ParseServiceAddress(s.addrManager, args.ChangeAddr)
-		if err != nil {
-			return fmt.Errorf("couldn't parse changeAddr: %w", err)
-		}
-	}
-
-	// Create the transaction
-	tx, err := s.vm.txBuilder.NewCaminoAddValidatorTx(
-		s.vm.Config.MinValidatorStake, // Stake amount
-		uint64(args.StartTime),        // Start time
-		uint64(args.EndTime),          // End time
-		nodeID,                        // Node ID
-		rewardAddress,                 // Reward Address
-		consortiumMemberAddress,       // consortium member address
-		privKeys.Keys,                 // Keys providing the staked tokens
-		changeAddr,
-	)
-	if err != nil {
-		return fmt.Errorf("couldn't create tx: %w", err)
-	}
-
-	reply.TxID = tx.ID()
-	reply.ChangeAddr, err = s.addrManager.FormatLocalAddress(changeAddr)
-
-	errs := wrappers.Errs{}
-	errs.Add(
-		err,
-		s.vm.Builder.AddUnverifiedTx(tx),
-		user.Close(),
-	)
-	return errs.Err
-}
-
 type SpendArgs struct {
 	api.JSONFromAddrs
 	api.JSONChangeAddr
@@ -413,6 +291,7 @@ type SpendArgs struct {
 	AmountToBurn uint64              `json:"amountToBurn"`
 	Encoding     formatting.Encoding `json:"encoding"`
 }
+
 type SpendReply struct {
 	Ins  string `json:"ins"`
 	Outs string `json:"outs"`

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -18,18 +18,24 @@ import (
 
 // Camino genesis args
 type Camino struct {
-	VerifyNodeSignature      bool            `serialize:"true"`
-	LockModeBondDeposit      bool            `serialize:"true"`
-	InitialAdmin             ids.ShortID     `serialize:"true"`
-	AddressStates            []AddressState  `serialize:"true"`
-	DepositOffers            []DepositOffer  `serialize:"true"`
-	Deposits                 []*txs.Tx       `serialize:"true"`
-	InitialMultisigAddresses []MultisigAlias `serialize:"true" json:"initialMultisigAddresses"`
+	VerifyNodeSignature      bool                     `serialize:"true"`
+	LockModeBondDeposit      bool                     `serialize:"true"`
+	InitialAdmin             ids.ShortID              `serialize:"true"`
+	AddressStates            []AddressState           `serialize:"true"`
+	DepositOffers            []DepositOffer           `serialize:"true"`
+	Deposits                 []*txs.Tx                `serialize:"true"`
+	ConsortiumMembersNodeIDs []ConsortiumMemberNodeID `serialize:"true"`
+	InitialMultisigAddresses []MultisigAlias          `serialize:"true"`
+}
+
+type ConsortiumMemberNodeID struct {
+	ConsortiumMemberAddress ids.ShortID `serialize:"true"`
+	NodeID                  ids.NodeID  `serialize:"true"`
 }
 
 type AddressState struct {
-	Address ids.ShortID `serialize:"true" json:"address"`
-	State   uint64      `serialize:"true" json:"state"`
+	Address ids.ShortID `serialize:"true"`
+	State   uint64      `serialize:"true"`
 }
 
 type DepositOffer struct {

--- a/vms/platformvm/state/camino_consortium_member_nodes.go
+++ b/vms/platformvm/state/camino_consortium_member_nodes.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+func (cs *caminoState) writeNodeConsortiumMembers() error {
+	for nodeID, addr := range cs.modifiedConsortiumMemberNodes {
+		delete(cs.modifiedConsortiumMemberNodes, nodeID)
+		if err := cs.consortiumMemberNodesDB.Put(nodeID[:], addr[:]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (cs *caminoState) SetNodeConsortiumMember(nodeID ids.NodeID, addr ids.ShortID) {
+	cs.modifiedConsortiumMemberNodes[nodeID] = addr
+}
+
+func (cs *caminoState) GetNodeConsortiumMember(nodeID ids.NodeID) (ids.ShortID, error) {
+	if addr, ok := cs.modifiedConsortiumMemberNodes[nodeID]; ok {
+		return addr, nil
+	}
+
+	if addr, ok := cs.consortiumMemberNodesCache.Get(nodeID); ok {
+		return addr.(ids.ShortID), nil
+	}
+
+	addrBytes, err := cs.consortiumMemberNodesDB.Get(nodeID[:])
+	if err != nil {
+		return ids.ShortEmpty, err
+	}
+
+	return ids.ToShortID(addrBytes)
+}

--- a/vms/platformvm/state/camino_deposit_offer.go
+++ b/vms/platformvm/state/camino_deposit_offer.go
@@ -84,7 +84,6 @@ func (cs *caminoState) writeDepositOffers() error {
 			return fmt.Errorf("failed to serialize deposit offer: %w", err)
 		}
 
-		offerID := offerID
 		if err := cs.depositOffersList.Put(offerID[:], offerBytes); err != nil {
 			return err
 		}

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -158,6 +158,40 @@ func (d *diff) GetDeposit(depositTxID ids.ID) (*deposit.Deposit, error) {
 	return parentState.GetDeposit(depositTxID)
 }
 
+func (d *diff) SetMultisigOwner(owner *MultisigOwner) {
+	d.caminoDiff.modifiedMultisigOwners[owner.Alias] = owner
+}
+
+func (d *diff) GetMultisigOwner(alias ids.ShortID) (*MultisigOwner, error) {
+	if msigOwner, ok := d.caminoDiff.modifiedMultisigOwners[alias]; ok {
+		return msigOwner, nil
+	}
+
+	parentState, ok := d.stateVersions.GetState(d.parentID)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
+	}
+
+	return parentState.GetMultisigOwner(alias)
+}
+
+func (d *diff) SetNodeConsortiumMember(nodeID ids.NodeID, addr ids.ShortID) {
+	d.caminoDiff.modifiedConsortiumMemberNodes[nodeID] = addr
+}
+
+func (d *diff) GetNodeConsortiumMember(nodeID ids.NodeID) (ids.ShortID, error) {
+	if addr, ok := d.caminoDiff.modifiedConsortiumMemberNodes[nodeID]; ok {
+		return addr, nil
+	}
+
+	parentState, ok := d.stateVersions.GetState(d.parentID)
+	if !ok {
+		return ids.ShortEmpty, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
+	}
+
+	return parentState.GetNodeConsortiumMember(nodeID)
+}
+
 // Finally apply all changes
 func (d *diff) ApplyCaminoState(baseState State) {
 	for k, v := range d.caminoDiff.modifiedAddressStates {

--- a/vms/platformvm/state/camino_multisig_alias.go
+++ b/vms/platformvm/state/camino_multisig_alias.go
@@ -41,16 +41,20 @@ func (cs *caminoState) GetMultisigOwner(alias ids.ShortID) (*MultisigOwner, erro
 		return owner, nil
 	}
 
-	multisigAlias := &MultisigOwner{}
-	maBytes, err := cs.multisigOwnersDB.Get(alias.Bytes())
+	maBytes, err := cs.multisigOwnersDB.Get(alias[:])
 	if err != nil {
-		return multisigAlias, err
+		return nil, err
 	}
 
-	_, err = blocks.GenesisCodec.Unmarshal(maBytes, multisigAlias)
-	multisigAlias.Alias = alias
+	multisigOwner := &MultisigOwner{}
+	_, err = blocks.GenesisCodec.Unmarshal(maBytes, multisigOwner)
+	if err != nil {
+		return nil, err
+	}
 
-	return multisigAlias, err
+	multisigOwner.Alias = alias
+
+	return multisigOwner, nil
 }
 
 func (cs *caminoState) writeMultisigOwners() error {

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -76,3 +76,11 @@ func (s *state) SetMultisigOwner(owner *MultisigOwner) {
 func (s *state) GetMultisigOwner(alias ids.ShortID) (*MultisigOwner, error) {
 	return s.caminoState.GetMultisigOwner(alias)
 }
+
+func (s *state) SetNodeConsortiumMember(nodeID ids.NodeID, addr ids.ShortID) {
+	s.caminoState.SetNodeConsortiumMember(nodeID, addr)
+}
+
+func (s *state) GetNodeConsortiumMember(nodeID ids.NodeID) (ids.ShortID, error) {
+	return s.caminoState.GetNodeConsortiumMember(nodeID)
+}

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -232,6 +232,48 @@ func (mr *MockChainMockRecorder) GetAllDepositOffers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllDepositOffers", reflect.TypeOf((*MockChain)(nil).GetAllDepositOffers))
 }
 
+// GetMultisigOwner mocks base method.
+func (m *MockChain) GetMultisigOwner(arg0 ids.ShortID) (*MultisigOwner, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMultisigOwner", arg0)
+	ret0, _ := ret[0].(*MultisigOwner)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMultisigOwner indicates an expected call of GetMultisigOwner.
+func (mr *MockChainMockRecorder) GetMultisigOwner(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultisigOwner", reflect.TypeOf((*MockState)(nil).GetMultisigOwner), arg0)
+}
+
+// SetNodeConsortiumMember mocks base method.
+func (m *MockChain) SetNodeConsortiumMember(arg0 ids.NodeID, arg1 ids.ShortID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNodeConsortiumMember", arg0)
+}
+
+// SetNodeConsortiumMember indicates an expected call of SetNodeConsortiumMember.
+func (mr *MockChainMockRecorder) SetNodeConsortiumMember(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeConsortiumMember", reflect.TypeOf((*MockState)(nil).SetNodeConsortiumMember), arg0, arg1)
+}
+
+// GetNodeConsortiumMember mocks base method.
+func (m *MockChain) GetNodeConsortiumMember(arg0 ids.NodeID) (ids.ShortID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeConsortiumMember", arg0)
+	ret0, _ := ret[0].(ids.ShortID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeConsortiumMember indicates an expected call of GetNodeConsortiumMember.
+func (mr *MockChainMockRecorder) GetNodeConsortiumMember(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeConsortiumMember", reflect.TypeOf((*MockState)(nil).GetNodeConsortiumMember), arg0)
+}
+
 // GetChains mocks base method.
 func (m *MockChain) GetChains(arg0 ids.ID) ([]*txs.Tx, error) {
 	m.ctrl.T.Helper()
@@ -557,6 +599,18 @@ func (m *MockChain) SetCurrentSupply(arg0 ids.ID, arg1 uint64) {
 func (mr *MockChainMockRecorder) SetCurrentSupply(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentSupply", reflect.TypeOf((*MockChain)(nil).SetCurrentSupply), arg0, arg1)
+}
+
+// SetMultisigOwner mocks base method.
+func (m *MockChain) SetMultisigOwner(arg0 *MultisigOwner) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMultisigOwner", arg0)
+}
+
+// SetMultisigOwner indicates an expected call of SetMultisigOwner.
+func (mr *MockChainMockRecorder) SetMultisigOwner(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigOwner", reflect.TypeOf((*MockState)(nil).SetMultisigOwner), arg0)
 }
 
 // SetTimestamp mocks base method.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -256,6 +256,48 @@ func (mr *MockDiffMockRecorder) GetAllDepositOffers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllDepositOffers", reflect.TypeOf((*MockDiff)(nil).GetAllDepositOffers))
 }
 
+// GetMultisigOwner mocks base method.
+func (m *MockDiff) GetMultisigOwner(arg0 ids.ShortID) (*MultisigOwner, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMultisigOwner", arg0)
+	ret0, _ := ret[0].(*MultisigOwner)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMultisigOwner indicates an expected call of GetMultisigOwner.
+func (mr *MockDiffMockRecorder) GetMultisigOwner(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultisigOwner", reflect.TypeOf((*MockState)(nil).GetMultisigOwner), arg0)
+}
+
+// SetNodeConsortiumMember mocks base method.
+func (m *MockDiff) SetNodeConsortiumMember(arg0 ids.NodeID, arg1 ids.ShortID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNodeConsortiumMember", arg0)
+}
+
+// SetNodeConsortiumMember indicates an expected call of SetNodeConsortiumMember.
+func (mr *MockDiffMockRecorder) SetNodeConsortiumMember(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeConsortiumMember", reflect.TypeOf((*MockState)(nil).SetNodeConsortiumMember), arg0, arg1)
+}
+
+// GetNodeConsortiumMember mocks base method.
+func (m *MockDiff) GetNodeConsortiumMember(arg0 ids.NodeID) (ids.ShortID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeConsortiumMember", arg0)
+	ret0, _ := ret[0].(ids.ShortID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeConsortiumMember indicates an expected call of GetNodeConsortiumMember.
+func (mr *MockDiffMockRecorder) GetNodeConsortiumMember(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeConsortiumMember", reflect.TypeOf((*MockState)(nil).GetNodeConsortiumMember), arg0)
+}
+
 // GetChains mocks base method.
 func (m *MockDiff) GetChains(arg0 ids.ID) ([]*txs.Tx, error) {
 	m.ctrl.T.Helper()
@@ -581,6 +623,18 @@ func (m *MockDiff) SetCurrentSupply(arg0 ids.ID, arg1 uint64) {
 func (mr *MockDiffMockRecorder) SetCurrentSupply(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentSupply", reflect.TypeOf((*MockDiff)(nil).SetCurrentSupply), arg0, arg1)
+}
+
+// SetMultisigOwner mocks base method.
+func (m *MockDiff) SetMultisigOwner(arg0 *MultisigOwner) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMultisigOwner", arg0)
+}
+
+// SetMultisigOwner indicates an expected call of SetMultisigOwner.
+func (mr *MockDiffMockRecorder) SetMultisigOwner(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigOwner", reflect.TypeOf((*MockState)(nil).SetMultisigOwner), arg0)
 }
 
 // SetTimestamp mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -437,6 +437,33 @@ func (mr *MockStateMockRecorder) GetMultisigOwner(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultisigOwner", reflect.TypeOf((*MockState)(nil).GetMultisigOwner), arg0)
 }
 
+// SetNodeConsortiumMember mocks base method.
+func (m *MockState) SetNodeConsortiumMember(arg0 ids.NodeID, arg1 ids.ShortID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNodeConsortiumMember", arg0)
+}
+
+// SetNodeConsortiumMember indicates an expected call of SetNodeConsortiumMember.
+func (mr *MockStateMockRecorder) SetNodeConsortiumMember(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeConsortiumMember", reflect.TypeOf((*MockState)(nil).SetNodeConsortiumMember), arg0, arg1)
+}
+
+// GetNodeConsortiumMember mocks base method.
+func (m *MockState) GetNodeConsortiumMember(arg0 ids.NodeID) (ids.ShortID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeConsortiumMember", arg0)
+	ret0, _ := ret[0].(ids.ShortID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeConsortiumMember indicates an expected call of GetNodeConsortiumMember.
+func (mr *MockStateMockRecorder) GetNodeConsortiumMember(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeConsortiumMember", reflect.TypeOf((*MockState)(nil).GetNodeConsortiumMember), arg0)
+}
+
 // GetPendingDelegatorIterator mocks base method.
 func (m *MockState) GetPendingDelegatorIterator(arg0 ids.ID, arg1 ids.NodeID) (StakerIterator, error) {
 	m.ctrl.T.Helper()

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -137,7 +137,6 @@ type State interface {
 	BlockState
 	uptime.State
 	avax.UTXOReader
-	CaminoMultisig
 
 	GetValidatorWeightDiffs(height uint64, subnetID ids.ID) (map[ids.NodeID]*ValidatorWeightDiff, error)
 
@@ -1337,7 +1336,7 @@ func (s *state) loadPendingValidators() error {
 }
 
 // Invariant: initValidatorSets requires loadCurrentValidators to have already
-//            been called.
+//	been called.
 func (s *state) initValidatorSets() error {
 	primaryValidators, ok := s.cfg.Validators.Get(constants.PrimaryNetworkID)
 	if !ok {
@@ -1432,6 +1431,7 @@ func (s *state) Close() error {
 		s.chainDB.Close(),
 		s.singletonDB.Close(),
 		s.blockDB.Close(),
+		s.caminoState.Close(),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -101,7 +101,7 @@ func TestCaminoBuilderTxAddressState(t *testing.T) {
 	}
 }
 
-func TestCaminoBuilderNewAddValidatorTxNodeSig(t *testing.T) {
+func TestCaminoBuilderNewAddSubnetValidatorTxNodeSig(t *testing.T) {
 	nodeKey1, nodeID1 := nodeid.GenerateCaminoNodeKeyAndID()
 	nodeKey2, _ := nodeid.GenerateCaminoNodeKeyAndID()
 
@@ -142,35 +142,7 @@ func TestCaminoBuilderNewAddValidatorTxNodeSig(t *testing.T) {
 		// because the error will rise from the execution
 	}
 	for name, tt := range tests {
-		key, err := testKeyfactory.NewPrivateKey()
-		require.NoError(t, err)
-		consortiumMemberKey, ok := key.(*crypto.PrivateKeySECP256K1R)
-		require.True(t, ok)
-		consortiumMemberAddr := consortiumMemberKey.Address()
-
-		t.Run("AddValidatorTx: "+name, func(t *testing.T) {
-			env := newCaminoEnvironment(true, tt.caminoConfig)
-			env.ctx.Lock.Lock()
-			defer func() {
-				if err := shutdownCaminoEnvironment(env); err != nil {
-					t.Fatal(err)
-				}
-			}()
-
-			_, err := env.txBuilder.NewCaminoAddValidatorTx(
-				defaultCaminoValidatorWeight,
-				uint64(defaultValidateStartTime.Unix()+1),
-				uint64(defaultValidateEndTime.Unix()),
-				tt.nodeID,
-				consortiumMemberAddr,
-				ids.ShortEmpty,
-				[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], tt.nodeKey, consortiumMemberKey},
-				ids.ShortEmpty,
-			)
-			require.ErrorIs(t, err, tt.expectedErr)
-		})
-
-		t.Run("AddSubnetValidatorTx: "+name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			env := newCaminoEnvironment(true, tt.caminoConfig)
 			env.ctx.Lock.Lock()
 			defer func() {

--- a/vms/platformvm/txs/camino_add_validator_test.go
+++ b/vms/platformvm/txs/camino_add_validator_test.go
@@ -123,7 +123,6 @@ func TestCaminoAddValidatorTxSyntacticVerify(t *testing.T) {
 						Addrs:     []ids.ShortID{ids.ShortEmpty},
 					},
 				},
-				ConsortiumMemberAddress: caminoPreFundedKeys[0].PublicKey().Address(),
 			}
 
 			utx = tt.preExecute(t, utx)

--- a/vms/platformvm/txs/camino_add_validator_tx.go
+++ b/vms/platformvm/txs/camino_add_validator_tx.go
@@ -18,16 +18,13 @@ import (
 var (
 	_ ValidatorTx = (*CaminoAddValidatorTx)(nil)
 
-	errAssetNotAVAX                 = errors.New("locked output must be AVAX")
-	errStakeOutsNotEmpty            = errors.New("stake outputs must be empty")
-	errEmptyConsortiumMemberAddress = errors.New("consortium member address cannot be empty")
+	errAssetNotAVAX      = errors.New("locked output must be AVAX")
+	errStakeOutsNotEmpty = errors.New("stake outputs must be empty")
 )
 
 // CaminoAddValidatorTx is an unsigned caminoAddValidatorTx
 type CaminoAddValidatorTx struct {
 	AddValidatorTx `serialize:"true"`
-
-	ConsortiumMemberAddress ids.ShortID `serialize:"true" json:"consortiumMemberAddress"`
 }
 
 func (tx *CaminoAddValidatorTx) Stake() []*avax.TransferableOutput {
@@ -51,8 +48,6 @@ func (tx *CaminoAddValidatorTx) SyntacticVerify(ctx *snow.Context) error {
 		return errTooManyShares
 	case tx.Validator.NodeID == ids.EmptyNodeID:
 		return errEmptyNodeID
-	case tx.ConsortiumMemberAddress == ids.ShortEmpty:
-		return errEmptyConsortiumMemberAddress
 	}
 
 	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -334,7 +334,7 @@ func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf api.Camino) []b
 	return genesisBytes
 }
 
-func generateTestUTXO(txID ids.ID, outputIndex int, assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.UTXO {
+func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.UTXO {
 	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
 		Amt:          amount,
 		OutputOwners: outputOwners,
@@ -351,7 +351,7 @@ func generateTestUTXO(txID ids.ID, outputIndex int, assetID ids.ID, amount uint6
 	testUTXO := &avax.UTXO{
 		UTXOID: avax.UTXOID{
 			TxID:        txID,
-			OutputIndex: uint32(outputIndex),
+			OutputIndex: uint32(0),
 		},
 		Asset: avax.Asset{ID: assetID},
 		Out:   out,


### PR DESCRIPTION
- Add consortium nodes state, that will map nodeID to consortium member addresses. This state will be initially filled from genesis, but we will add possibility to add new records via transaction.
- Update addValidator transaction to use consortium nods state and consortium member signatures in instead of node signature to confirm, that this transaction is authorized by both node owner and consortium member.
- Fix linkedDB key bug: now Put method will copy key slice underlying array to prevent for-range array value replacement (thanks @c4t-ag for the solution) 
- Add missed camino state Close() method that will close databases, this method is now called from avax state.Close()
- Make multi-signature owners accessible from diff: multi-signature owners still shouldn't be modified after genesis, but we need to get multi-signature owner from diff, in order to use it in executor