### PR TITLE
[GENESIS] Replace deposit offer ids with arbitrary memo in genesis json

### DIFF
--- a/genesis/camino_config.go
+++ b/genesis/camino_config.go
@@ -130,7 +130,7 @@ type PlatformAllocation struct {
 	ValidatorDuration uint64     `json:"validatorDuration"`
 	DepositDuration   uint64     `json:"depositDuration"`
 	TimestampOffset   uint64     `json:"timestampOffset"`
-	DepositOfferID    ids.ID     `json:"depositOfferID"`
+	DepositOfferMemo  string     `json:"depositOfferMemo"`
 	Memo              string     `json:"memo"`
 }
 
@@ -139,16 +139,13 @@ func (a PlatformAllocation) Unparse() (UnparsedPlatformAllocation, error) {
 		Amount:            a.Amount,
 		ValidatorDuration: a.ValidatorDuration,
 		DepositDuration:   a.DepositDuration,
+		DepositOfferMemo:  a.DepositOfferMemo,
 		TimestampOffset:   a.TimestampOffset,
 		Memo:              a.Memo,
 	}
 
 	if a.NodeID != ids.EmptyNodeID {
 		ua.NodeID = a.NodeID.String()
-	}
-
-	if a.DepositOfferID != ids.Empty {
-		ua.DepositOfferID = a.DepositOfferID.String()
 	}
 
 	return ua, nil

--- a/genesis/camino_config_test.go
+++ b/genesis/camino_config_test.go
@@ -15,9 +15,8 @@ import (
 )
 
 var (
-	nodeID         = ids.GenerateTestNodeID()
-	depositOfferID = ids.GenerateTestID()
-	shortID2       = ids.GenerateTestShortID()
+	nodeID   = ids.GenerateTestNodeID()
+	shortID2 = ids.GenerateTestShortID()
 )
 
 func TestUnparse(t *testing.T) {
@@ -54,7 +53,10 @@ func TestUnparse(t *testing.T) {
 						Amount:            1,
 						NodeID:            nodeID,
 						ValidatorDuration: 1,
-						DepositOfferID:    depositOfferID,
+						DepositDuration:   1,
+						DepositOfferMemo:  "deposit offer memo",
+						TimestampOffset:   1,
+						Memo:              "some str",
 					}},
 				}},
 				InitialMultisigAddresses: []genesis.MultisigAlias{{
@@ -77,7 +79,10 @@ func TestUnparse(t *testing.T) {
 						Amount:            1,
 						NodeID:            nodeID.String(),
 						ValidatorDuration: 1,
-						DepositOfferID:    depositOfferID.String(),
+						DepositDuration:   1,
+						DepositOfferMemo:  "deposit offer memo",
+						TimestampOffset:   1,
+						Memo:              "some str",
 					}},
 				}},
 				InitialMultisigAddresses: []UnparsedMultisigAlias{{

--- a/genesis/genesis_camino.json
+++ b/genesis/genesis_camino.json
@@ -6,7 +6,7 @@
     "initialAdmin": "X-camino1m4nr983lhd4p4nfsqk3a6a9mejugnn73f83vuy",
     "depositOffers": [
       {
-        "offerID": "DDTaFCwYbhEiJ35ZSA25qFGbfrRnqoi4a9czFJ5WCbNYxf8NY",
+        "memo": "presale3y",
         "interestRateNominator": 80000,
         "startOffset": 0,
         "endOffset": 111585600,
@@ -20,7 +20,7 @@
         }
       },
       {
-        "offerID": "Mc2xe3kHRdAnCbMYhK1p4GhnpJSYbyR47d6upA8Xg98DMpByf",
+        "memo": "team5y",
         "interestRateNominator": 0,
         "startOffset": 0,
         "endOffset": 158889600,
@@ -34,7 +34,7 @@
         }
       },
       {
-        "offerID": "2qQCBBxw2wMZXNdqQKtDojeVpNN5z9WpRVuHsR4UBZr5wrXy9n",
+        "memo": "presale4y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 143121600,
@@ -48,7 +48,7 @@
         }
       },
       {
-        "offerID": "2mdhxmmNUgxmc8W17LpyegMVqHLofYGgDFVMEYuua9R4V4aSuj",
+        "memo": "presale5y",
         "interestRateNominator": 100000,
         "startOffset": 0,
         "endOffset": 174657600,
@@ -77,12 +77,12 @@
             "nodeID": "NodeID-PGHYeLVkU6ZVQEu8CuRBk6pQ2NJNAuzZ4",
             "validatorDuration": 100000,
             "depositDuration": 110376000,
-            "depositOfferID": "DDTaFCwYbhEiJ35ZSA25qFGbfrRnqoi4a9czFJ5WCbNYxf8NY"
+            "depositOfferMemo": "presale3y"
           },
           {
             "amount": 10000000000000000,
             "depositDuration": 110376000,
-            "depositOfferID": "DDTaFCwYbhEiJ35ZSA25qFGbfrRnqoi4a9czFJ5WCbNYxf8NY"
+            "depositOfferMemo": "presale3y"
           }
         ]
       }

