### PR TITLE
Replace genesis.Block UnlockedUTXOsTx single tx field with []*txs.Tx

### DIFF
--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,15 +370,15 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "26iyDcHpjqw6sm7rTZJ4aC4KxegngGVsdY8hX6n8SH7mY7YJ8U",
+			expectedID: "9z7NSs8bnNuhv5AwEf2exY35SsYaJL7gW9Z5oT14hZmnkaiUM",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "2cigqmnKPYfuzjbd7iM7brWrYrSy3kUwq9M75oYHf8x6TnTQx3",
+			expectedID: "2FTgrjjDa5S7hCwpyZNsMccUACZ5Z4ToqHVxtFtECSyF3DKgge",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "28AD11ihPPg3oXLgnonVKauA62pr7yC6nd8JEEg4yFBKgsTvmq",
+			expectedID: "2BKZXGV9hJqf4jU9CrKMaXEdNxLBHAqRGmEgTWb7L6GmC9dqR8",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -194,10 +194,10 @@ func (ma *MultisigAlias) Verify(txID ids.ID) error {
 }
 
 type Block struct {
-	Timestamp       uint64    `serialize:"true"`
-	Deposits        []*txs.Tx `serialize:"true"`
-	Validators      []*txs.Tx `serialize:"true"`
-	UnlockedUTXOsTx *txs.Tx   `serialize:"true"`
+	Timestamp        uint64    `serialize:"true"`
+	Deposits         []*txs.Tx `serialize:"true"`
+	Validators       []*txs.Tx `serialize:"true"`
+	UnlockedUTXOsTxs []*txs.Tx `serialize:"true"`
 }
 
 func (b *Block) Init() error {
@@ -211,8 +211,10 @@ func (b *Block) Init() error {
 			return err
 		}
 	}
-	if err := b.UnlockedUTXOsTx.Sign(txs.GenesisCodec, nil); err != nil {
-		return err
+	for _, tx := range b.UnlockedUTXOsTxs {
+		if err := tx.Sign(txs.GenesisCodec, nil); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -226,8 +228,8 @@ func (b *Block) Time() time.Time {
 }
 
 func (b *Block) Txs() []*txs.Tx {
-	txs := make([]*txs.Tx, 0, len(b.Validators)+len(b.Deposits)+1)
+	txs := make([]*txs.Tx, 0, len(b.Validators)+len(b.Deposits)+len(b.UnlockedUTXOsTxs))
 	txs = append(txs, b.Validators...)
 	txs = append(txs, b.Deposits...)
-	return append(txs, b.UnlockedUTXOsTx)
+	return append(txs, b.UnlockedUTXOsTxs...)
 }

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -286,14 +286,9 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 	// adding blocks (validators and deposits)
 
 	for blockIndex, block := range g.Camino.Blocks {
-		// add unlocked utxos tx
-		tx, ok := block.UnlockedUTXOsTx.Unsigned.(*txs.BaseTx)
-		if !ok {
-			return errWrongTxType
-		}
-
-		if len(tx.Outs) > 0 {
-			s.AddTx(block.UnlockedUTXOsTx, status.Committed)
+		// add unlocked utxos txs
+		for _, tx := range block.UnlockedUTXOsTxs {
+			s.AddTx(tx, status.Committed)
 		}
 
 		// add validators

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -190,8 +190,7 @@ func defaultGenesisState(addresses []genesis.AddressState, deposits []*txs.Tx) *
 						RewardsOwner: &secp256k1fx.OutputOwners{},
 					},
 				}}},
-				Deposits:        deposits,
-				UnlockedUTXOsTx: &txs.Tx{Unsigned: &txs.BaseTx{}},
+				Deposits: deposits,
 			}},
 			DepositOffers: []genesis.DepositOffer{
 				{


### PR DESCRIPTION
Initially, genesis.Block.UnlockedUTXOsTx field was always containing non-nil transaction, even if transaction itself was empty. That was done, because we can't marshal nil. This PR replaces this field with array of transactions, but array will contain either zero or just one transaction.