### PR TITLE
Peak3d/spend

### DIFF
--- a/genesis/genesis_kopernikus.go
+++ b/genesis/genesis_kopernikus.go
@@ -3,7 +3,7 @@
 
 // PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE => X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3
 // PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN => X-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68
-// staking/local/staker1.key / crt => NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL
+// staking/local/staker1.key / crt => NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL => PrivateKey-26ksbvjbz8jUTtzbCm3MYobKcDh22QPuPQX5dj2faQdR63TRdM
 // 56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 => 0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC
 
 package genesis


### PR DESCRIPTION
## Why this should be merged
This PR includes a few changes required for getting caminojs working with the new Spend() logic on platform chain
- Return signer addresses in Spend() to allow proper signing
- Remove GetAddressStatesTx because of missing signers
- Implement GetAddressStatesTx to fetch the states applied to an address