--- a/genesis/genesis_columbus.json
+++ b/genesis/genesis_columbus.json
@@ -12,7 +12,7 @@
     "initialAdmin": "X-columbus1xkprh24vfyx8zghmvt2p60mmskwghzsn3q705m",
     "depositOffers": [
       {
-        "offerID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+        "memo": "presale3y",
         "interestRateNominator": 80000,
         "startOffset": 0,
         "endOffset": 114177600,
@@ -26,7 +26,7 @@
         }
       },
       {
-        "offerID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+        "memo": "team5y",
         "interestRateNominator": 0,
         "startOffset": 0,
         "endOffset": 161481600,
@@ -40,7 +40,7 @@
         }
       },
       {
-        "offerID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+        "memo": "presale4y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 145713600,
@@ -54,7 +54,7 @@
         }
       },
       {
-        "offerID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+        "memo": "presale5y",
         "interestRateNominator": 100000,
         "startOffset": 0,
         "endOffset": 177249600,
@@ -68,7 +68,7 @@
         }
       },
       {
-        "offerID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+        "memo": "undeposittest1y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 34128000,
@@ -82,7 +82,7 @@
         }
       },
       {
-        "offerID": "2v3jKLqt6k49uJCvrm9bXvSGxKyRGg951FCNePFAdxtrWVXaaz",
+        "memo": "flexdeposittest1",
         "interestRateNominator": 110000,
         "startOffset": 0,
         "endOffset": 65664000,
@@ -96,7 +96,7 @@
         }
       },
       {
-        "offerID": "2KcftFNc5i85MfRPXEJ9Zts3z241xpJbhmu8Mc4KhMCZm6uUrh",
+        "memo": "flexdeposittest2",
         "interestRateNominator": 210000,
         "startOffset": 0,
         "endOffset": 65664000,
@@ -142,7 +142,7 @@
             "validatorDuration": 31104000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "2"
           },
           {
@@ -167,7 +167,7 @@
             "validatorDuration": 62208000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "3"
           },
           {
@@ -190,7 +190,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "4"
           },
           {
@@ -228,7 +228,7 @@
           {
             "amount": 100000000000000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "6"
           }
         ]
@@ -246,7 +246,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "7"
           },
           {
@@ -269,7 +269,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "8"
           },
           {
@@ -292,7 +292,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "9"
           },
           {
@@ -315,7 +315,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "10"
           },
           {
@@ -338,7 +338,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "11"
           },
           {
@@ -361,7 +361,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "12"
           },
           {
@@ -400,7 +400,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "14"
           }
         ]
@@ -418,7 +418,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "15"
           },
           {
@@ -441,7 +441,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "16"
           },
           {
@@ -464,7 +464,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "17"
           },
           {
@@ -487,7 +487,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "18"
           },
           {
@@ -510,7 +510,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "19"
           },
           {
@@ -533,7 +533,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "20"
           },
           {
@@ -556,7 +556,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "21"
           }
         ]
@@ -574,7 +574,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "22"
           },
           {
@@ -597,7 +597,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "23"
           },
           {
@@ -620,7 +620,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "24"
           },
           {
@@ -643,7 +643,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "25"
           },
           {
@@ -666,7 +666,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "26"
           },
           {
@@ -688,7 +688,7 @@
           {
             "amount": 2800000000000000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "27"
           }
         ]
