### PR TITLE
[TX] RegisterNodeTx: Verify that node is not already registered

### DIFF
--- a/genesis/genesis_kopernikus.go
+++ b/genesis/genesis_kopernikus.go
@@ -4,6 +4,7 @@
 // PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE => X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3
 // PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN => X-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68
 // staking/local/staker1.key / crt => NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL => PrivateKey-26ksbvjbz8jUTtzbCm3MYobKcDh22QPuPQX5dj2faQdR63TRdM
+// staking/local/staker2.key / crt => NodeID-D1LbWvUf9iaeEyUbTYYtYq4b7GaYR5tnJ => PrivateKey-2ZW6HUePBW2dP7dBGa5stjXe1uvK9LwEgrjebDwXEyL5bDMWWS
 // 56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027 => 0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC
 
 package genesis


### PR DESCRIPTION
## Why this should be merged
Right now it is possible to overwrite an already registered node->member mapping in case 2 different addresses register for the same nodeID.

## How this was tested
- Register a nodeID as validator in genesis
- Execute a RegisterNodeTx with a new address but the existing nodeID.