### PR TITLE
[GENESIS] Split PlatformAllocation by MaxStake

### DIFF
--- a/genesis/genesis_kopernikus.json
+++ b/genesis/genesis_kopernikus.json
@@ -62,14 +62,14 @@
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
         "avaxAddr": "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3",
-        "xAmount": 988998000000000000,
+        "xAmount": 988994000000000000,
         "addressStates": {
           "consortiumMember": true,
           "kycVerified": true
         },
         "platformAllocations": [
           {
-            "amount": 2000000000000,
+            "amount": 4000000000000,
             "nodeID": "NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL",
             "validatorDuration": 31536000,
             "depositOfferID": "wVVZinZkN9x6e9dh3DNNfrmdXaHPPwKWt3Zerx2vD8Ccuo6E7",

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -374,11 +374,11 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "MXCF5iu2oy7exb7CRJQf1krydFTz7GeAbTZSbotNNdFKeDFan",
+			expectedID: "23TBPZcVmyrcZJepPEmMWDju64VKhfZwAf14gZt263sVU8xL3Y",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "2EgNKCY4aCx5ihqW4RKVA8pvc4UGCwFHcU2HxZ6SJk9ZaYJ2cb",
+			expectedID: "C9N6PC7bmub2FDWqHzw8tAQkP284coq8H8wuR74ahwwCHcQrs",
 		},
 		{
 			networkID:  constants.LocalID,
@@ -439,7 +439,7 @@ func TestVMGenesis(t *testing.T) {
 			vmTest: []vmTest{
 				{
 					vmID:       constants.AVMID,
-					expectedID: "gJXhUnsXEka3zrocAe5hn1iawYRxjZTUYF8u9qiiPY59DUWeh",
+					expectedID: "2hQXfgx6aeM7ZPthZJTdtUK6rG1uhdvfYqFhBw7ajziYMM7toX",
 				},
 				{
 					vmID:       constants.EVMID,
@@ -505,7 +505,7 @@ func TestAVAXAssetID(t *testing.T) {
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "j96h2LMjHpFXL5BCsH3gwhQ4gTq6DxyfCW2xmVLAu2C1fAgq1",
+			expectedID: "227CxttTm32vqdUFsYjysNdXdrFahsmwqCwjjFteuQpmsEeCbv",
 		},
 		{
 			networkID:  constants.LocalID,


### PR DESCRIPTION
## Why this should be merged
All genesis platform allocation is used for stake, because stakingConfig is not checked
## How this works
PlatformAllocations are split in stake and deposits
