### PR TITLE
VerifySpend override

### DIFF
--- a/vms/platformvm/utxo/handler.go
+++ b/vms/platformvm/utxo/handler.go
@@ -69,7 +69,7 @@ func Produce(
 }
 
 // TODO: Stake and Authorize should be replaced by similar methods in the
-//	P-chain wallet
+//       P-chain wallet
 type Spender interface {
 	// Spend the provided amount while deducting the provided fee.
 	// Arguments:
@@ -567,12 +567,12 @@ func (h *handler) VerifySpendUTXOs(
 		}
 
 		// Get output signed by real owners (would stay the same if its not msig)
-		msigOut, err := h.getMultisigTransferOutput(utxo)
+		out, err := h.getMultisigTransferOutput(out)
 		if err != nil {
 			return err
 		}
 		// Verify that this tx's credentials allow [in] to be spent
-		if err := h.fx.VerifyTransfer(tx, in, creds[index], msigOut); err != nil {
+		if err := h.fx.VerifyTransfer(tx, in, creds[index], out); err != nil {
 			return fmt.Errorf("failed to verify transfer: %w", err)
 		}
 


### PR DESCRIPTION
This PR adds:
- Override VerifySpend and VerifySpendUTXOs funcs in caminoHandler - now they call avax VerifySpend funcs if lockModeDepositBond false, and call VerifyLock if true. This fixes bug, when avax VerifySpend was processing locked.Out without error.
- Changes VerifyLockUTXOs func, so it will now accept appliedLockState unlocked. In this case, func will error if any of utxos are locked. This is used to verify burn-only or cross-chain avax transactions
- Changes handler getMultisigTransferOutput func to accept secp out instead of utxo, func will error on wrong out type.