@@ -706,7 +706,7 @@
             "amount": 10000000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "28"
           },
           {
@@ -729,7 +729,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "29"
           },
           {
@@ -752,7 +752,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "30"
           },
           {
@@ -775,7 +775,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "31"
           },
           {
@@ -798,7 +798,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "32"
           },
           {
@@ -821,7 +821,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "33"
           },
           {
@@ -844,7 +844,7 @@
             "amount": 15000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "34"
           },
           {
@@ -867,7 +867,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "35"
           },
           {
@@ -890,7 +890,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "36"
           },
           {
@@ -913,7 +913,7 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "37"
           },
           {
@@ -936,7 +936,7 @@
             "amount": 40000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "38"
           },
           {
@@ -959,7 +959,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "39"
           },
           {
@@ -982,7 +982,7 @@
             "amount": 200000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "40"
           },
           {
@@ -1005,7 +1005,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "41"
           },
           {
@@ -1028,7 +1028,7 @@
             "amount": 20000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "42"
           },
           {
@@ -1051,7 +1051,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "43"
           },
           {
@@ -1074,7 +1074,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "44"
           },
           {
@@ -1097,7 +1097,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "45"
           },
           {
@@ -1120,7 +1120,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "46"
           },
           {
@@ -1143,7 +1143,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "47"
           },
           {
@@ -1166,7 +1166,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "48"
           },
           {
@@ -1189,7 +1189,7 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "49"
           },
           {
@@ -1214,7 +1214,7 @@
             "validatorDuration": 32400000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "50"
           },
           {
@@ -1237,7 +1237,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "51"
           },
           {
@@ -1260,7 +1260,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "52"
           },
           {
@@ -1283,7 +1283,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "53"
           },
           {
@@ -1306,7 +1306,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "54"
           },
           {
@@ -1329,7 +1329,7 @@
             "amount": 600000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "55"
           },
           {
@@ -1352,7 +1352,7 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "56"
           },
           {
@@ -1375,7 +1375,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "57"
           },
           {
@@ -1398,7 +1398,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "58"
           },
           {
@@ -1421,7 +1421,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "59"
           },
           {
@@ -1444,7 +1444,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "60"
           },
           {
@@ -1467,7 +1467,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "61"
           },
           {
@@ -1490,7 +1490,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "62"
           },
           {
@@ -1513,7 +1513,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "63"
           },
           {
@@ -1536,7 +1536,7 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "64"
           },
           {
@@ -1559,7 +1559,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "65"
           },
           {
@@ -1582,7 +1582,7 @@
             "amount": 60000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "66"
           },
           {
@@ -1605,7 +1605,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "67"
           },
           {
@@ -1628,7 +1628,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "68"
           },
           {
@@ -1651,7 +1651,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "69"
           },
           {
@@ -1674,7 +1674,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "70"
           },
           {
@@ -1697,7 +1697,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "71"
           },
           {
@@ -1720,7 +1720,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "72"
           },
           {
@@ -1743,7 +1743,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "73"
           },
           {
@@ -1766,7 +1766,7 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "74"
           },
           {
@@ -1789,7 +1789,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "75"
           },
           {
@@ -1812,7 +1812,7 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "76"
           },
           {
@@ -1835,7 +1835,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "77"
           },
           {
@@ -1858,7 +1858,7 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "78"
           },
           {
@@ -1881,7 +1881,7 @@
             "amount": 25000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "79"
           },
           {
@@ -1904,7 +1904,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "80"
           },
           {
@@ -1927,7 +1927,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "81"
           },
           {
@@ -1950,7 +1950,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "82"
           },
           {
@@ -1973,7 +1973,7 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "83"
           },
           {
@@ -1996,7 +1996,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "84"
           },
           {
@@ -2019,7 +2019,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "85"
           },
           {
@@ -2042,7 +2042,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "86"
           },
           {
@@ -2065,7 +2065,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "87"
           },
           {
@@ -2088,7 +2088,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "88"
           },
           {
@@ -2111,7 +2111,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "89"
           },
           {
@@ -2134,7 +2134,7 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "90"
           },
           {
@@ -2157,7 +2157,7 @@
             "amount": 1000000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "91"
           },
           {
@@ -2180,7 +2180,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "92"
           },
           {
@@ -2203,7 +2203,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "93"
           },
           {
@@ -2226,7 +2226,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "94"
           },
           {
@@ -2249,7 +2249,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "95"
           },
           {
@@ -2272,7 +2272,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "96"
           },
           {
@@ -2295,7 +2295,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "97"
           },
           {
@@ -2318,7 +2318,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "98"
           },
           {
@@ -2341,7 +2341,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "99"
           },
           {
@@ -2364,7 +2364,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "100"
           },
           {
@@ -2387,7 +2387,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "101"
           },
           {
@@ -2410,7 +2410,7 @@
             "amount": 25000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "102"
           },
           {
@@ -2433,7 +2433,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "103"
           },
           {
@@ -2456,7 +2456,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "104"
           },
           {
@@ -2479,7 +2479,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "105"
           },
           {
@@ -2502,7 +2502,7 @@
             "amount": 1000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "106"
           },
           {
@@ -2525,7 +2525,7 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "107"
           },
           {
@@ -2548,7 +2548,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "108"
           },
           {
@@ -2571,7 +2571,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "109"
           },
           {
@@ -2594,7 +2594,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "110"
           },
           {
@@ -2617,7 +2617,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "111"
           },
           {
@@ -2640,7 +2640,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "112"
           },
           {
@@ -2663,7 +2663,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "113"
           },
           {
@@ -2686,7 +2686,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "114"
           },
           {
@@ -2709,7 +2709,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "115"
           },
           {
@@ -2732,7 +2732,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "116"
           },
           {
@@ -2755,7 +2755,7 @@
             "amount": 400000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "117"
           },
           {
@@ -2778,7 +2778,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "118"
           },
           {
@@ -2801,7 +2801,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "119"
           },
           {
@@ -2824,7 +2824,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "120"
           },
           {
@@ -2847,7 +2847,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "121"
           },
           {
@@ -2870,7 +2870,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "122"
           },
           {
@@ -2893,7 +2893,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "123"
           },
           {
@@ -2916,7 +2916,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "124"
           },
           {
@@ -2939,7 +2939,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "125"
           },
           {
@@ -2962,7 +2962,7 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "126"
           },
           {
@@ -2984,7 +2984,7 @@
           {
             "amount": 300000000000000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "127"
           }
         ]
