### PR TITLE
[PVM] Force Lock instead Spend in case of lockModeBondDeposit

### DIFF
--- a/genesis/camino_genesis_test.go
+++ b/genesis/camino_genesis_test.go
@@ -1,0 +1,55 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package genesis
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenesisChainData(t *testing.T) {
+	type vmTest struct {
+		vmIDs      []ids.ID
+		expectedID []string
+	}
+	tests := []struct {
+		networkID uint32
+		vmTest    vmTest
+	}{
+		{
+			networkID: constants.CaminoID,
+			vmTest: vmTest{
+				vmIDs:      []ids.ID{constants.AVMID, constants.EVMID},
+				expectedID: []string{"yMQo4UEa2Gkk6aSmifkUuBsystV1iu1NppatvoYz6yCDnRjiq", "RinAZCjd5Dm4wk1FBWiXiiSW2VZkjzgNyR7nNBRkuCvG9zRkJ"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(constants.NetworkIDToNetworkName[test.networkID], func(t *testing.T) {
+			require := require.New(t)
+
+			config := GetConfig(test.networkID)
+			genesisBytes, _, err := FromConfig(config)
+			require.NoError(err)
+
+			genesisTx, lock, err := GenesisChainData(genesisBytes, test.vmTest.vmIDs)
+			require.NoError(err)
+			require.True(lock)
+
+			for idx, tx := range genesisTx {
+				require.Equal(
+					test.vmTest.expectedID[idx],
+					tx.ID().String(),
+					"%s genesisID with networkID %d mismatch",
+					test.vmTest.vmIDs[idx],
+					test.networkID,
+				)
+			}
+		})
+	}
+}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -24,7 +24,9 @@ fi
 TESTS=${TESTS:-"golangci_lint license_header"}
 
 function test_golangci_lint {
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+  if ! [ -x "$(command -v golangci-lint)" ]; then
+    go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+  fi
   golangci-lint run --config .golangci.yml
 }
 

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -94,7 +94,7 @@ func TestCaminoBuilderTxAddressState(t *testing.T) {
 				tt.remove,
 				tt.state,
 				caminoPreFundedKeys,
-				ids.ShortEmpty,
+				nil,
 			)
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
@@ -251,7 +251,7 @@ func TestUnlockDepositTx(t *testing.T) {
 			tx, err := env.txBuilder.NewUnlockDepositTx(
 				[]ids.ID{depositTxID},
 				[]*crypto.PrivateKeySECP256K1R{testKey.(*crypto.PrivateKeySECP256K1R)},
-				ids.ShortEmpty,
+				nil,
 			)
 			require.ErrorIs(t, err, tt.expectedErr)
 

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -139,7 +139,7 @@ func newCaminoEnvironment(postBanff bool, caminoGenesisConf api.Camino) *caminoE
 
 	atomicUTXOs := avax.NewAtomicUTXOManager(ctx.SharedMemory, txs.Codec)
 	uptimes := uptime.NewManager(baseState)
-	utxoHandler := utxo.NewHandler(ctx, &clk, baseState, fx)
+	utxoHandler := utxo.NewCaminoHandler(ctx, &clk, baseState, fx, true)
 
 	txBuilder := NewCamino(
 		ctx,

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -106,7 +106,7 @@ func newCaminoEnvironment(postBanff bool, caminoGenesisConf api.Camino) *caminoE
 
 	atomicUTXOs := avax.NewAtomicUTXOManager(ctx.SharedMemory, txs.Codec)
 	uptimes := uptime.NewManager(baseState)
-	utxoHandler := utxo.NewHandler(ctx, &clk, baseState, fx)
+	utxoHandler := utxo.NewCaminoHandler(ctx, &clk, baseState, fx, true)
 
 	txBuilder := builder.NewCamino(
 		ctx,

--- a/vms/platformvm/utxo/camino_handler.go
+++ b/vms/platformvm/utxo/camino_handler.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utxo
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+type caminoHandler struct {
+	handler
+	lockModeBondDeposit bool
+}
+
+func NewCaminoHandler(
+	ctx *snow.Context,
+	clk *mockable.Clock,
+	utxoReader avax.UTXOReader,
+	fx fx.Fx,
+	lockModeBondDeposit bool,
+) Handler {
+	return &caminoHandler{
+		handler: handler{
+			ctx:         ctx,
+			clk:         clk,
+			utxosReader: utxoReader,
+			fx:          fx,
+		},
+		lockModeBondDeposit: lockModeBondDeposit,
+	}
+}
+
+func (h *caminoHandler) Spend(
+	keys []*crypto.PrivateKeySECP256K1R,
+	amount uint64,
+	fee uint64,
+	changeAddr ids.ShortID,
+) (
+	[]*avax.TransferableInput, // inputs
+	[]*avax.TransferableOutput, // returnedOutputs
+	[]*avax.TransferableOutput, // stakedOutputs
+	[][]*crypto.PrivateKeySECP256K1R, // signers
+	error,
+) {
+	if h.lockModeBondDeposit {
+		var change *secp256k1fx.OutputOwners
+		if changeAddr != ids.ShortEmpty {
+			change = &secp256k1fx.OutputOwners{
+				Locktime:  0,
+				Threshold: 1,
+				Addrs:     []ids.ShortID{changeAddr},
+			}
+		}
+		inputs, outputs, signers, err := h.Lock(keys, amount, fee, locked.StateUnlocked, nil, change, 0)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		return inputs, outputs, []*avax.TransferableOutput{}, signers, nil
+	}
+	return h.handler.Spend(keys, amount, fee, changeAddr)
+}

--- a/vms/platformvm/utxo/camino_owner_id.go
+++ b/vms/platformvm/utxo/camino_owner_id.go
@@ -15,6 +15,14 @@ import (
 
 var errOutNotOwned = errors.New("out doesn't implement fx.Owned interface")
 
+type OwnedWrapper struct {
+	wrapped interface{}
+}
+
+func (o OwnedWrapper) Owners() interface{} {
+	return o.wrapped
+}
+
 // Returns hash of marshalled bytes of output owner, which can be treated as owner ID.
 // [out] must implement fx.Owned interface.
 func GetOwnerID(out interface{}) (ids.ID, error) {

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -178,7 +178,16 @@ func (vm *VM) Initialize(
 	}
 
 	vm.atomicUtxosManager = avax.NewAtomicUTXOManager(chainCtx.SharedMemory, txs.Codec)
-	utxoHandler := utxo.NewHandler(vm.ctx, &vm.clock, vm.state, vm.fx)
+
+	camCfg, _ := vm.state.CaminoConfig()
+	utxoHandler := utxo.NewCaminoHandler(
+		vm.ctx,
+		&vm.clock,
+		vm.state,
+		vm.fx,
+		camCfg != nil && camCfg.LockModeBondDeposit,
+	)
+
 	vm.uptimeManager = uptime.NewManager(vm.state)
 	vm.UptimeLockedCalculator.SetCalculator(&vm.bootstrapped, &chainCtx.Lock, vm.uptimeManager)
 


### PR DESCRIPTION
## Why this should be merged
Non-Camino specific tx via API are currently built using avalanche Spend() function.
This work switches to camino Lock() instead ava Spend() function to benefit from our imroved compacting logic.

Beside this Lock() function was extended to allow different owner groups for chnage and (unlocked) outputs to fulfill the existing mplementation in caminojs.

## How this works
The handler, responsible for producing inputs and outputs in Spend() function, is initialized with the lockmodeBondDeposit.
In case it is true, we call Lock() inside Spend() instead normal processing.

## How this was tested
Unit Tests
