### PR TITLE
[PVM] Various fixes

### DIFF
--- a/vms/platformvm/state/camino_claimable.go
+++ b/vms/platformvm/state/camino_claimable.go
@@ -28,6 +28,9 @@ func (cs *caminoState) SetClaimable(ownerID ids.ID, claimable *Claimable) {
 
 func (cs *caminoState) GetClaimable(ownerID ids.ID) (*Claimable, error) {
 	if claimable, ok := cs.modifiedClaimables[ownerID]; ok {
+		if claimable == nil {
+			return nil, database.ErrNotFound
+		}
 		return claimable, nil
 	}
 

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -216,6 +216,9 @@ func (d *diff) SetClaimable(ownerID ids.ID, claimable *Claimable) {
 
 func (d *diff) GetClaimable(ownerID ids.ID) (*Claimable, error) {
 	if claimable, ok := d.caminoDiff.modifiedClaimables[ownerID]; ok {
+		if claimable == nil {
+			return nil, database.ErrNotFound
+		}
 		return claimable, nil
 	}
 

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -274,6 +274,10 @@ func TestUnlockDepositTx(t *testing.T) {
 }
 
 func TestNewClaimRewardTx(t *testing.T) {
+	caminoConfig := &state.CaminoConfig{
+		LockModeBondDeposit: true,
+	}
+
 	depositTxID1 := ids.GenerateTestID()
 	depositTxID2 := ids.GenerateTestID()
 
@@ -299,6 +303,7 @@ func TestNewClaimRewardTx(t *testing.T) {
 		"OK, single deposit tx": {
 			state: func(ctrl *gomock.Controller) state.State {
 				s := state.NewMockState(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// utxo fetching for utxo handler Lock(..)
 				s.EXPECT().UTXOIDs(feeAddr[:], ids.Empty, math.MaxInt).Return([]ids.ID{feeUTXO.InputID()}, nil)
 				s.EXPECT().UTXOIDs(rewardOwner1Addr[:], ids.Empty, math.MaxInt).Return([]ids.ID{}, nil)
@@ -325,6 +330,7 @@ func TestNewClaimRewardTx(t *testing.T) {
 		"OK, two deposit tx": {
 			state: func(ctrl *gomock.Controller) state.State {
 				s := state.NewMockState(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// utxo fetching for utxo handler Lock(..)
 				s.EXPECT().UTXOIDs(feeAddr[:], ids.Empty, math.MaxInt).Return([]ids.ID{feeUTXO.InputID()}, nil)
 				s.EXPECT().UTXOIDs(rewardOwner1Addr[:], ids.Empty, math.MaxInt).Return([]ids.ID{}, nil)
@@ -356,6 +362,7 @@ func TestNewClaimRewardTx(t *testing.T) {
 		"OK, two deposit tx, owner keys intersect": {
 			state: func(ctrl *gomock.Controller) state.State {
 				s := state.NewMockState(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// utxo fetching for utxo handler Lock(..)
 				s.EXPECT().UTXOIDs(feeAddr[:], ids.Empty, math.MaxInt).Return([]ids.ID{feeUTXO.InputID()}, nil)
 				s.EXPECT().UTXOIDs(rewardOwner1Addr[:], ids.Empty, math.MaxInt).Return([]ids.ID{}, nil)
@@ -395,6 +402,7 @@ func TestNewClaimRewardTx(t *testing.T) {
 		"Fail, deposit errored": {
 			state: func(ctrl *gomock.Controller) state.State {
 				s := state.NewMockState(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// utxo fetching for utxo handler Lock(..)
 				s.EXPECT().UTXOIDs(feeAddr[:], ids.Empty, math.MaxInt).Return([]ids.ID{feeUTXO.InputID()}, nil)
 				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
@@ -414,6 +422,7 @@ func TestNewClaimRewardTx(t *testing.T) {
 		"Fail, deposit not committed": {
 			state: func(ctrl *gomock.Controller) state.State {
 				s := state.NewMockState(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// utxo fetching for utxo handler Lock(..)
 				s.EXPECT().UTXOIDs(feeAddr[:], ids.Empty, math.MaxInt).Return([]ids.ID{feeUTXO.InputID()}, nil)
 				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
@@ -433,6 +442,7 @@ func TestNewClaimRewardTx(t *testing.T) {
 		"Fail, deposit isn't deposit": {
 			state: func(ctrl *gomock.Controller) state.State {
 				s := state.NewMockState(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// utxo fetching for utxo handler Lock(..)
 				s.EXPECT().UTXOIDs(feeAddr[:], ids.Empty, math.MaxInt).Return([]ids.ID{feeUTXO.InputID()}, nil)
 				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
@@ -456,6 +466,7 @@ func TestNewClaimRewardTx(t *testing.T) {
 		"Fail, deposit rewards owner isn't secp type (shouldn't happen)": {
 			state: func(ctrl *gomock.Controller) state.State {
 				s := state.NewMockState(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// utxo fetching for utxo handler Lock(..)
 				s.EXPECT().UTXOIDs(feeAddr[:], ids.Empty, math.MaxInt).Return([]ids.ID{feeUTXO.InputID()}, nil)
 				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
@@ -479,6 +490,7 @@ func TestNewClaimRewardTx(t *testing.T) {
 		"Fail, missing deposit signer": {
 			state: func(ctrl *gomock.Controller) state.State {
 				s := state.NewMockState(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// utxo fetching for utxo handler Lock(..)
 				s.EXPECT().UTXOIDs(feeAddr[:], ids.Empty, math.MaxInt).Return([]ids.ID{feeUTXO.InputID()}, nil)
 				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)

--- a/vms/platformvm/txs/camino_reward_validator_tx.go
+++ b/vms/platformvm/txs/camino_reward_validator_tx.go
@@ -3,7 +3,13 @@
 
 package txs
 
-import "github.com/ava-labs/avalanchego/vms/components/avax"
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
 
 var _ UnsignedTx = (*CaminoRewardValidatorTx)(nil)
 
@@ -22,4 +28,26 @@ type CaminoRewardValidatorTx struct {
 	Outs []*avax.TransferableOutput `serialize:"true" json:"outputs"`
 
 	RewardValidatorTx `serialize:"true"`
+}
+
+func (tx *CaminoRewardValidatorTx) InitCtx(ctx *snow.Context) {
+	for _, in := range tx.Ins {
+		in.FxID = secp256k1fx.ID
+	}
+	for _, out := range tx.Outs {
+		out.FxID = secp256k1fx.ID
+		out.InitCtx(ctx)
+	}
+}
+
+func (tx *CaminoRewardValidatorTx) InputIDs() set.Set[ids.ID] {
+	inputIDs := set.NewSet[ids.ID](len(tx.Ins))
+	for _, in := range tx.Ins {
+		inputIDs.Add(in.InputID())
+	}
+	return inputIDs
+}
+
+func (tx *CaminoRewardValidatorTx) Outputs() []*avax.TransferableOutput {
+	return tx.Outs
 }

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -655,7 +655,7 @@ func (e *CaminoStandardTxExecutor) ClaimRewardTx(tx *txs.ClaimRewardTx) error {
 		return errWrongLockMode
 	}
 
-	if err := locked.VerifyLockMode(tx.Ins, tx.Outs, caminoConfig.LockModeBondDeposit); err != nil {
+	if err := locked.VerifyNoLocks(tx.Ins, tx.Outs); err != nil {
 		return err
 	}
 
@@ -758,6 +758,10 @@ func (e *CaminoStandardTxExecutor) ClaimRewardTx(tx *txs.ClaimRewardTx) error {
 }
 
 func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error {
+	if err := locked.VerifyNoLocks(tx.Ins, tx.Outs); err != nil {
+		return err
+	}
+
 	if err := e.Tx.SyntacticVerify(e.Ctx); err != nil {
 		return err
 	}
@@ -841,7 +845,7 @@ func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error 
 		e.Tx.Creds[:len(e.Tx.Creds)-2], // base tx creds
 		e.Config.TxFee,
 		e.Ctx.AVAXAssetID,
-		locked.StateBonded,
+		locked.StateUnlocked,
 	); err != nil {
 		return err
 	}
@@ -890,6 +894,10 @@ func addCreds(tx *txs.Tx, creds []verify.Verifiable) {
 }
 
 func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error {
+	if err := locked.VerifyNoLocks(tx.Ins, tx.Outs); err != nil {
+		return err
+	}
+
 	if err := e.Tx.SyntacticVerify(e.Ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Missing caminoRewardValidatorTx methods
This PR adds missing caminoRewardValidatorTx methods override for InitCtx, InputIDs and Outputs. Methods derived from parent tx aren't valid for camino tx.

#### Txs inconsistency with LockModeDepositBond
Various txs that should only burn fee weren't checking for "NoLocks", some of them was using VerifySpend and some - VerifyLock(locked.StateUnlocked). This PR fixes that by adding VerifyNoLocks check into corresponding executor functions.

Deposit-related txs like DepositTx, UnlockDepositTx, ClaimRewardTx weren't checking for  LockModeDepositBond in builder functions. This PR fixes this by adding this this checks.