@@ -3002,7 +3002,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "128"
           },
           {
@@ -3025,7 +3025,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "129"
           },
           {
@@ -3048,7 +3048,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "130"
           },
           {
@@ -3071,7 +3071,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "131"
           },
           {
@@ -3094,7 +3094,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "132"
           },
           {
@@ -3117,7 +3117,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "133"
           },
           {
@@ -3140,7 +3140,7 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "134"
           },
           {
@@ -3163,7 +3163,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "135"
           },
           {
@@ -3186,7 +3186,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "136"
           },
           {
@@ -3209,7 +3209,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "137"
           },
           {
@@ -3232,7 +3232,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "138"
           },
           {
@@ -3255,7 +3255,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "139"
           },
           {
@@ -3278,7 +3278,7 @@
             "amount": 250000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "140"
           },
           {
@@ -3301,7 +3301,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "141"
           },
           {
@@ -3324,7 +3324,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "142"
           },
           {
@@ -3347,7 +3347,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "143"
           },
           {
@@ -3370,7 +3370,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "144"
           },
           {
@@ -3393,7 +3393,7 @@
             "amount": 3000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "145"
           },
           {
@@ -3416,7 +3416,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "146"
           },
           {
@@ -3439,7 +3439,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "147"
           },
           {
@@ -3462,7 +3462,7 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "148"
           },
           {
@@ -3485,7 +3485,7 @@
             "amount": 150000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "149"
           },
           {
@@ -3508,7 +3508,7 @@
             "amount": 25000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "150"
           },
           {
@@ -3531,7 +3531,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "151"
           },
           {
@@ -3554,7 +3554,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "152"
           },
           {
@@ -3577,7 +3577,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "153"
           },
           {
@@ -3600,7 +3600,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "154"
           },
           {
@@ -3623,7 +3623,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "155"
           },
           {
@@ -3646,7 +3646,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "156"
           },
           {
@@ -3669,7 +3669,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "157"
           },
           {
@@ -3692,7 +3692,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "158"
           },
           {
@@ -3715,7 +3715,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "159"
           },
           {
@@ -3738,7 +3738,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "160"
           },
           {
@@ -3761,7 +3761,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "161"
           },
           {
@@ -3784,7 +3784,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "162"
           },
           {
@@ -3807,7 +3807,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "163"
           },
           {
@@ -3830,7 +3830,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "164"
           },
           {
@@ -3853,7 +3853,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "165"
           },
           {
@@ -3876,7 +3876,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "166"
           },
           {
@@ -3899,7 +3899,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "167"
           },
           {
@@ -3922,7 +3922,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "168"
           },
           {
@@ -3945,7 +3945,7 @@
             "amount": 400000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "169"
           },
           {
@@ -3968,7 +3968,7 @@
             "amount": 250000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "170"
           },
           {
@@ -3991,7 +3991,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "171"
           },
           {
@@ -4014,7 +4014,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "172"
           },
           {
@@ -4037,7 +4037,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "173"
           },
           {
@@ -4060,7 +4060,7 @@
             "amount": 50000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "174"
           },
           {
@@ -4083,7 +4083,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "175"
           },
           {
@@ -4106,7 +4106,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "176"
           },
           {
@@ -4129,7 +4129,7 @@
             "amount": 75000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "177"
           },
           {
@@ -4152,7 +4152,7 @@
             "amount": 20000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "178"
           },
           {
@@ -4175,7 +4175,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "179"
           },
           {
@@ -4198,7 +4198,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "180"
           },
           {
@@ -4221,7 +4221,7 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "181"
           },
           {
@@ -4244,7 +4244,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "182"
           },
           {
@@ -4267,7 +4267,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "183"
           },
           {
@@ -4290,7 +4290,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "184"
           },
           {
@@ -4313,7 +4313,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "185"
           },
           {
@@ -4336,7 +4336,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "186"
           },
           {
@@ -4359,7 +4359,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "187"
           },
           {
@@ -4382,7 +4382,7 @@
             "amount": 25000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "188"
           },
           {
@@ -4405,7 +4405,7 @@
             "amount": 120000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "189"
           },
           {
@@ -4428,7 +4428,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "190"
           },
           {
@@ -4451,7 +4451,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "191"
           },
           {
@@ -4474,7 +4474,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "192"
           },
           {
@@ -4497,7 +4497,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "193"
           },
           {
@@ -4520,7 +4520,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "194"
           },
           {
@@ -4543,7 +4543,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "195"
           },
           {
@@ -4566,7 +4566,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "196"
           },
           {
@@ -4589,7 +4589,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "197"
           },
           {
@@ -4612,7 +4612,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "198"
           },
           {
@@ -4635,7 +4635,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "199"
           },
           {
@@ -4658,7 +4658,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "200"
           },
           {
@@ -4681,7 +4681,7 @@
             "amount": 150000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "201"
           },
           {
@@ -4704,7 +4704,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "202"
           },
           {
@@ -4727,7 +4727,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "203"
           },
           {
@@ -4750,7 +4750,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "204"
           },
           {
@@ -4773,7 +4773,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "205"
           },
           {
@@ -4796,7 +4796,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "206"
           },
           {
@@ -4819,7 +4819,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "207"
           },
           {
@@ -4842,7 +4842,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "208"
           },
           {
@@ -4865,7 +4865,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "209"
           },
           {
@@ -4888,7 +4888,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "210"
           },
           {
@@ -4911,7 +4911,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "211"
           },
           {
@@ -4934,7 +4934,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "212"
           },
           {
@@ -4957,7 +4957,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "213"
           },
           {
@@ -4980,7 +4980,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "214"
           },
           {
@@ -5003,7 +5003,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "215"
           },
           {
@@ -5026,7 +5026,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "216"
           },
           {
@@ -5049,7 +5049,7 @@
             "amount": 70000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "217"
           },
           {
@@ -5072,7 +5072,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "218"
           },
           {
@@ -5095,7 +5095,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "219"
           },
           {
@@ -5118,7 +5118,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "220"
           },
           {
@@ -5141,7 +5141,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "221"
           },
           {
@@ -5164,7 +5164,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "222"
           },
           {
@@ -5187,7 +5187,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "223"
           },
           {
@@ -5210,7 +5210,7 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "224"
           },
           {
@@ -5232,7 +5232,7 @@
           {
             "amount": 4500000000000000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "225"
           }
         ]
