### PR TITLE
[PVM] Add GetClaimables api, owner id refactoring

### DIFF
--- a/vms/platformvm/txs/camino_owner_id.go
+++ b/vms/platformvm/txs/camino_owner_id.go
@@ -1,7 +1,7 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package utxo
+package txs
 
 import (
 	"errors"
@@ -10,30 +10,25 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
-	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
 var errOutNotOwned = errors.New("out doesn't implement fx.Owned interface")
 
-type OwnedWrapper struct {
-	wrapped interface{}
-}
-
-func (o OwnedWrapper) Owners() interface{} {
-	return o.wrapped
-}
-
-// Returns hash of marshalled bytes of output owner, which can be treated as owner ID.
-// [out] must implement fx.Owned interface.
-func GetOwnerID(out interface{}) (ids.ID, error) {
-	owned, ok := out.(fx.Owned)
-	if !ok {
-		return ids.Empty, fmt.Errorf("expected fx.Owned but got %T: %w", out, errOutNotOwned)
-	}
-	owner := owned.Owners()
-	ownerBytes, err := txs.Codec.Marshal(txs.Version, owner)
+// Returns hash of marshalled bytes of owner, which can be treated as owner ID.
+func GetOwnerID(owner interface{}) (ids.ID, error) {
+	ownerBytes, err := Codec.Marshal(Version, owner)
 	if err != nil {
 		return ids.Empty, fmt.Errorf("couldn't marshal owner: %w", err)
 	}
 	return hashing.ComputeHash256Array(ownerBytes), nil
+}
+
+// Returns hash of marshalled bytes of output owner, which can be treated as owner ID.
+// [out] must implement fx.Owned interface.
+func GetOutputOwnerID(out interface{}) (ids.ID, error) {
+	owned, ok := out.(fx.Owned)
+	if !ok {
+		return ids.Empty, fmt.Errorf("expected fx.Owned but got %T: %w", out, errOutNotOwned)
+	}
+	return GetOwnerID(owned.Owners())
 }

--- a/vms/platformvm/txs/executor/camino_state_changes.go
+++ b/vms/platformvm/txs/executor/camino_state_changes.go
@@ -187,7 +187,7 @@ func caminoAdvanceTimeTo(
 					Addrs:     []ids.ShortID{validatorAddr},
 				}
 
-				ownerID, err := GetOwnerID(owner)
+				ownerID, err := txs.GetOwnerID(owner)
 				if err != nil {
 					return err
 				}
@@ -237,12 +237,4 @@ func caminoAdvanceTimeTo(
 	}
 
 	return nil
-}
-
-func GetOwnerID(owner *secp256k1fx.OutputOwners) (ids.ID, error) {
-	ownerBytes, err := txs.Codec.Marshal(txs.Version, owner)
-	if err != nil {
-		return ids.Empty, fmt.Errorf("couldn't marshal owner: %w", err)
-	}
-	return hashing.ComputeHash256Array(ownerBytes), nil
 }

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -268,7 +268,7 @@ func (h *handler) Lock(
 
 	var toOwnerID *ids.ID
 	if to != nil && appliedLockState == locked.StateUnlocked {
-		id, err := GetOwnerID(OwnedWrapper{*to})
+		id, err := txs.GetOwnerID(to)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -277,7 +277,7 @@ func (h *handler) Lock(
 
 	var changeOwnerID *ids.ID
 	if change != nil {
-		id, err := GetOwnerID(OwnedWrapper{*change})
+		id, err := txs.GetOwnerID(change)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -317,7 +317,7 @@ func (h *handler) Lock(
 			continue
 		}
 
-		outOwnerID, err := GetOwnerID(out)
+		outOwnerID, err := txs.GetOutputOwnerID(out)
 		if err != nil {
 			// We couldn't get owner of this output, so move on to the next one
 			continue
@@ -886,7 +886,7 @@ func (h *handler) VerifyLockUTXOs(
 
 		ownerID := &ids.Empty
 		if *otherLockTxID != ids.Empty {
-			id, err := GetOwnerID(out)
+			id, err := txs.GetOutputOwnerID(out)
 			if err != nil {
 				return err
 			}
@@ -931,7 +931,7 @@ func (h *handler) VerifyLockUTXOs(
 
 		ownerID := &ids.Empty
 		if *otherLockTxID != ids.Empty {
-			id, err := GetOwnerID(out)
+			id, err := txs.GetOutputOwnerID(out)
 			if err != nil {
 				return err
 			}
@@ -1111,7 +1111,7 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 			}
 
 			// calculating consumed amounts
-			ownerID, err := GetOwnerID(out)
+			ownerID, err := txs.GetOutputOwnerID(out)
 			if err != nil {
 				return nil, err
 			}
@@ -1172,7 +1172,7 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 
 		producedAmount := out.Amount()
 
-		ownerID, err := GetOwnerID(out)
+		ownerID, err := txs.GetOutputOwnerID(out)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR does 2 things:
- We have duplicated definitions of owner id funcs, this PR replaces them with just one in txs package.
- Add GetClaimables rpc handler, which returns amounts (validator reward, expired deposit reward) that can be claimed by given owner and deposit reward amounts for given deposit transaction ids that can be claimed at current timestamp.