### PR TITLE
[PVM] Make GetClaimables api work without error, when claimable not found

### DIFF
--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"github.com/ava-labs/avalanchego/api"
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto"
@@ -20,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/keystore"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/vms/types"
@@ -509,7 +511,9 @@ func (s *CaminoService) GetClaimables(_ *http.Request, args *GetClaimablesArgs, 
 	}
 
 	claimable, err := s.vm.state.GetClaimable(ownerID)
-	if err != nil {
+	if err == database.ErrNotFound {
+		claimable = &state.Claimable{}
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`GetClaimables` api is calling `state.GetClaimable(ownerID)` method and was returning error if state method errored. Now, if error is database.ErrNotFound, it just uses zero-value with 0 in amount fields, which is correct behavior.