@@ -5250,7 +5250,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "226"
           },
           {
@@ -5273,7 +5273,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "227"
           },
           {
@@ -5296,7 +5296,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "228"
           },
           {
@@ -5321,7 +5321,7 @@
             "validatorDuration": 30672000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "229"
           },
           {
@@ -5344,7 +5344,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "230"
           },
           {
@@ -5367,7 +5367,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "231"
           },
           {
@@ -5390,7 +5390,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "232"
           },
           {
@@ -5413,7 +5413,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "233"
           },
           {
@@ -5436,7 +5436,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "234"
           },
           {
@@ -5459,7 +5459,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "235"
           },
           {
@@ -5482,7 +5482,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "236"
           },
           {
@@ -5507,7 +5507,7 @@
             "validatorDuration": 31536000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "237"
           },
           {
@@ -5530,7 +5530,7 @@
             "amount": 500000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "238"
           },
           {
@@ -5553,7 +5553,7 @@
             "amount": 300000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "239"
           },
           {
@@ -5576,7 +5576,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "240"
           },
           {
@@ -5599,7 +5599,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "241"
           },
           {
@@ -5622,7 +5622,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "242"
           },
           {
@@ -5645,7 +5645,7 @@
             "amount": 400000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "243"
           },
           {
@@ -5668,7 +5668,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "244"
           },
           {
@@ -5691,7 +5691,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "245"
           },
           {
@@ -5714,7 +5714,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "246"
           },
           {
@@ -5737,7 +5737,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "247"
           },
           {
@@ -5760,7 +5760,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "248"
           },
           {
@@ -5785,7 +5785,7 @@
             "validatorDuration": 30240000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "249"
           },
           {
@@ -5808,7 +5808,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "250"
           },
           {
@@ -5831,7 +5831,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "251"
           },
           {
@@ -5854,7 +5854,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "252"
           },
           {
@@ -5877,7 +5877,7 @@
             "amount": 300000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "253"
           },
           {
@@ -5900,7 +5900,7 @@
             "amount": 250000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "254"
           },
           {
@@ -5923,7 +5923,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "255"
           },
           {
@@ -5946,7 +5946,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "256"
           },
           {
@@ -5969,7 +5969,7 @@
             "amount": 1000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "257"
           },
           {
@@ -5992,7 +5992,7 @@
             "amount": 500000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "258"
           },
           {
@@ -6015,7 +6015,7 @@
             "amount": 1500000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "259"
           },
           {
@@ -6039,7 +6039,7 @@
             "nodeID": "NodeID-5APqagKQK2d9cMrtgR2h3bsC4GrU3UkNr",
             "validatorDuration": 31968000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "260"
           }
         ]

