### PR TITLE
Add registerNodeTx builder and service methods

### DIFF
--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -33,6 +33,9 @@ func newCaminoTxMetrics(
 		txMetrics: *txm,
 		// Camino specific tx metrics
 		numAddAddressStateTxs: newTxMetric(namespace, "add_address_state", registerer, &errs),
+		numDepositTxs:         newTxMetric(namespace, "deposit", registerer, &errs),
+		numUnlockDepositTxs:   newTxMetric(namespace, "unlock_deposit", registerer, &errs),
+		numRegisterNodeTx:     newTxMetric(namespace, "register_node", registerer, &errs),
 	}
 	return m, errs.Err
 }

--- a/vms/platformvm/msig/msig.go
+++ b/vms/platformvm/msig/msig.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package msig
+
+import (
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+func GetOwner(state state.Chain, addr ids.ShortID) (*secp256k1fx.OutputOwners, error) {
+	msigOwner, err := state.GetMultisigOwner(addr)
+	if err != nil && err != database.ErrNotFound {
+		return nil, err
+	}
+
+	if msigOwner != nil {
+		return &msigOwner.Owners, nil
+	}
+
+	return &secp256k1fx.OutputOwners{
+		Threshold: 1,
+		Addrs:     []ids.ShortID{addr},
+	}, nil
+}

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -250,6 +250,14 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 
 	for _, consortiumMemberNode := range g.Camino.ConsortiumMembersNodeIDs {
 		cs.SetNodeConsortiumMember(consortiumMemberNode.NodeID, &consortiumMemberNode.ConsortiumMemberAddress)
+		addrState, err := cs.GetAddressStates(consortiumMemberNode.ConsortiumMemberAddress)
+		if err != nil {
+			return err
+		}
+		cs.SetAddressStates(
+			consortiumMemberNode.ConsortiumMemberAddress,
+			addrState|txs.AddressStateRegisteredNodeBit,
+		)
 	}
 
 	// adding deposit offers

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -259,7 +259,6 @@ func (mr *MockChainMockRecorder) SetNodeConsortiumMember(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeConsortiumMember", reflect.TypeOf((*MockChain)(nil).SetNodeConsortiumMember), arg0, arg1)
 }
 
-
 // GetNodeConsortiumMember mocks base method.
 func (m *MockChain) GetNodeConsortiumMember(arg0 ids.NodeID) (ids.ShortID, error) {
 	m.ctrl.T.Helper()

--- a/vms/platformvm/txs/camino_address_state_tx.go
+++ b/vms/platformvm/txs/camino_address_state_tx.go
@@ -29,8 +29,8 @@ const (
 	AddressStateConsortiumBit  = uint64(0b10000000000000000000000000000000000)
 	AddressStateKycBits        = uint64(0b11100000000000000000000000000000000)
 
-	AddressStateValidator     = uint8(38)
-	AddressStateValidatorBits = uint64(0b100000000000000000000000000000000000000)
+	AddressStateRegisteredNode    = uint8(38)
+	AddressStateRegisteredNodeBit = uint64(0b100000000000000000000000000000000000000)
 
 	AddressStateMax       = uint8(63)
 	AddressStateValidBits = AddressStateRoleBits | AddressStateKycBits

--- a/vms/platformvm/txs/camino_register_node_tx.go
+++ b/vms/platformvm/txs/camino_register_node_tx.go
@@ -15,7 +15,8 @@ import (
 var (
 	_ UnsignedTx = (*RegisterNodeTx)(nil)
 
-	errNoNodeID = errors.New("no nodeID specified")
+	errNoNodeID                  = errors.New("no nodeID specified")
+	errConsortiumMemberAddrEmpty = errors.New("consortium member address is empty")
 )
 
 // RegisterNodeTx is an unsigned registerNodeTx
@@ -49,10 +50,16 @@ func (tx *RegisterNodeTx) SyntacticVerify(ctx *snow.Context) error {
 		return nil
 	case tx.NewNodeID == ids.EmptyNodeID && tx.OldNodeID == ids.EmptyNodeID:
 		return errNoNodeID
+	case tx.ConsortiumMemberAddress == ids.ShortEmpty:
+		return errConsortiumMemberAddrEmpty
 	}
 
 	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {
 		return fmt.Errorf("failed to verify BaseTx: %w", err)
+	}
+
+	if err := tx.ConsortiumMemberAuth.Verify(); err != nil {
+		return fmt.Errorf("failed to verify consortium member auth: %w", err)
 	}
 
 	// cache that this is valid

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/platformvm/msig"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/utxo"
@@ -42,6 +43,7 @@ var (
 	errDepositDurationToBig       = errors.New("deposit duration is greater than deposit offer maximum duration")
 	errSupplyOverflow             = errors.New("resulting total supply would be more, than allowed maximum")
 	errNotConsortiumMember        = errors.New("address isn't consortium member")
+	errConsortiumMemberHasNode    = errors.New("consortium member already has registered node")
 	errConsortiumSignatureMissing = errors.New("wrong consortium's member signature")
 	errNotNodeOwner               = errors.New("node is registered for another consortium member address")
 )
@@ -125,7 +127,7 @@ func (e *CaminoStandardTxExecutor) AddValidatorTx(tx *txs.AddValidatorTx) error 
 		return err
 	}
 
-	consortiumMemberOwner, err := e.getMSIGOwner(consortiumMemberAddress)
+	consortiumMemberOwner, err := msig.GetOwner(e.State, consortiumMemberAddress)
 	if err != nil {
 		return err
 	}
@@ -631,9 +633,17 @@ func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error 
 		return errNotConsortiumMember
 	}
 
+	newNodeIDNotEmpty := tx.NewNodeID != ids.EmptyNodeID
+	oldNodeIDNotEmpty := tx.OldNodeID != ids.EmptyNodeID
+
+	if !oldNodeIDNotEmpty && newNodeIDNotEmpty &&
+		consortiumMemberAddressState&txs.AddressStateRegisteredNodeBit == 1 {
+		return errConsortiumMemberHasNode
+	}
+
 	// verify consortium member cred
 
-	consortiumMemberOwner, err := e.getMSIGOwner(tx.ConsortiumMemberAddress)
+	consortiumMemberOwner, err := msig.GetOwner(e.State, tx.ConsortiumMemberAddress)
 	if err != nil {
 		return err
 	}
@@ -649,7 +659,6 @@ func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error 
 
 	// verify old nodeID ownership
 
-	oldNodeIDNotEmpty := tx.OldNodeID != ids.EmptyNodeID
 	if oldNodeIDNotEmpty {
 		oldNodeOwnerAddr, err := e.State.GetNodeConsortiumMember(tx.OldNodeID)
 		if err != nil {
@@ -662,7 +671,6 @@ func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error 
 
 	// verify new nodeID cred
 
-	newNodeIDNotEmpty := tx.NewNodeID != ids.EmptyNodeID
 	if newNodeIDNotEmpty {
 		if err := e.Backend.Fx.VerifyPermission(
 			e.Tx.Unsigned,
@@ -687,7 +695,7 @@ func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error 
 		e.Tx.Creds[:len(e.Tx.Creds)-2], // base tx creds
 		e.Config.TxFee,
 		e.Ctx.AVAXAssetID,
-		locked.StateUnlocked,
+		locked.StateBonded,
 	); err != nil {
 		return err
 	}
@@ -707,6 +715,18 @@ func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error 
 
 	if newNodeIDNotEmpty {
 		e.State.SetNodeConsortiumMember(tx.NewNodeID, &tx.ConsortiumMemberAddress)
+	}
+
+	newConsortiumMemberAddressState := consortiumMemberAddressState
+
+	if !oldNodeIDNotEmpty && newNodeIDNotEmpty {
+		newConsortiumMemberAddressState |= txs.AddressStateRegisteredNodeBit
+	} else if !newNodeIDNotEmpty {
+		newConsortiumMemberAddressState &^= txs.AddressStateRegisteredNodeBit
+	}
+
+	if newConsortiumMemberAddressState != consortiumMemberAddressState {
+		e.State.SetAddressStates(tx.ConsortiumMemberAddress, newConsortiumMemberAddressState)
 	}
 
 	return nil
@@ -801,7 +821,7 @@ func verifyAccess(roles, statesBit uint64) error {
 		if (roles & txs.AddressStateRoleKycBit) == 0 {
 			return errInvalidRoles
 		}
-	case (txs.AddressStateValidatorBits & statesBit) != 0:
+	case (txs.AddressStateRegisteredNodeBit & statesBit) != 0:
 		if (roles & txs.AddressStateRoleValidatorBit) == 0 {
 			return errInvalidRoles
 		}
@@ -822,20 +842,4 @@ func verifyAddrsOwner(addrs set.Set[ids.ShortID], owner *secp256k1fx.OutputOwner
 		}
 	}
 	return errors.New("missing signature")
-}
-
-func (e *CaminoStandardTxExecutor) getMSIGOwner(addr ids.ShortID) (*secp256k1fx.OutputOwners, error) {
-	msigOwner, err := e.State.GetMultisigOwner(addr)
-	if err != nil && err != database.ErrNotFound {
-		return nil, err
-	}
-
-	if msigOwner != nil {
-		return &msigOwner.Owners, nil
-	}
-
-	return &secp256k1fx.OutputOwners{
-		Threshold: 1,
-		Addrs:     []ids.ShortID{addr},
-	}, nil
 }

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -222,7 +222,9 @@ func TestCaminoStandardTxExecutorAddValidatorTx(t *testing.T) {
 					changeAddr:    ids.ShortEmpty,
 				}
 			},
-			preExecute:  func(t *testing.T, tx *txs.Tx) {},
+			preExecute: func(t *testing.T, tx *txs.Tx) {
+				env.state.SetNodeConsortiumMember(nodeID, &addr0)
+			},
 			expectedErr: errConsortiumSignatureMissing,
 		},
 		"Not enough sigs from msig consortium member": {


### PR DESCRIPTION
This PR adds:
- rpc handler that creates new registerNodeTx transaction
- corresponding tx builder method
- missed checks in registerNodeTx syntactic check
- registers missed metrics (deposit, unlockDeposit, registerNode)
- address state bit for address that registered node, now checked/updated in registerNodeTx