--- a/genesis/genesis_kopernikus.json
+++ b/genesis/genesis_kopernikus.json
@@ -6,7 +6,7 @@
     "initialAdmin": "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3",
     "depositOffers": [
       {
-        "offerID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi",
+        "memo": "presale3y",
         "interestRateNominator": 80000,
         "startOffset": 0,
         "endOffset": 112795200,
@@ -20,7 +20,7 @@
         }
       },
       {
-        "offerID": "2AySgbKZp8PP95KCsttY68uKJyFbsATHnE73jk1P9fSppmqV45",
+        "memo": "team5y",
         "interestRateNominator": 0,
         "startOffset": 0,
         "endOffset": 160099200,
@@ -34,7 +34,7 @@
         }
       },
       {
-        "offerID": "2uGR8giEWip1mGWQzF1DXNVpUXY8M1futjhVErqV7uJntHmWrh",
+        "memo": "presale4y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 144331200,
@@ -48,7 +48,7 @@
         }
       },
       {
-        "offerID": "2ad2QNdpDQWGUMx7WWRwAG1bxFwx5amEZzfoqGrGF1D7N3HNLp",
+        "memo": "presale5y",
         "interestRateNominator": 100000,
         "startOffset": 0,
         "endOffset": 175867200,
@@ -62,7 +62,7 @@
         }
       },
       {
-        "offerID": "k5VaqN4kFtcKQWfjyJpk4YA8VBwW7TyeRicDGsdzRNRNSG1R1",
+        "memo": "undeposittest1y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 32745600,
@@ -76,7 +76,7 @@
         }
       },
       {
-        "offerID": "2vGw1ZaUWWGxhAm69Dt13zw5sUvmtCbzVTvvzPp34Ch5qEznBg",
+        "memo": "flexdeposittest1",
         "interestRateNominator": 110000,
         "startOffset": 0,
         "endOffset": 64281600,
@@ -90,7 +90,7 @@
         }
       },
       {
-        "offerID": "24zEuyv4zBvF2pGPbzwVYhCxPQUfuqD4pWDRfJrJapXBhFfxDh",
+        "memo": "flexdeposittest2",
         "interestRateNominator": 210000,
         "startOffset": 0,
         "endOffset": 64281600,
@@ -120,14 +120,14 @@
             "validatorDuration": 31536000,
             "depositDuration": 110376000,
             "timestampOffset": 0,
-            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi",
+            "depositOfferMemo": "presale3y",
             "memo": "KOPERNIKUS"
           },
           {
             "amount": 10000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 0,
-            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi"
+            "depositOfferMemo": "presale3y"
           },
           {
             "amount": 4000000000000
@@ -150,7 +150,7 @@
             "amount": 600000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 0,
-            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi"
+            "depositOfferMemo": "presale3y"
           }
         ]
       }

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,15 +370,15 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2WTr7jgbMWB4os5swbFNLeoeKCKWie3YkTSPxoYDXmbkR1UG3J",
+			expectedID: "2T2WUBTb9JZU1STkhw9hj3e3yuE3wUdWK2jYAprYoXJdtvjCcM",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "fv6SDDQvnRMJYjnYKhcXoe345FZZr5hc9h8tnwAdQQvVNMZae",
+			expectedID: "ryHKHZ5Cc2e8GbzdjubtMfeWi78yP5rta7xSjHYzCoZSsdXmy",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "2jKs6s57q8eo3kFK1ky7PqvG7atzMD4hJDSZ1BFh8gGmdS558H",
+			expectedID: "29jJZ5u2Vsfsb3gHEPiwuy2923uLfTdqHtZD1gJ74x2x7NdU2j",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/deposit/camino_deposit.go
+++ b/vms/platformvm/deposit/camino_deposit.go
@@ -33,6 +33,7 @@ type Offer struct {
 	MaxDuration             uint32 `serialize:"true"`
 	UnlockPeriodDuration    uint32 `serialize:"true"`
 	NoRewardsPeriodDuration uint32 `serialize:"true"`
+	Memo                    string `serialize:"true"`
 	Flags                   uint64 `serialize:"true"`
 }
 

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -52,7 +52,6 @@ type AddressState struct {
 }
 
 type DepositOffer struct {
-	OfferID                 ids.ID `serialize:"false"`
 	InterestRateNominator   uint64 `serialize:"true" json:"interestRateNominator"`
 	Start                   uint64 `serialize:"true" json:"start"`
 	End                     uint64 `serialize:"true" json:"end"`
@@ -61,6 +60,7 @@ type DepositOffer struct {
 	MaxDuration             uint32 `serialize:"true" json:"maxDuration"`
 	UnlockPeriodDuration    uint32 `serialize:"true" json:"unlockPeriodDuration"`
 	NoRewardsPeriodDuration uint32 `serialize:"true" json:"noRewardsPeriodDuration"`
+	Memo                    string `serialize:"true" json:"memo"`
 	Flags                   uint64 `serialize:"true" json:"flags"`
 }
 
@@ -106,12 +106,8 @@ func (offer DepositOffer) Verify() error {
 		)
 	}
 
-	calcID, err := offer.ID()
-	if err != nil {
-		return err
-	}
-	if offer.OfferID != calcID {
-		return fmt.Errorf("deposit offer ID (%s) mismatched with the calculated one (%s)", offer.OfferID, calcID)
+	if offer.Memo == "" {
+		return errors.New("deposit offer has no memo")
 	}
 
 	return nil

--- a/vms/platformvm/state/camino_deposit_offer.go
+++ b/vms/platformvm/state/camino_deposit_offer.go
@@ -101,6 +101,7 @@ func ParseDepositOfferFromGenesisOffer(genesisOffer *genesis.DepositOffer) (*dep
 		MaxDuration:             genesisOffer.MaxDuration,
 		UnlockPeriodDuration:    genesisOffer.UnlockPeriodDuration,
 		NoRewardsPeriodDuration: genesisOffer.NoRewardsPeriodDuration,
+		Memo:                    genesisOffer.Memo,
 		Flags:                   genesisOffer.Flags,
 	}
 	if err := offer.SetID(); err != nil {


### PR DESCRIPTION
Offer ids where changing when we modified genesis start time, that was a pain, cause then we needed to generate new ids and update json file. This PR replaces offer ids with arbitrary unique memo strings in json file. This memo is also transported into state deposit offers, but not encoded properly in this PR cause of some structural difficulties which will be resolved in next PR (https://github.com/chain4travel/caminogo/pull/173)