### PR TITLE
Offer memo

### DIFF
--- a/genesis/camino_config.go
+++ b/genesis/camino_config.go
@@ -130,7 +130,7 @@ type PlatformAllocation struct {
 	ValidatorDuration uint64     `json:"validatorDuration"`
 	DepositDuration   uint64     `json:"depositDuration"`
 	TimestampOffset   uint64     `json:"timestampOffset"`
-	DepositOfferID    ids.ID     `json:"depositOfferID"`
+	DepositOfferMemo  string     `json:"depositOfferMemo"`
 	Memo              string     `json:"memo"`
 }
 
@@ -139,16 +139,13 @@ func (a PlatformAllocation) Unparse() (UnparsedPlatformAllocation, error) {
 		Amount:            a.Amount,
 		ValidatorDuration: a.ValidatorDuration,
 		DepositDuration:   a.DepositDuration,
+		DepositOfferMemo:  a.DepositOfferMemo,
 		TimestampOffset:   a.TimestampOffset,
 		Memo:              a.Memo,
 	}
 
 	if a.NodeID != ids.EmptyNodeID {
 		ua.NodeID = a.NodeID.String()
-	}
-
-	if a.DepositOfferID != ids.Empty {
-		ua.DepositOfferID = a.DepositOfferID.String()
 	}
 
 	return ua, nil

--- a/genesis/camino_config_test.go
+++ b/genesis/camino_config_test.go
@@ -15,9 +15,8 @@ import (
 )
 
 var (
-	nodeID         = ids.GenerateTestNodeID()
-	depositOfferID = ids.GenerateTestID()
-	shortID2       = ids.GenerateTestShortID()
+	nodeID   = ids.GenerateTestNodeID()
+	shortID2 = ids.GenerateTestShortID()
 )
 
 func TestUnparse(t *testing.T) {
@@ -54,7 +53,10 @@ func TestUnparse(t *testing.T) {
 						Amount:            1,
 						NodeID:            nodeID,
 						ValidatorDuration: 1,
-						DepositOfferID:    depositOfferID,
+						DepositDuration:   1,
+						DepositOfferMemo:  "deposit offer memo",
+						TimestampOffset:   1,
+						Memo:              "some str",
 					}},
 				}},
 				InitialMultisigAddresses: []genesis.MultisigAlias{{
@@ -77,7 +79,10 @@ func TestUnparse(t *testing.T) {
 						Amount:            1,
 						NodeID:            nodeID.String(),
 						ValidatorDuration: 1,
-						DepositOfferID:    depositOfferID.String(),
+						DepositDuration:   1,
+						DepositOfferMemo:  "deposit offer memo",
+						TimestampOffset:   1,
+						Memo:              "some str",
 					}},
 				}},
 				InitialMultisigAddresses: []UnparsedMultisigAlias{{

--- a/genesis/camino_config_test.go
+++ b/genesis/camino_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/stretchr/testify/require"
 )
@@ -20,30 +21,33 @@ var (
 )
 
 func TestUnparse(t *testing.T) {
-	type fields struct {
-		VerifyNodeSignature      bool
-		LockModeBondDeposit      bool
-		InitialAdmin             ids.ShortID
-		DepositOffers            []genesis.DepositOffer
-		Allocations              []CaminoAllocation
-		InitialMultisigAddresses []genesis.MultisigAlias
-	}
 	type args struct {
 		networkID uint32
 	}
 	tests := map[string]struct {
-		fields fields
+		camino Camino
 		args   args
 		want   UnparsedCamino
 		err    error
 	}{
 		"success": {
 			args: args{networkID: 12345},
-			fields: fields{
+			camino: Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
 				InitialAdmin:        sampleShortID,
-				DepositOffers:       nil,
+				DepositOffers: []DepositOffer{{
+					InterestRateNominator:   1,
+					Start:                   2,
+					End:                     3,
+					MinAmount:               4,
+					MinDuration:             5,
+					MaxDuration:             6,
+					UnlockPeriodDuration:    7,
+					NoRewardsPeriodDuration: 8,
+					Memo:                    "offer memo",
+					Flags:                   deposit.OfferFlagLocked,
+				}},
 				Allocations: []CaminoAllocation{{
 					ETHAddr:       sampleShortID,
 					AVAXAddr:      sampleShortID,
@@ -69,7 +73,20 @@ func TestUnparse(t *testing.T) {
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
 				InitialAdmin:        "X-" + wrappers.IgnoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
-				DepositOffers:       []UnparsedDepositOffer{},
+				DepositOffers: []UnparsedDepositOffer{{
+					InterestRateNominator:   1,
+					StartOffset:             2,
+					EndOffset:               3,
+					MinAmount:               4,
+					MinDuration:             5,
+					MaxDuration:             6,
+					UnlockPeriodDuration:    7,
+					NoRewardsPeriodDuration: 8,
+					Memo:                    "offer memo",
+					Flags: UnparsedDepositOfferFlags{
+						Locked: true,
+					},
+				}},
 				Allocations: []UnparsedCaminoAllocation{{
 					ETHAddr:       "0x" + hex.EncodeToString(sampleShortID.Bytes()),
 					AVAXAddr:      "X-" + wrappers.IgnoreError(address.FormatBech32("local", sampleShortID.Bytes())).(string),
@@ -95,15 +112,7 @@ func TestUnparse(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := Camino{
-				VerifyNodeSignature:      tt.fields.VerifyNodeSignature,
-				LockModeBondDeposit:      tt.fields.LockModeBondDeposit,
-				InitialAdmin:             tt.fields.InitialAdmin,
-				DepositOffers:            tt.fields.DepositOffers,
-				Allocations:              tt.fields.Allocations,
-				InitialMultisigAddresses: tt.fields.InitialMultisigAddresses,
-			}
-			got, err := c.Unparse(tt.args.networkID, 0)
+			got, err := tt.camino.Unparse(tt.args.networkID, 0)
 
 			if tt.err != nil {
 				require.ErrorContains(t, err, tt.err.Error())

--- a/genesis/camino_unparsed_config.go
+++ b/genesis/camino_unparsed_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis
@@ -31,7 +31,7 @@ func (uc UnparsedCamino) Parse(startTime uint64) (Camino, error) {
 	c := Camino{
 		VerifyNodeSignature:      uc.VerifyNodeSignature,
 		LockModeBondDeposit:      uc.LockModeBondDeposit,
-		DepositOffers:            make([]genesis.DepositOffer, len(uc.DepositOffers)),
+		DepositOffers:            make([]DepositOffer, len(uc.DepositOffers)),
 		Allocations:              make([]CaminoAllocation, len(uc.Allocations)),
 		InitialMultisigAddresses: make([]genesis.MultisigAlias, len(uc.InitialMultisigAddresses)),
 	}
@@ -224,8 +224,8 @@ type UnparsedDepositOfferFlags struct {
 	Locked bool `json:"locked"`
 }
 
-func (udo UnparsedDepositOffer) Parse(startTime uint64) (genesis.DepositOffer, error) {
-	do := genesis.DepositOffer{
+func (udo UnparsedDepositOffer) Parse(startTime uint64) (DepositOffer, error) {
+	do := DepositOffer{
 		InterestRateNominator:   udo.InterestRateNominator,
 		MinAmount:               udo.MinAmount,
 		MinDuration:             udo.MinDuration,
@@ -252,32 +252,4 @@ func (udo UnparsedDepositOffer) Parse(startTime uint64) (genesis.DepositOffer, e
 	}
 
 	return do, nil
-}
-
-func (udo *UnparsedDepositOffer) Unparse(do genesis.DepositOffer, startime uint64) error {
-	udo.InterestRateNominator = do.InterestRateNominator
-	udo.MinAmount = do.MinAmount
-	udo.MinDuration = do.MinDuration
-	udo.MaxDuration = do.MaxDuration
-	udo.UnlockPeriodDuration = do.UnlockPeriodDuration
-	udo.NoRewardsPeriodDuration = do.NoRewardsPeriodDuration
-	udo.Memo = do.Memo
-
-	offerStartOffset, err := math.Sub(do.Start, startime)
-	if err != nil {
-		return err
-	}
-	udo.StartOffset = offerStartOffset
-
-	offerEndOffset, err := math.Sub(do.End, startime)
-	if err != nil {
-		return err
-	}
-	udo.EndOffset = offerEndOffset
-
-	if do.Flags&deposit.OfferFlagLocked != 0 {
-		udo.Flags.Locked = true
-	}
-
-	return nil
 }

--- a/genesis/genesis_camino.json
+++ b/genesis/genesis_camino.json
@@ -6,7 +6,7 @@
     "initialAdmin": "X-camino1m4nr983lhd4p4nfsqk3a6a9mejugnn73f83vuy",
     "depositOffers": [
       {
-        "offerID": "DDTaFCwYbhEiJ35ZSA25qFGbfrRnqoi4a9czFJ5WCbNYxf8NY",
+        "memo": "presale3y",
         "interestRateNominator": 80000,
         "startOffset": 0,
         "endOffset": 111585600,
@@ -20,7 +20,7 @@
         }
       },
       {
-        "offerID": "Mc2xe3kHRdAnCbMYhK1p4GhnpJSYbyR47d6upA8Xg98DMpByf",
+        "memo": "team5y",
         "interestRateNominator": 0,
         "startOffset": 0,
         "endOffset": 158889600,
@@ -34,7 +34,7 @@
         }
       },
       {
-        "offerID": "2qQCBBxw2wMZXNdqQKtDojeVpNN5z9WpRVuHsR4UBZr5wrXy9n",
+        "memo": "presale4y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 143121600,
@@ -48,7 +48,7 @@
         }
       },
       {
-        "offerID": "2mdhxmmNUgxmc8W17LpyegMVqHLofYGgDFVMEYuua9R4V4aSuj",
+        "memo": "presale5y",
         "interestRateNominator": 100000,
         "startOffset": 0,
         "endOffset": 174657600,
@@ -77,12 +77,12 @@
             "nodeID": "NodeID-PGHYeLVkU6ZVQEu8CuRBk6pQ2NJNAuzZ4",
             "validatorDuration": 100000,
             "depositDuration": 110376000,
-            "depositOfferID": "DDTaFCwYbhEiJ35ZSA25qFGbfrRnqoi4a9czFJ5WCbNYxf8NY"
+            "depositOfferMemo": "presale3y"
           },
           {
             "amount": 10000000000000000,
             "depositDuration": 110376000,
-            "depositOfferID": "DDTaFCwYbhEiJ35ZSA25qFGbfrRnqoi4a9czFJ5WCbNYxf8NY"
+            "depositOfferMemo": "presale3y"
           }
         ]
       }

--- a/genesis/genesis_columbus.json
+++ b/genesis/genesis_columbus.json
@@ -12,7 +12,6 @@
     "initialAdmin": "X-columbus1xkprh24vfyx8zghmvt2p60mmskwghzsn3q705m",
     "depositOffers": [
       {
-        "memo": "presale3y",
         "interestRateNominator": 80000,
         "startOffset": 0,
         "endOffset": 114177600,
@@ -21,26 +20,12 @@
         "maxDuration": 110376000,
         "unlockPeriodDuration": 31536000,
         "noRewardsPeriodDuration": 15768000,
+        "memo": "presale 3Y - not pickable after network creation, only for genesis allocations",
         "flags": {
           "locked": true
         }
       },
       {
-        "memo": "team5y",
-        "interestRateNominator": 0,
-        "startOffset": 0,
-        "endOffset": 161481600,
-        "minAmount": 1,
-        "minDuration": 157680000,
-        "maxDuration": 157680000,
-        "unlockPeriodDuration": 63072000,
-        "noRewardsPeriodDuration": 31536000,
-        "flags": {
-          "locked": true
-        }
-      },
-      {
-        "memo": "presale4y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 145713600,
@@ -49,12 +34,12 @@
         "maxDuration": 141912000,
         "unlockPeriodDuration": 31536000,
         "noRewardsPeriodDuration": 15768000,
+        "memo": "presale 4Y - not pickable after network creation, only for genesis allocations",
         "flags": {
           "locked": true
         }
       },
       {
-        "memo": "presale5y",
         "interestRateNominator": 100000,
         "startOffset": 0,
         "endOffset": 177249600,
@@ -63,12 +48,54 @@
         "maxDuration": 173448000,
         "unlockPeriodDuration": 31536000,
         "noRewardsPeriodDuration": 15768000,
+        "memo": "presale 5Y - not pickable after network creation, only for genesis allocations",
         "flags": {
           "locked": true
         }
       },
       {
-        "memo": "undeposittest1y",
+        "interestRateNominator": 0,
+        "startOffset": 0,
+        "endOffset": 177249600,
+        "minAmount": 1,
+        "minDuration": 157680000,
+        "maxDuration": 157680000,
+        "unlockPeriodDuration": 157680000,
+        "noRewardsPeriodDuration": 0,
+        "memo": "Directly start with undeposit for 5years -- (Mostly used for longterm funds of the camino foundation reserve, marketing, team, second sale, etc)",
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "interestRateNominator": 0,
+        "startOffset": 0,
+        "endOffset": 114177600,
+        "minAmount": 1,
+        "minDuration": 110376000,
+        "maxDuration": 110376000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 0,
+        "memo": "Seed investors lock",
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "interestRateNominator": 0,
+        "startOffset": 0,
+        "endOffset": 161481600,
+        "minAmount": 1,
+        "minDuration": 157680000,
+        "maxDuration": 157680000,
+        "unlockPeriodDuration": 63072000,
+        "noRewardsPeriodDuration": 0,
+        "memo": "Founders/Team 5Y - not pickable after network creation, only for genesis allocations",
+        "flags": {
+          "locked": true
+        }
+      },
+      {
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 34128000,
@@ -77,12 +104,12 @@
         "maxDuration": 31536000,
         "unlockPeriodDuration": 31536000,
         "noRewardsPeriodDuration": 15768000,
+        "memo": "un-deposit test - not pickable after network creation, only for genesis allocations",
         "flags": {
           "locked": true
         }
       },
       {
-        "memo": "flexdeposittest1",
         "interestRateNominator": 110000,
         "startOffset": 0,
         "endOffset": 65664000,
@@ -91,12 +118,12 @@
         "maxDuration": 31536000,
         "unlockPeriodDuration": 0,
         "noRewardsPeriodDuration": 0,
+        "memo": "depositOffer test#1 - pickable after network creation and not in genesis as duration is not choosable per allocation!",
         "flags": {
           "locked": false
         }
       },
       {
-        "memo": "flexdeposittest2",
         "interestRateNominator": 210000,
         "startOffset": 0,
         "endOffset": 65664000,
@@ -105,6 +132,7 @@
         "maxDuration": 31536000,
         "unlockPeriodDuration": 43200,
         "noRewardsPeriodDuration": 43200,
+        "memo": "depositOffer test#2 - pickable after network creation and not in genesis as duration is not choosable per allocation!",
         "flags": {
           "locked": false
         }
@@ -129,7 +157,7 @@
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1v7kdfuh0u2sg26cu7nf6drptz7lzayfm7vqrnk",
+        "avaxAddr": "X-columbus194sm66h2qrmtae7gcesnmxdstzqv0mpt7k2snk",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -142,7 +170,7 @@
             "validatorDuration": 31104000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
             "memo": "2"
           },
           {
@@ -154,7 +182,7 @@
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ce27vm0mwdkf03ct6vh8gtldur0rm4rdv0uazk",
+        "avaxAddr": "X-columbus1z5ykr4vxdhqder6jl0j5je2kl9cqxxlnfu6kkh",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -167,7 +195,7 @@
             "validatorDuration": 62208000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
             "memo": "3"
           },
           {
@@ -190,7 +218,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "4"
           },
           {
@@ -202,7 +230,7 @@
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1vscyf7czawylztn6ghhg0z27swwewxgzzxkyke",
+        "avaxAddr": "X-columbus1prxyey5xugn5c6tqusha9m4hd4rvld23ag7y8x",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -210,7 +238,7 @@
         },
         "platformAllocations": [
           {
-            "amount": 779955800000000000,
+            "amount": 768391300000000000,
             "timestampOffset": 2592000,
             "memo": "5+"
           }
@@ -228,7 +256,7 @@
           {
             "amount": 100000000000000,
             "depositDuration": 157680000,
-            "depositOfferMemo": "team5y",
+            "depositOfferMemo": "Founders/Team 5Y - not pickable after network creation, only for genesis allocations",
             "memo": "6"
           }
         ]
@@ -246,7 +274,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
             "memo": "7"
           },
           {
@@ -269,7 +297,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
             "memo": "8"
           },
           {
@@ -292,7 +320,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
             "memo": "9"
           },
           {
@@ -315,7 +343,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "10"
           },
           {
@@ -338,7 +366,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "11"
           },
           {
@@ -361,7 +389,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "12"
           },
           {
@@ -400,7 +428,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "14"
           }
         ]
@@ -418,7 +446,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "15"
           },
           {
@@ -430,7 +458,7 @@
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1v7kdfuh0u2sg26cu7nf6drptz7lzayfm7vqrnk",
+        "avaxAddr": "X-columbus194sm66h2qrmtae7gcesnmxdstzqv0mpt7k2snk",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -441,7 +469,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
             "memo": "16"
           },
           {
@@ -464,7 +492,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "17"
           },
           {
@@ -487,7 +515,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "18"
           },
           {
@@ -510,7 +538,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "19"
           },
           {
@@ -533,7 +561,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "20"
           },
           {
@@ -556,7 +584,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "21"
           }
         ]
@@ -574,7 +602,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "22"
           },
           {
@@ -597,7 +625,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "23"
           },
           {
@@ -620,7 +648,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "24"
           },
           {
@@ -643,7 +671,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "25"
           },
           {
@@ -665,20 +693,358 @@
           {
             "amount": 100000000000000,
             "depositDuration": 31536000,
-            "timestampOffset": 2592000,
-            "depositOfferMemo": "undeposittest1y",
+            "timestampOffset": 3600,
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
             "memo": "26"
           },
           {
             "amount": 1000000000000,
-            "timestampOffset": 2592000,
+            "timestampOffset": 3600,
             "memo": "26+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1e7h6w8fncznrnf68x3ch9zsaxm4gjjfuf3n5t2",
+        "avaxAddr": "X-columbus1xe5hkpx5w7ryky3ddzjjdwmuuvf8dkpfltnr22",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
+            "memo": "27"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 3600,
+            "memo": "27+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1d0ydd4wyq670lzrp0y7xd3wej4z7ysp26md7p6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
+            "memo": "28"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "28+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13lcv2qp3jl8kkz7hm4uwf5scquvsfnx7q370cg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
+            "memo": "29"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "29+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xa6vsx5pwyk7adyz00ldj7n73vr4qma7xfhds0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1010000000000000,
+            "timestampOffset": 3600,
+            "memo": "30+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus102uap4au55t22m797rr030wyrw0jlgw27m99k0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "31"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "31+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1c35zu69gd42yu9ecrptzwf0z9g7fhfvr3yu28x",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "32"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "32+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus10xf9u6we06ljq20jtq90hj0f6q8l2psp95uzpp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "33"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "33+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1dgrg4j4p5e6k5jn8080n6333r934pyum99x6c4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "Directly start with undeposit for 5years -- (Mostly used for longterm funds of the camino foundation reserve, marketing, team, second sale, etc)",
+            "memo": "34"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "34+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qfyvkqnv8yd9rmlf6sv0gdx20dgg4ers4pjp83",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "Seed investors lock",
+            "memo": "35"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "35+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1fvr4nd743ew0gcy00se24hp2ecpmk4h74sca9g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "Founders/Team 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "36"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "36+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yk9lw48um0r0rn9ydf9fhjfwwfq0qh7qtr9sz7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
+            "memo": "37"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "37+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1lmwsgy9zv8hyxwsek0pvsq7cpejtkvwkq54uvj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 86400,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "depositOffer test#1 - pickable after network creation and not in genesis as duration is not choosable per allocation!",
+            "memo": "38"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "38+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1maff3tql60ndkwn9mvz06ssywvag4uf4d73csa",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 864000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "depositOffer test#2 - pickable after network creation and not in genesis as duration is not choosable per allocation!",
+            "memo": "39"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "39+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18gw475en5h5jvtkslp7xqed7t7ugq6rmjjvpk2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "40"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "40+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ytsp00yv55dg72xjlsh3l444a7xczmn25kfc7p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "un-deposit test - not pickable after network creation, only for genesis allocations",
+            "memo": "41"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 2592000,
+            "memo": "41+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jn87l4s3f0r2xa0kk3nw8n939pvkyjyztz5wqu",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -688,8 +1054,8 @@
           {
             "amount": 2800000000000000,
             "depositDuration": 157680000,
-            "depositOfferMemo": "team5y",
-            "memo": "27"
+            "depositOfferMemo": "Founders/Team 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "42"
           }
         ]
       },
@@ -706,19 +1072,19 @@
             "amount": 10000000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "28"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "43"
           },
           {
             "amount": 100000000000000,
             "timestampOffset": 2592000,
-            "memo": "28+"
+            "memo": "43+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kn7rn8huslse9lku6n2jp3tydpnepfe3tv56z4",
+        "avaxAddr": "X-columbus1396cw839aatmnf2f3nmuuh6p6zn2vesym8ucrn",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -729,13 +1095,13 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "29"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "44"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "29+"
+            "memo": "44+"
           }
         ]
       },
@@ -752,13 +1118,13 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "30"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "45"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "30+"
+            "memo": "45+"
           }
         ]
       },
@@ -775,13 +1141,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "31"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "46"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "31+"
+            "memo": "46+"
           }
         ]
       },
@@ -798,13 +1164,13 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "32"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "47"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "32+"
+            "memo": "47+"
           }
         ]
       },
@@ -821,13 +1187,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "33"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "48"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "33+"
+            "memo": "48+"
           }
         ]
       },
@@ -844,13 +1210,13 @@
             "amount": 15000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "34"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "49"
           },
           {
             "amount": 150000000000,
             "timestampOffset": 2592000,
-            "memo": "34+"
+            "memo": "49+"
           }
         ]
       },
@@ -867,13 +1233,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "35"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "50"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "35+"
+            "memo": "50+"
           }
         ]
       },
@@ -890,19 +1256,19 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "36"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "51"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "36+"
+            "memo": "51+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19fpg5r87ur86u64vugacducwmulf3m7esxygmz",
+        "avaxAddr": "X-columbus16ryrmg6csk09mmnswmnkdvtv2a7ug07792trp3",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -913,13 +1279,13 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "37"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "52"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "37+"
+            "memo": "52+"
           }
         ]
       },
@@ -936,13 +1302,13 @@
             "amount": 40000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "38"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "53"
           },
           {
             "amount": 400000000000,
             "timestampOffset": 2592000,
-            "memo": "38+"
+            "memo": "53+"
           }
         ]
       },
@@ -959,19 +1325,19 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "39"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "54"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "39+"
+            "memo": "54+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16zfwqtqrp9rah023gfh205f3j292cwl2j2kn9c",
+        "avaxAddr": "X-columbus1u3p0peu345nvsnh27jcqun2yq89le838lycxp8",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -982,13 +1348,13 @@
             "amount": 200000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "40"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "55"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "40+"
+            "memo": "55+"
           }
         ]
       },
@@ -1005,13 +1371,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "41"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "56"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "41+"
+            "memo": "56+"
           }
         ]
       },
@@ -1028,19 +1394,19 @@
             "amount": 20000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "42"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "57"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "42+"
+            "memo": "57+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1vq2w2xemvxznka75429dfzxesq05wm7znyudlf",
+        "avaxAddr": "X-columbus1mp7f8rt2jd604ywnhetk2xq4mmj9qluvaj5fxx",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1051,19 +1417,19 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "43"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "58"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "43+"
+            "memo": "58+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rnjszgltcd004tlxjuvg463g7v48tf5ln0hsxm",
+        "avaxAddr": "X-columbus1f4c73ufv6d9z93580jau6ugky9px22y0ypzzut",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1074,13 +1440,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "44"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "59"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "44+"
+            "memo": "59+"
           }
         ]
       },
@@ -1097,13 +1463,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "45"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "60"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "45+"
+            "memo": "60+"
           }
         ]
       },
@@ -1120,19 +1486,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "46"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "61"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "46+"
+            "memo": "61+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1svc43t9yvwkfzvnwlrgppd3vjsy5t7wv73auel",
+        "avaxAddr": "X-columbus1eqqw5kc58pfw8p63r4grdwwh2u4u4rgfv5rerv",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -1143,13 +1509,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "47"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "62"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "47+"
+            "memo": "62+"
           }
         ]
       },
@@ -1166,13 +1532,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "48"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "63"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "48+"
+            "memo": "63+"
           }
         ]
       },
@@ -1189,19 +1555,19 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "49"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "64"
           },
           {
             "amount": 5000000000000,
             "timestampOffset": 2592000,
-            "memo": "49+"
+            "memo": "64+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1k9d6k4keaje95mwfw6qtz5whkhar3spekmmtvv",
+        "avaxAddr": "X-columbus1dx3455vvn9ncgs7fkyvnuzy94xl4fgwh8wk8e2",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -1214,13 +1580,13 @@
             "validatorDuration": 32400000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "50"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "65"
           },
           {
             "amount": 5000000000000,
             "timestampOffset": 2592000,
-            "memo": "50+"
+            "memo": "65+"
           }
         ]
       },
@@ -1237,13 +1603,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "51"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "66"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "51+"
+            "memo": "66+"
           }
         ]
       },
@@ -1260,13 +1626,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "52"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "67"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "52+"
+            "memo": "67+"
           }
         ]
       },
@@ -1283,13 +1649,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "53"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "68"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "53+"
+            "memo": "68+"
           }
         ]
       },
@@ -1306,19 +1672,19 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "54"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "69"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "54+"
+            "memo": "69+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus14jsqtvkx2u4andtrddaaj06ay8qg5d3hxg43jp",
+        "avaxAddr": "X-columbus1t5ayje5edr2msh2dqtg4m6xp0fuv4k3qsw4fnd",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1329,13 +1695,13 @@
             "amount": 600000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "55"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "70"
           },
           {
             "amount": 6000000000000,
             "timestampOffset": 2592000,
-            "memo": "55+"
+            "memo": "70+"
           }
         ]
       },
@@ -1352,13 +1718,13 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "56"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "71"
           },
           {
             "amount": 5000000000000,
             "timestampOffset": 2592000,
-            "memo": "56+"
+            "memo": "71+"
           }
         ]
       },
@@ -1375,13 +1741,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "57"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "72"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "57+"
+            "memo": "72+"
           }
         ]
       },
@@ -1398,13 +1764,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "58"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "73"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "58+"
+            "memo": "73+"
           }
         ]
       },
@@ -1421,19 +1787,19 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "59"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "74"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "59+"
+            "memo": "74+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12aghnv0jhwsd5yd436l6czeexzyqsv8cqsr867",
+        "avaxAddr": "X-columbus12e08wmmlauses9u4z7sj306mlpycq0gz5zkkrj",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1444,19 +1810,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "60"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "75"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "60+"
+            "memo": "75+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1lwfr2907ruy6wayyxm8w324c9sqj6kagkhxdgc",
+        "avaxAddr": "X-columbus1gqe0v4mamv5gxj9qh4hanftkhqvpnzec438z63",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1467,19 +1833,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "61"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "76"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "61+"
+            "memo": "76+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1t8h492s3qnrm6xrrg29xr9f39ggnna0eaw8yvt",
+        "avaxAddr": "X-columbus1hmrn6czfq65kqwfeq537ktp8ygzxdx4qc09s4a",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1490,13 +1856,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "62"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "77"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "62+"
+            "memo": "77+"
           }
         ]
       },
@@ -1513,13 +1879,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "63"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "78"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "63+"
+            "memo": "78+"
           }
         ]
       },
@@ -1536,13 +1902,13 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "64"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "79"
           },
           {
             "amount": 150000000000,
             "timestampOffset": 2592000,
-            "memo": "64+"
+            "memo": "79+"
           }
         ]
       },
@@ -1559,13 +1925,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "65"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "80"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "65+"
+            "memo": "80+"
           }
         ]
       },
@@ -1582,19 +1948,19 @@
             "amount": 60000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "66"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "81"
           },
           {
             "amount": 600000000000,
             "timestampOffset": 2592000,
-            "memo": "66+"
+            "memo": "81+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18ahxzmj3280c5evh3mjjk3g5kqp7ewtk7d87ua",
+        "avaxAddr": "X-columbus1hs88mzs5s37t8nueennxy7gxz2stdpjey5mxcg",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1605,13 +1971,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "67"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "82"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "67+"
+            "memo": "82+"
           }
         ]
       },
@@ -1628,13 +1994,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "68"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "83"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "68+"
+            "memo": "83+"
           }
         ]
       },
@@ -1651,13 +2017,13 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "69"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "84"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "69+"
+            "memo": "84+"
           }
         ]
       },
@@ -1674,13 +2040,13 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "70"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "85"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "70+"
+            "memo": "85+"
           }
         ]
       },
@@ -1697,13 +2063,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "71"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "86"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "71+"
+            "memo": "86+"
           }
         ]
       },
@@ -1720,13 +2086,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "72"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "87"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "72+"
+            "memo": "87+"
           }
         ]
       },
@@ -1743,19 +2109,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "73"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "88"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "73+"
+            "memo": "88+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16kkecr7xhhry9dzhcjr3merda0994nxkefhxgd",
+        "avaxAddr": "X-columbus1auylykzk6zqxsvrrx6gy2dc4v4l9fp3ttxp7h0",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1766,13 +2132,13 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "74"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "89"
           },
           {
             "amount": 150000000000,
             "timestampOffset": 2592000,
-            "memo": "74+"
+            "memo": "89+"
           }
         ]
       },
@@ -1789,13 +2155,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "75"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "90"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "75+"
+            "memo": "90+"
           }
         ]
       },
@@ -1812,13 +2178,13 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "76"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "91"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "76+"
+            "memo": "91+"
           }
         ]
       },
@@ -1835,13 +2201,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "77"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "92"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "77+"
+            "memo": "92+"
           }
         ]
       },
@@ -1858,13 +2224,13 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "78"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "93"
           },
           {
             "amount": 150000000000,
             "timestampOffset": 2592000,
-            "memo": "78+"
+            "memo": "93+"
           }
         ]
       },
@@ -1881,13 +2247,13 @@
             "amount": 25000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "79"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "94"
           },
           {
             "amount": 250000000000,
             "timestampOffset": 2592000,
-            "memo": "79+"
+            "memo": "94+"
           }
         ]
       },
@@ -1904,19 +2270,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "80"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "95"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "80+"
+            "memo": "95+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1l828527ytgs0wlk9ncvw7zgp4jtadzc25xl2tz",
+        "avaxAddr": "X-columbus1cvd8ardpsynhgfhdaapf7akhqv6sc7m975mrdv",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -1927,13 +2293,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "81"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "96"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "81+"
+            "memo": "96+"
           }
         ]
       },
@@ -1950,13 +2316,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "82"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "97"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "82+"
+            "memo": "97+"
           }
         ]
       },
@@ -1973,13 +2339,13 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "83"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "98"
           },
           {
             "amount": 5000000000000,
             "timestampOffset": 2592000,
-            "memo": "83+"
+            "memo": "98+"
           }
         ]
       },
@@ -1996,13 +2362,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "84"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "99"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "84+"
+            "memo": "99+"
           }
         ]
       },
@@ -2019,13 +2385,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "85"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "100"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "85+"
+            "memo": "100+"
           }
         ]
       },
@@ -2042,13 +2408,13 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "86"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "101"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "86+"
+            "memo": "101+"
           }
         ]
       },
@@ -2065,13 +2431,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "87"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "102"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "87+"
+            "memo": "102+"
           }
         ]
       },
@@ -2088,13 +2454,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "88"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "103"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "88+"
+            "memo": "103+"
           }
         ]
       },
@@ -2111,13 +2477,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "89"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "104"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "89+"
+            "memo": "104+"
           }
         ]
       },
@@ -2134,13 +2500,13 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "90"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "105"
           },
           {
             "amount": 150000000000,
             "timestampOffset": 2592000,
-            "memo": "90+"
+            "memo": "105+"
           }
         ]
       },
@@ -2157,19 +2523,19 @@
             "amount": 1000000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "91"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "106"
           },
           {
             "amount": 10000000000000,
             "timestampOffset": 2592000,
-            "memo": "91+"
+            "memo": "106+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13cvll3vsm02quegweeupnan5kvkqtkzpj0r5xe",
+        "avaxAddr": "X-columbus124aw7ncdfefyqm4srujj9h3yxt9qzpsartnjtj",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2180,13 +2546,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "92"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "107"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "92+"
+            "memo": "107+"
           }
         ]
       },
@@ -2203,13 +2569,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "93"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "108"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "93+"
+            "memo": "108+"
           }
         ]
       },
@@ -2226,19 +2592,19 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "94"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "109"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "94+"
+            "memo": "109+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ujp0vh9az0gaeuqd44vmmx9f7ztmyhmt9hj9vt",
+        "avaxAddr": "X-columbus1lc4qzvsqfzt2yy9k4596v394se6pg97lqfjvch",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2249,13 +2615,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "95"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "110"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "95+"
+            "memo": "110+"
           }
         ]
       },
@@ -2272,19 +2638,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "96"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "111"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "96+"
+            "memo": "111+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1udj7xy6g2ppr9d4m55e9v2r98lk8ntcl3f98m2",
+        "avaxAddr": "X-columbus1zc75guv3vwlhheq76egjesu23eccaa9ke5m62m",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2295,13 +2661,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "97"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "112"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "97+"
+            "memo": "112+"
           }
         ]
       },
@@ -2318,13 +2684,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "98"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "113"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "98+"
+            "memo": "113+"
           }
         ]
       },
@@ -2341,19 +2707,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "99"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "114"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "99+"
+            "memo": "114+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jj003n7f454ku29y5l3a05p6quzu0khz3axu3q",
+        "avaxAddr": "X-columbus1tvlzzcgfey8mc7z3mhwepk84kagutdwm459wah",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2364,13 +2730,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "100"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "115"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "100+"
+            "memo": "115+"
           }
         ]
       },
@@ -2387,19 +2753,19 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "101"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "116"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "101+"
+            "memo": "116+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19q3cq6pz468vpx7g337laevc2vjkt9482uugwx",
+        "avaxAddr": "X-columbus1yqgm4zkumgv5hf2afp798arjm59tat3vz7p3v0",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2410,13 +2776,13 @@
             "amount": 25000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "102"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "117"
           },
           {
             "amount": 250000000000,
             "timestampOffset": 2592000,
-            "memo": "102+"
+            "memo": "117+"
           }
         ]
       },
@@ -2433,13 +2799,13 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "103"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "118"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "103+"
+            "memo": "118+"
           }
         ]
       },
@@ -2456,13 +2822,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "104"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "119"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "104+"
+            "memo": "119+"
           }
         ]
       },
@@ -2479,13 +2845,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "105"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "120"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "105+"
+            "memo": "120+"
           }
         ]
       },
@@ -2502,13 +2868,13 @@
             "amount": 1000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "106"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "121"
           },
           {
             "amount": 10000000000000,
             "timestampOffset": 2592000,
-            "memo": "106+"
+            "memo": "121+"
           }
         ]
       },
@@ -2525,13 +2891,13 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "107"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "122"
           },
           {
             "amount": 300000000000,
             "timestampOffset": 2592000,
-            "memo": "107+"
+            "memo": "122+"
           }
         ]
       },
@@ -2548,13 +2914,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "108"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "123"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "108+"
+            "memo": "123+"
           }
         ]
       },
@@ -2571,13 +2937,13 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "109"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "124"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "109+"
+            "memo": "124+"
           }
         ]
       },
@@ -2594,13 +2960,13 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "110"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "125"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "110+"
+            "memo": "125+"
           }
         ]
       },
@@ -2617,19 +2983,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "111"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "126"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "111+"
+            "memo": "126+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pe75rm3mkxs6q99d0wxh9mzrwtv5jzvz3udtwh",
+        "avaxAddr": "X-columbus1xsznkqapgemyrm5mm6whkxsd6tjqhx6av3sf0t",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -2640,13 +3006,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "112"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "127"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "112+"
+            "memo": "127+"
           }
         ]
       },
@@ -2663,19 +3029,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "113"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "128"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "113+"
+            "memo": "128+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19drcmmm4smw3hd4a6k4fyzapaznf9t05uzlu5p",
+        "avaxAddr": "X-columbus1edf9wnssqddknydsdym28al5axq7dum70kr7gh",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2686,13 +3052,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "114"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "129"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "114+"
+            "memo": "129+"
           }
         ]
       },
@@ -2709,13 +3075,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "115"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "130"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "115+"
+            "memo": "130+"
           }
         ]
       },
@@ -2732,13 +3098,13 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "116"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "131"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "116+"
+            "memo": "131+"
           }
         ]
       },
@@ -2755,13 +3121,13 @@
             "amount": 400000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "117"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "132"
           },
           {
             "amount": 4000000000000,
             "timestampOffset": 2592000,
-            "memo": "117+"
+            "memo": "132+"
           }
         ]
       },
@@ -2778,19 +3144,19 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "118"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "133"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "118+"
+            "memo": "133+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1epg2a7nk4c7yqh48286n3r8hnc5lhtddjt7t2v",
+        "avaxAddr": "X-columbus1sjsdrw4avghcnvm4rkvsd5clhcujgm8d63mwh3",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2801,13 +3167,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "119"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "134"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "119+"
+            "memo": "134+"
           }
         ]
       },
@@ -2824,19 +3190,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "120"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "135"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "120+"
+            "memo": "135+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18nleueq7dvfr782dlq3cpz9402y0944cpkkf9p",
+        "avaxAddr": "X-columbus16g8j2vrcywjskaygezkm5rl40df6m063kj5axq",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2847,19 +3213,19 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "121"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "136"
           },
           {
             "amount": 1500000000000,
             "timestampOffset": 2592000,
-            "memo": "121+"
+            "memo": "136+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13jm659wgtlyhynufv2jmmjsux5hgq7sjdukzne",
+        "avaxAddr": "X-columbus1am4366ap64h8gftnfd5xcx6gspk237y8hcdfyk",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2870,13 +3236,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "122"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "137"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "122+"
+            "memo": "137+"
           }
         ]
       },
@@ -2893,19 +3259,19 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "123"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "138"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "123+"
+            "memo": "138+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1krytgmsvgezzn6vj8zx2jhy3hjmed7cxyhvh6f",
+        "avaxAddr": "X-columbus1u8cuvpxmq807q95newex63za3kpw3nqwlftvl3",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -2916,13 +3282,13 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "124"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "139"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "124+"
+            "memo": "139+"
           }
         ]
       },
@@ -2939,13 +3305,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "125"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "140"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "125+"
+            "memo": "140+"
           }
         ]
       },
@@ -2962,13 +3328,13 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "126"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "141"
           },
           {
             "amount": 150000000000,
             "timestampOffset": 2592000,
-            "memo": "126+"
+            "memo": "141+"
           }
         ]
       },
@@ -2984,8 +3350,8 @@
           {
             "amount": 300000000000000,
             "depositDuration": 157680000,
-            "depositOfferMemo": "team5y",
-            "memo": "127"
+            "depositOfferMemo": "Founders/Team 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "142"
           }
         ]
       },
@@ -3002,13 +3368,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "128"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "143"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "128+"
+            "memo": "143+"
           }
         ]
       },
@@ -3025,13 +3391,13 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "129"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "144"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "129+"
+            "memo": "144+"
           }
         ]
       },
@@ -3048,19 +3414,19 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "130"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "145"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "130+"
+            "memo": "145+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1t9wruy74ma9k7nswq2vvmw05yqzfdaenglfxue",
+        "avaxAddr": "X-columbus1nsh2rw3sjvylgd9gk3jpmfx4dlfgm92yy49540",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3071,13 +3437,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "131"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "146"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "131+"
+            "memo": "146+"
           }
         ]
       },
@@ -3094,13 +3460,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "132"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "147"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "132+"
+            "memo": "147+"
           }
         ]
       },
@@ -3117,13 +3483,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "133"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "148"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "133+"
+            "memo": "148+"
           }
         ]
       },
@@ -3140,13 +3506,13 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "134"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "149"
           },
           {
             "amount": 300000000000,
             "timestampOffset": 2592000,
-            "memo": "134+"
+            "memo": "149+"
           }
         ]
       },
@@ -3163,13 +3529,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "135"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "150"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "135+"
+            "memo": "150+"
           }
         ]
       },
@@ -3186,13 +3552,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "136"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "151"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "136+"
+            "memo": "151+"
           }
         ]
       },
@@ -3209,19 +3575,19 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "137"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "152"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "137+"
+            "memo": "152+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1t7ptfcxfxgv7xal499pm0m2r8rf8kaukkwy3uy",
+        "avaxAddr": "X-columbus1rn52cw296jemvujuv6h9824aezv3w2p4jdpfg8",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3232,19 +3598,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "138"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "153"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "138+"
+            "memo": "153+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1c3zwa9ezxa77wd8qkvtyk6akfkr7usn82z6qlg",
+        "avaxAddr": "X-columbus1f3jtdegkvq8m8avdfqs478hg94xu097hqdd29v",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3255,13 +3621,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "139"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "154"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "139+"
+            "memo": "154+"
           }
         ]
       },
@@ -3278,13 +3644,13 @@
             "amount": 250000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "140"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "155"
           },
           {
             "amount": 2500000000000,
             "timestampOffset": 2592000,
-            "memo": "140+"
+            "memo": "155+"
           }
         ]
       },
@@ -3301,13 +3667,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "141"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "156"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "141+"
+            "memo": "156+"
           }
         ]
       },
@@ -3324,19 +3690,19 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "142"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "157"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "142+"
+            "memo": "157+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qg4c3qpvq08gsu90sw9x84fcw86tdgcx6vapgh",
+        "avaxAddr": "X-columbus1ga0ut4yez75rp8077g77uycgchnxyg28n8t2st",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3347,13 +3713,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "143"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "158"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "143+"
+            "memo": "158+"
           }
         ]
       },
@@ -3370,13 +3736,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "144"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "159"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "144+"
+            "memo": "159+"
           }
         ]
       },
@@ -3393,19 +3759,19 @@
             "amount": 3000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "145"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "160"
           },
           {
             "amount": 30000000000000,
             "timestampOffset": 2592000,
-            "memo": "145+"
+            "memo": "160+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1lf3rmuueyqhdjkqphwkky4e5wcaevflguhu6hc",
+        "avaxAddr": "X-columbus1sjxkh9rcjjt4n3nj907rhh5ejey4wa023vpwmp",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3416,13 +3782,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "146"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "161"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "146+"
+            "memo": "161+"
           }
         ]
       },
@@ -3439,13 +3805,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "147"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "162"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "147+"
+            "memo": "162+"
           }
         ]
       },
@@ -3462,13 +3828,13 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "148"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "163"
           },
           {
             "amount": 300000000000,
             "timestampOffset": 2592000,
-            "memo": "148+"
+            "memo": "163+"
           }
         ]
       },
@@ -3485,13 +3851,13 @@
             "amount": 150000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "149"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "164"
           },
           {
             "amount": 1500000000000,
             "timestampOffset": 2592000,
-            "memo": "149+"
+            "memo": "164+"
           }
         ]
       },
@@ -3508,19 +3874,19 @@
             "amount": 25000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "150"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "165"
           },
           {
             "amount": 250000000000,
             "timestampOffset": 2592000,
-            "memo": "150+"
+            "memo": "165+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1syef5x68ra2k9edldegm9wvqhg567ygwhqtaug",
+        "avaxAddr": "X-columbus1gxw932wm6g0up8pt76af60y4racuugedpfqjfw",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3531,13 +3897,13 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "151"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "166"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "151+"
+            "memo": "166+"
           }
         ]
       },
@@ -3554,19 +3920,19 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "152"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "167"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "152+"
+            "memo": "167+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1puxw75l9njng4gr8f27ajl7qpl45ndyzgkrn2l",
+        "avaxAddr": "X-columbus1k0lnzgar08aa95daf5k066kvuvj0fscxnz9866",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3577,13 +3943,13 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "153"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "168"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "153+"
+            "memo": "168+"
           }
         ]
       },
@@ -3600,13 +3966,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "154"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "169"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "154+"
+            "memo": "169+"
           }
         ]
       },
@@ -3623,13 +3989,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "155"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "170"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "155+"
+            "memo": "170+"
           }
         ]
       },
@@ -3646,13 +4012,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "156"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "171"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "156+"
+            "memo": "171+"
           }
         ]
       },
@@ -3669,19 +4035,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "157"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "172"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "157+"
+            "memo": "172+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1wqmv02nm4cu0alxyegxcc4mp4732q6ac9k9jjp",
+        "avaxAddr": "X-columbus15nanl7nh4p8f0w7d35xy9z0zg2e6cagq4fw57v",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3692,13 +4058,13 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "158"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "173"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "158+"
+            "memo": "173+"
           }
         ]
       },
@@ -3715,19 +4081,19 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "159"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "174"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "159+"
+            "memo": "174+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12x34xyn47cx3cqprf7pqz6cpzv60ynelpqsg74",
+        "avaxAddr": "X-columbus1aytql7x689t96yvf5ctdr23d2gx646lv3fhf5h",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3738,13 +4104,13 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "160"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "175"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "160+"
+            "memo": "175+"
           }
         ]
       },
@@ -3761,19 +4127,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "161"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "176"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "161+"
+            "memo": "176+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12362l5ftcuva4q6p5jcyf7h6gjgy2qtmsqwuys",
+        "avaxAddr": "X-columbus1y30tmzcz0na4nu0uqdh4460dute9nwhvlq6c8t",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3784,19 +4150,19 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "162"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "177"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "162+"
+            "memo": "177+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ldwjgkwgd7hhyutdfdskr5nmw87k77t6z75n49",
+        "avaxAddr": "X-columbus1vpqxc97jyqecl0arr7t0je08z06nljv0ls7yyv",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3807,19 +4173,19 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "163"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "178"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "163+"
+            "memo": "178+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yc54996lkxajkys2zpaquju8hn3pwr58za4u5m",
+        "avaxAddr": "X-columbus1whe7zklwmyxw4ct0x2wsex0ztcfd0dyyva074q",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -3830,13 +4196,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "164"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "179"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "164+"
+            "memo": "179+"
           }
         ]
       },
@@ -3853,13 +4219,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "165"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "180"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "165+"
+            "memo": "180+"
           }
         ]
       },
@@ -3876,13 +4242,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "166"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "181"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "166+"
+            "memo": "181+"
           }
         ]
       },
@@ -3899,13 +4265,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "167"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "182"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "167+"
+            "memo": "182+"
           }
         ]
       },
@@ -3922,13 +4288,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "168"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "183"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "168+"
+            "memo": "183+"
           }
         ]
       },
@@ -3945,13 +4311,13 @@
             "amount": 400000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "169"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "184"
           },
           {
             "amount": 4000000000000,
             "timestampOffset": 2592000,
-            "memo": "169+"
+            "memo": "184+"
           }
         ]
       },
@@ -3968,13 +4334,13 @@
             "amount": 250000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "170"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "185"
           },
           {
             "amount": 2500000000000,
             "timestampOffset": 2592000,
-            "memo": "170+"
+            "memo": "185+"
           }
         ]
       },
@@ -3991,13 +4357,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "171"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "186"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "171+"
+            "memo": "186+"
           }
         ]
       },
@@ -4014,19 +4380,19 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "172"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "187"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "172+"
+            "memo": "187+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rjtkck732eu288f7gc98u4ckc5zwr5xw63atxy",
+        "avaxAddr": "X-columbus1sgctncsl8zaryp5w62xp25qqjhskzqr74p7dfd",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -4037,13 +4403,13 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "173"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "188"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "173+"
+            "memo": "188+"
           }
         ]
       },
@@ -4060,13 +4426,13 @@
             "amount": 50000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "174"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "189"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "174+"
+            "memo": "189+"
           }
         ]
       },
@@ -4083,13 +4449,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "175"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "190"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "175+"
+            "memo": "190+"
           }
         ]
       },
@@ -4106,13 +4472,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "176"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "191"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "176+"
+            "memo": "191+"
           }
         ]
       },
@@ -4129,13 +4495,13 @@
             "amount": 75000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "177"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "192"
           },
           {
             "amount": 750000000000,
             "timestampOffset": 2592000,
-            "memo": "177+"
+            "memo": "192+"
           }
         ]
       },
@@ -4152,13 +4518,13 @@
             "amount": 20000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "178"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "193"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "178+"
+            "memo": "193+"
           }
         ]
       },
@@ -4175,13 +4541,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "179"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "194"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "179+"
+            "memo": "194+"
           }
         ]
       },
@@ -4198,13 +4564,13 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "180"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "195"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "180+"
+            "memo": "195+"
           }
         ]
       },
@@ -4221,13 +4587,13 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "181"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "196"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "181+"
+            "memo": "196+"
           }
         ]
       },
@@ -4244,13 +4610,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "182"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "197"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "182+"
+            "memo": "197+"
           }
         ]
       },
@@ -4267,13 +4633,13 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "183"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "198"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "183+"
+            "memo": "198+"
           }
         ]
       },
@@ -4290,13 +4656,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "184"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "199"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "184+"
+            "memo": "199+"
           }
         ]
       },
@@ -4313,13 +4679,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "185"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "200"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "185+"
+            "memo": "200+"
           }
         ]
       },
@@ -4336,13 +4702,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "186"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "201"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "186+"
+            "memo": "201+"
           }
         ]
       },
@@ -4359,13 +4725,13 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "187"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "202"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "187+"
+            "memo": "202+"
           }
         ]
       },
@@ -4382,13 +4748,13 @@
             "amount": 25000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "188"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "203"
           },
           {
             "amount": 250000000000,
             "timestampOffset": 2592000,
-            "memo": "188+"
+            "memo": "203+"
           }
         ]
       },
@@ -4405,13 +4771,13 @@
             "amount": 120000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "189"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "204"
           },
           {
             "amount": 1200000000000,
             "timestampOffset": 2592000,
-            "memo": "189+"
+            "memo": "204+"
           }
         ]
       },
@@ -4428,13 +4794,13 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "190"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "205"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "190+"
+            "memo": "205+"
           }
         ]
       },
@@ -4451,19 +4817,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "191"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "206"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "191+"
+            "memo": "206+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rnfwllg4wjtygafheat8da4lv4wqa7yyf8qata",
+        "avaxAddr": "X-columbus153ejpsghh0tzamey70clpcd7g0y9r6g677x0f7",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -4474,13 +4840,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "192"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "207"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "192+"
+            "memo": "207+"
           }
         ]
       },
@@ -4497,13 +4863,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "193"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "208"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "193+"
+            "memo": "208+"
           }
         ]
       },
@@ -4520,13 +4886,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "194"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "209"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "194+"
+            "memo": "209+"
           }
         ]
       },
@@ -4543,13 +4909,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "195"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "210"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "195+"
+            "memo": "210+"
           }
         ]
       },
@@ -4566,13 +4932,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "196"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "211"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "196+"
+            "memo": "211+"
           }
         ]
       },
@@ -4589,13 +4955,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "197"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "212"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "197+"
+            "memo": "212+"
           }
         ]
       },
@@ -4612,13 +4978,13 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "198"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "213"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "198+"
+            "memo": "213+"
           }
         ]
       },
@@ -4635,19 +5001,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "199"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "214"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "199+"
+            "memo": "214+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1zpmmsy75djpguyp7m55vp4x37k4hesx595thn5",
+        "avaxAddr": "X-columbus1ysa48z2anf29ckcmg8rak384s0k8uwd2cx2234",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -4658,13 +5024,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "200"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "215"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "200+"
+            "memo": "215+"
           }
         ]
       },
@@ -4681,19 +5047,19 @@
             "amount": 150000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "201"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "216"
           },
           {
             "amount": 1500000000000,
             "timestampOffset": 2592000,
-            "memo": "201+"
+            "memo": "216+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1h87ampd07hwtnqywpsagrxm9ygkmcr34e2uldc",
+        "avaxAddr": "X-columbus1ksn7egxazmfm2d4948cxrzwjt60ez867tleqvs",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -4704,13 +5070,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "202"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "217"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "202+"
+            "memo": "217+"
           }
         ]
       },
@@ -4727,13 +5093,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "203"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "218"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "203+"
+            "memo": "218+"
           }
         ]
       },
@@ -4750,13 +5116,13 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "204"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "219"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "204+"
+            "memo": "219+"
           }
         ]
       },
@@ -4773,13 +5139,13 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "205"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "220"
           },
           {
             "amount": 500000000000,
             "timestampOffset": 2592000,
-            "memo": "205+"
+            "memo": "220+"
           }
         ]
       },
@@ -4796,13 +5162,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "206"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "221"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "206+"
+            "memo": "221+"
           }
         ]
       },
@@ -4819,13 +5185,13 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "207"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "222"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "207+"
+            "memo": "222+"
           }
         ]
       },
@@ -4842,13 +5208,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "208"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "223"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "208+"
+            "memo": "223+"
           }
         ]
       },
@@ -4865,13 +5231,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "209"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "224"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "209+"
+            "memo": "224+"
           }
         ]
       },
@@ -4888,13 +5254,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "210"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "225"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "210+"
+            "memo": "225+"
           }
         ]
       },
@@ -4911,19 +5277,19 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "211"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "226"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "211+"
+            "memo": "226+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18fphrmnm8zl5y8m2z39ydpmhl4pvtslj8kwpxe",
+        "avaxAddr": "X-columbus1t7hagl6tr9hj7hvt66xv73au3edt8fj0aagwk4",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -4934,19 +5300,19 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "212"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "227"
           },
           {
             "amount": 1500000000000,
             "timestampOffset": 2592000,
-            "memo": "212+"
+            "memo": "227+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1uhdv7ytdu9w7mza2etzajrcqvl2j85s93d328a",
+        "avaxAddr": "X-columbus1p4xp6m8qgt202aqklwcnhfqx5rg9c2hucrj7qv",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -4957,13 +5323,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "213"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "228"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "213+"
+            "memo": "228+"
           }
         ]
       },
@@ -4980,13 +5346,13 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "214"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "229"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "214+"
+            "memo": "229+"
           }
         ]
       },
@@ -5003,19 +5369,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "215"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "230"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "215+"
+            "memo": "230+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus104wz2lt44kw2u8r775hfdujk6rrpgmjdhl7q6h",
+        "avaxAddr": "X-columbus15xxam9nwdz53wdl9zsewqpnjel0arf0wqvl2h5",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -5026,13 +5392,13 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "216"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "231"
           },
           {
             "amount": 1500000000000,
             "timestampOffset": 2592000,
-            "memo": "216+"
+            "memo": "231+"
           }
         ]
       },
@@ -5049,19 +5415,19 @@
             "amount": 70000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "217"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "232"
           },
           {
             "amount": 700000000000,
             "timestampOffset": 2592000,
-            "memo": "217+"
+            "memo": "232+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yqqenlx3n6lc7jas4m0jh9cghct3me68depja2",
+        "avaxAddr": "X-columbus1cvt8hhmkysu5rdjzvdvvp70tq5u7ae4pq8kw9s",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -5072,13 +5438,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "218"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "233"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "218+"
+            "memo": "233+"
           }
         ]
       },
@@ -5095,13 +5461,13 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "219"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "234"
           },
           {
             "amount": 200000000000,
             "timestampOffset": 2592000,
-            "memo": "219+"
+            "memo": "234+"
           }
         ]
       },
@@ -5118,19 +5484,19 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "220"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "235"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "220+"
+            "memo": "235+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1l828527ytgs0wlk9ncvw7zgp4jtadzc25xl2tz",
+        "avaxAddr": "X-columbus1cvd8ardpsynhgfhdaapf7akhqv6sc7m975mrdv",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -5141,13 +5507,13 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "221"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "236"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "221+"
+            "memo": "236+"
           }
         ]
       },
@@ -5164,19 +5530,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "222"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "237"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "222+"
+            "memo": "237+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1w82vcsrucl4lrys8dtnk5t2yshpnuq234u53x9",
+        "avaxAddr": "X-columbus13ugty8yv3xn96kcet56kkvjx26m9e88v8fjh7m",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -5187,19 +5553,19 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "223"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "238"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "223+"
+            "memo": "238+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus10hdjkp8qynahtewufy6ek3pv0r35j7ufqaze4x",
+        "avaxAddr": "X-columbus1vntz0u4d88yjxsfm9rmpczrx7295wu9gx2m7qs",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -5210,19 +5576,19 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "224"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "239"
           },
           {
             "amount": 150000000000,
             "timestampOffset": 2592000,
-            "memo": "224+"
+            "memo": "239+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rm36u8p8v2vslddf0z2zmj97shcfx94awvfcgc",
+        "avaxAddr": "X-columbus1w9atxlc3rvv7328xclhrvly5rhjzcts5ffy5p6",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5232,14 +5598,14 @@
           {
             "amount": 4500000000000000,
             "depositDuration": 157680000,
-            "depositOfferMemo": "team5y",
-            "memo": "225"
+            "depositOfferMemo": "Founders/Team 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "240"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1zq3vqpsxpfakseymatqmm7krm64uhm80q8ey4p",
+        "avaxAddr": "X-columbus1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrkg2ksc",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5250,13 +5616,13 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "226"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "241"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "226+"
+            "memo": "241+"
           }
         ]
       },
@@ -5273,19 +5639,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "227"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "242"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "227+"
+            "memo": "242+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16sw3qmf2m4p6enwfzs9qfhjm538dzpf2ess6dg",
+        "avaxAddr": "X-columbus17cm7uuukw5cx68sxlpzg6pzq5e723r9j7he0uy",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5296,13 +5662,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "228"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "243"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "228+"
+            "memo": "243+"
           }
         ]
       },
@@ -5321,13 +5687,13 @@
             "validatorDuration": 30672000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "229"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "244"
           },
           {
             "amount": 20000000000000,
             "timestampOffset": 2592000,
-            "memo": "229+"
+            "memo": "244+"
           }
         ]
       },
@@ -5344,19 +5710,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "230"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "245"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "230+"
+            "memo": "245+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xl6ezwlmpxhytmhlvrl85lvnheunjuu5un5qa9",
+        "avaxAddr": "X-columbus1qh9nzgm6q5cfa2mpshwu9guzahf5se7f8cs7g4",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5367,65 +5733,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "231"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "246"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "231+"
+            "memo": "246+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dd39r6a83pd5llzag9r4c9mqdgd38jzlnsd2t2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "232"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 2592000,
-            "memo": "232+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pkfar9ajf34egm9my20tnytmvn98d6d9xdahvr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "233"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 2592000,
-            "memo": "233+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ph50fuuzxmmkmpskmvkrdzudtdze4zfj33p4ef",
+        "avaxAddr": "X-columbus15wxmstyfxxx82ewdmz3usvfk20h39zqhvdqf66",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5436,42 +5756,19 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "234"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "247"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "234+"
+            "memo": "247+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rrdl8mgqhs7af9ktx4uw9puyanfc93223yn8kd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "235"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 2592000,
-            "memo": "235+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus17zjxkrmglzcmuwafag4uknacew39ev2ls9tga3",
+        "avaxAddr": "X-columbus1jm8694tdqc6q27my8wnwhe7mmpl93scy2ck8dn",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5482,19 +5779,88 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "236"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "248"
           },
           {
             "amount": 1500000000000,
             "timestampOffset": 2592000,
-            "memo": "236+"
+            "memo": "248+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yd8u5d2jq4x9nntadxq6zuz0g8k2x5twgme9d8",
+        "avaxAddr": "X-columbus1xvhn7tf5kqut6ed30s5kdk9du99k30h7f266e3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "249"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 2592000,
+            "memo": "249+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1f7mkhrp5pmcghqev620ukveklf293x9dpy58qu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "250"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 2592000,
+            "memo": "250+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13rvwcwccp4v72lqrtgnw2gaerrpfmn567scxd3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "251"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 2592000,
+            "memo": "251+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1shlcs8lgwxcnsc66gs2yn0k0qqft77hpekmeha",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5507,19 +5873,19 @@
             "validatorDuration": 31536000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "237"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "252"
           },
           {
             "amount": 20000000000000,
             "timestampOffset": 2592000,
-            "memo": "237+"
+            "memo": "252+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ymnp6l60g0ykhr9k484qcdfjjfmdskx4hz5gzk",
+        "avaxAddr": "X-columbus18har8esnq6gww24qhgsq39g390mn8p7kq6fhl3",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5530,13 +5896,13 @@
             "amount": 500000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "238"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "253"
           },
           {
             "amount": 5000000000000,
             "timestampOffset": 2592000,
-            "memo": "238+"
+            "memo": "253+"
           }
         ]
       },
@@ -5553,19 +5919,19 @@
             "amount": 300000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "239"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "254"
           },
           {
             "amount": 3000000000000,
             "timestampOffset": 2592000,
-            "memo": "239+"
+            "memo": "254+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yumnux0gjuxv2p074gcwqw5hv4cjhpc3gehteh",
+        "avaxAddr": "X-columbus1c3kd4e02r5mzg83ezs7yxhwrvyfstqnjpfvrld",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5576,13 +5942,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "240"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "255"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "240+"
+            "memo": "255+"
           }
         ]
       },
@@ -5599,19 +5965,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "241"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "256"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "241+"
+            "memo": "256+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kjxmutel336ev5kzfvsal7e4ytvmu7z6t2dwg2",
+        "avaxAddr": "X-columbus1dxd66ecwj99xyezr4p5fq7cfwcqqhj29vxlzu9",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5622,13 +5988,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "242"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "257"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "242+"
+            "memo": "257+"
           }
         ]
       },
@@ -5645,13 +6011,13 @@
             "amount": 400000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "243"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "258"
           },
           {
             "amount": 4000000000000,
             "timestampOffset": 2592000,
-            "memo": "243+"
+            "memo": "258+"
           }
         ]
       },
@@ -5668,19 +6034,19 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "244"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "259"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 2592000,
-            "memo": "244+"
+            "memo": "259+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1l84g47rj8r9p8zsznvnz2nce65k3wjxgeyrwzv",
+        "avaxAddr": "X-columbus1m6gxrjq7qesqz2y998zacjjphsehneaqj44pmm",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5691,19 +6057,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "245"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "260"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "245+"
+            "memo": "260+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1akmdd3p8e3c2vu2cp9cz40ssyt79tzcragnfl8",
+        "avaxAddr": "X-columbus1zepqrffl3c5szd7y7cnhcrcrtjvxg3zd9c37dm",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5714,19 +6080,19 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "246"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "261"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "246+"
+            "memo": "261+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1wpxls6rvgx6gpkm57zhjqy9g7wwq00kgxyugtq",
+        "avaxAddr": "X-columbus1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtadmsx8e",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5737,19 +6103,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "247"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "262"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "247+"
+            "memo": "262+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus17p73e7x3qamqh4r0m9dx7ktzd0dck5jrtdyxy4",
+        "avaxAddr": "X-columbus160l526l8mkfjeacnhyv5ucvp6uekv9ccvvuyvw",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5760,13 +6126,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "248"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "263"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "248+"
+            "memo": "263+"
           }
         ]
       },
@@ -5785,19 +6151,19 @@
             "validatorDuration": 30240000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "249"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "264"
           },
           {
             "amount": 5000000000000,
             "timestampOffset": 2592000,
-            "memo": "249+"
+            "memo": "264+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1v9dvjffg95tlxp7u3ehufgmm4xpuunzssaz527",
+        "avaxAddr": "X-columbus1td7w8a2ktccxktvh72275txv4dpzcn5y785zff",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5808,13 +6174,13 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "250"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "265"
           },
           {
             "amount": 2000000000000,
             "timestampOffset": 2592000,
-            "memo": "250+"
+            "memo": "265+"
           }
         ]
       },
@@ -5831,13 +6197,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "251"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "266"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "251+"
+            "memo": "266+"
           }
         ]
       },
@@ -5854,19 +6220,19 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "252"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "267"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "252+"
+            "memo": "267+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1p7tlgcxyx8clqq3yvf4pr9gjng22ns9k42lcs0",
+        "avaxAddr": "X-columbus1537zcugeec0243matenf36nc90qg0rhh3fggee",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -5877,13 +6243,13 @@
             "amount": 300000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "253"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "268"
           },
           {
             "amount": 3000000000000,
             "timestampOffset": 2592000,
-            "memo": "253+"
+            "memo": "268+"
           }
         ]
       },
@@ -5900,13 +6266,13 @@
             "amount": 250000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale4y",
-            "memo": "254"
+            "depositOfferMemo": "presale 4Y - not pickable after network creation, only for genesis allocations",
+            "memo": "269"
           },
           {
             "amount": 2500000000000,
             "timestampOffset": 2592000,
-            "memo": "254+"
+            "memo": "269+"
           }
         ]
       },
@@ -5923,13 +6289,13 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "255"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "270"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "255+"
+            "memo": "270+"
           }
         ]
       },
@@ -5946,13 +6312,13 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "256"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "271"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 2592000,
-            "memo": "256+"
+            "memo": "271+"
           }
         ]
       },
@@ -5969,13 +6335,13 @@
             "amount": 1000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "257"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "272"
           },
           {
             "amount": 10000000000000,
             "timestampOffset": 2592000,
-            "memo": "257+"
+            "memo": "272+"
           }
         ]
       },
@@ -5992,13 +6358,13 @@
             "amount": 500000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale3y",
-            "memo": "258"
+            "depositOfferMemo": "presale 3Y - not pickable after network creation, only for genesis allocations",
+            "memo": "273"
           },
           {
             "amount": 5000000000000,
             "timestampOffset": 2592000,
-            "memo": "258+"
+            "memo": "273+"
           }
         ]
       },
@@ -6015,19 +6381,19 @@
             "amount": 1500000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferMemo": "presale5y",
-            "memo": "259"
+            "depositOfferMemo": "presale 5Y - not pickable after network creation, only for genesis allocations",
+            "memo": "274"
           },
           {
             "amount": 15000000000000,
             "timestampOffset": 2592000,
-            "memo": "259+"
+            "memo": "274+"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1eh9hg8mpm5j9k9ddc5wpk8aj7evx8fzgzpt5yg",
+        "avaxAddr": "X-columbus1rn02xm62pnqx0mm6f23jtpwmd42zrkwcpn4pqa",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -6038,9 +6404,9 @@
             "amount": 10000000000000000,
             "nodeID": "NodeID-5APqagKQK2d9cMrtgR2h3bsC4GrU3UkNr",
             "validatorDuration": 31968000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "team5y",
-            "memo": "260"
+            "depositDuration": 110376000,
+            "depositOfferMemo": "Seed investors lock",
+            "memo": "275"
           }
         ]
       }
@@ -6067,11 +6433,11 @@
         "memo": "114"
       },
       {
-        "alias": "X-columbus1zq3vqpsxpfakseymatqmm7krm64uhm80q8ey4p",
+        "alias": "X-columbus1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrkg2ksc",
         "addresses": [
-          "X-columbus1rjlxz9m74deugtquzw0uz9ptvwr6ee02tjlyye",
-          "X-columbus19khkh86zw6c0w2en0vyw4kqtnmldsx2pkzqgt2",
-          "X-columbus13ac3fneqqp5em7mqst4dv7yv7ct4szwj6p57rd"
+          "X-columbus1xhgfdj0zwqyntv2a43xftcpdqgtzhyyc65gdm6",
+          "X-columbus1ggm6nly7q96mqxkjwc7yed0pzya7y9vz9vu533",
+          "X-columbus1mavgenegtk3elk07l4vzfxcyrvx2fsnvavdpj4"
         ],
         "threshold": 2,
         "memo": "123"
@@ -6086,9 +6452,9 @@
         "memo": "168"
       },
       {
-        "alias": "X-columbus17p73e7x3qamqh4r0m9dx7ktzd0dck5jrtdyxy4",
+        "alias": "X-columbus160l526l8mkfjeacnhyv5ucvp6uekv9ccvvuyvw",
         "addresses": [
-          "X-columbus1qvflkawwhe5sau8xuw4apzhu2reztnvulh6679"
+          "X-columbus1mvvz30r2ygmwyk9dc6y69ff9vqfxqdh95vwjfm"
         ],
         "threshold": 1,
         "memo": "169"
@@ -6112,29 +6478,29 @@
         "memo": "265"
       },
       {
-        "alias": "X-columbus1l84g47rj8r9p8zsznvnz2nce65k3wjxgeyrwzv",
+        "alias": "X-columbus1m6gxrjq7qesqz2y998zacjjphsehneaqj44pmm",
         "addresses": [
-          "X-columbus1qad6z8s8ghehxhyemrdv4uc3ndzk8tqnaxry2u",
+          "X-columbus1tue3f8kqn43l7548q35n5l8t6fyhw7a8qq5dmq",
           "X-columbus1nhkdq29jvecgsnhwxg36g3qy3fd6n7ayny4n7w"
         ],
         "threshold": 1,
         "memo": "294"
       },
       {
-        "alias": "X-columbus1akmdd3p8e3c2vu2cp9cz40ssyt79tzcragnfl8",
+        "alias": "X-columbus1zepqrffl3c5szd7y7cnhcrcrtjvxg3zd9c37dm",
         "addresses": [
           "X-columbus18dc4jdycs82yw3p9uk537kvt80snjvkyunge2d",
-          "X-columbus1flnpq33aprfsfwu55teq309zlwwfl5yv2e3x7r",
+          "X-columbus164ga3vuv2wr0ynrtfzhcw54mdz9appxp2t6s58",
           "X-columbus17vmr4hvyl3dw9ec7clptmqt2dpd0uaqzderkkn"
         ],
         "threshold": 2,
         "memo": "348"
       },
       {
-        "alias": "X-columbus1v9dvjffg95tlxp7u3ehufgmm4xpuunzssaz527",
+        "alias": "X-columbus1td7w8a2ktccxktvh72275txv4dpzcn5y785zff",
         "addresses": [
-          "X-columbus1r74sn3yjlf6utqxhd62ecwhcmj0rwexxqzzsc0",
-          "X-columbus1jc9fqt0t75v4c8p3rfctafegctkc5cd5lj2cja"
+          "X-columbus1nnj4786z985qx6qamvra4zyh6h3v7kxerr3yne",
+          "X-columbus1aypxtwfkzjy02vtyl05z2g3cqrfnml2dhyv0eq"
         ],
         "threshold": 2,
         "memo": "382"
@@ -6158,9 +6524,9 @@
         "memo": "394"
       },
       {
-        "alias": "X-columbus1wpxls6rvgx6gpkm57zhjqy9g7wwq00kgxyugtq",
+        "alias": "X-columbus1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtadmsx8e",
         "addresses": [
-          "X-columbus1fsz4z9sh7s05hr9cup9yz82cmx4avpt62nzmdd"
+          "X-columbus1gye293pwk9af9s9ws826wetzr6l4phz3p8yuqd"
         ],
         "threshold": 1,
         "memo": "402"
@@ -6174,32 +6540,32 @@
         "memo": "421"
       },
       {
-        "alias": "X-columbus1dd39r6a83pd5llzag9r4c9mqdgd38jzlnsd2t2",
+        "alias": "X-columbus15wxmstyfxxx82ewdmz3usvfk20h39zqhvdqf66",
         "addresses": [
           "X-columbus1c5hzeksvkgaydyk5mvxqtdu5ud0smeqp9fk4nt",
           "X-columbus16h4jp22kqeykwsejfsqw2huaeka9hd37n4vdyv",
-          "X-columbus1acfdnrpxm3ep58h9qzrtupxkvhemr67alqqf0f"
+          "X-columbus1udmhtchhzknfrc674765p7haalzp5nthxh4zk7"
         ],
         "threshold": 2,
         "memo": "422"
       },
       {
-        "alias": "X-columbus1pkfar9ajf34egm9my20tnytmvn98d6d9xdahvr",
+        "alias": "X-columbus1jm8694tdqc6q27my8wnwhe7mmpl93scy2ck8dn",
         "addresses": [
-          "X-columbus1xj5d33f760jtqm49ednl5dxjac3sl6vnwlx0sl",
-          "X-columbus1s5ualug048zxhlj50nr3527lk06dnyxrpg8lpq"
+          "X-columbus1tyhaxdvp2kdtcylmjjjk3au2sdvsfj9kcxsn49",
+          "X-columbus1vc6tq3tn3fz49y532q7tdg6w7at2dx3r5agd7p"
         ],
         "threshold": 1,
         "memo": "423"
       },
       {
-        "alias": "X-columbus1ph50fuuzxmmkmpskmvkrdzudtdze4zfj33p4ef",
+        "alias": "X-columbus1xvhn7tf5kqut6ed30s5kdk9du99k30h7f266e3",
         "addresses": [
-          "X-columbus1p0qgvr8ykvzjntjvcuclmsvv9mkav4ryp7rxhm",
-          "X-columbus1ynz6fr7xpf6y2zfnc8g797e8pmnj85ma69wqp7",
+          "X-columbus1vk90lszrs4kcpdu3zpqp3zapyvxrp8yhykxwlu",
           "X-columbus1vl8ac9pa058c6kqchtegqhyvqppa6ax9mms8nr",
-          "X-columbus1sk5shk4dxpk0t32ktc5gqzpptqmdhaytwgdyys",
-          "X-columbus16ju73s7am4w8q6rutlhl794hcuyv7tl6293cvm"
+          "X-columbus1d0el2szhu3azftp7z8w7vgp5gm2rcfcvptuw34",
+          "X-columbus15jrtmg8qf328qkasy892hf2n5hghh8xdgsx4fj",
+          "X-columbus1ajp9ctl6wczhk45yz2s66klhlf3czhvxcgcwdn"
         ],
         "threshold": 2,
         "memo": "424"
@@ -6214,68 +6580,68 @@
         "memo": "441"
       },
       {
-        "alias": "X-columbus1xl6ezwlmpxhytmhlvrl85lvnheunjuu5un5qa9",
+        "alias": "X-columbus1qh9nzgm6q5cfa2mpshwu9guzahf5se7f8cs7g4",
         "addresses": [
-          "X-columbus1rtgc42mnalqkfcsxx2m4027a340tttm6uqw3em",
-          "X-columbus1k6a24y06jr9hs2ztu3yevy9ax7uk5d6arjs2x4",
-          "X-columbus1a70jassv2cmt93j3fdtqm77q25y2ru4hqpd50l"
+          "X-columbus1zt7qczfecjda0qzn9zq9lvu24pv90ts64vx7td",
+          "X-columbus1zuhfsllesh4k54rxwkmxcwyn6jkpakr0u6fkuv",
+          "X-columbus1l9d26hr08w7d57hcepfz2hl8n66jzjgaan0t5e"
         ],
         "threshold": 2,
         "memo": "492"
       },
       {
-        "alias": "X-columbus1k9d6k4keaje95mwfw6qtz5whkhar3spekmmtvv",
+        "alias": "X-columbus1dx3455vvn9ncgs7fkyvnuzy94xl4fgwh8wk8e2",
         "addresses": [
-          "X-columbus1ht5n4ynt6dlt0r7ce2gadww64y4k2xund7kawe"
+          "X-columbus1y4044a9ltvz6weh7qvm930x685fa9fap2xjhpu"
         ],
         "threshold": 1,
         "memo": "564"
       },
       {
-        "alias": "X-columbus1eh9hg8mpm5j9k9ddc5wpk8aj7evx8fzgzpt5yg",
+        "alias": "X-columbus1rn02xm62pnqx0mm6f23jtpwmd42zrkwcpn4pqa",
         "addresses": [
-          "X-columbus1avzavnjk9fgmga3drf4scmycnwl8m2pvrflgv2"
+          "X-columbus17u7fq7jkawn59e680rwwax7ctjn473nl939vzv"
         ],
         "threshold": 1,
         "memo": "565"
       },
       {
-        "alias": "X-columbus1rrdl8mgqhs7af9ktx4uw9puyanfc93223yn8kd",
+        "alias": "X-columbus1f7mkhrp5pmcghqev620ukveklf293x9dpy58qu",
         "addresses": [
           "X-columbus1qx7x8d472llxgtg9h4wfw9q6mfzfqv7metum4c",
-          "X-columbus1y77kfdm5g293y7zm7ck2ap25w873wkv7xc5n0v",
-          "X-columbus19vsn3h29rjxgpaxc7c8hx4s9agkr0jkq59k0cu",
-          "X-columbus1xevlxkmqkpqxga5thezc8ckyjpxeqj39x4tk6r",
-          "X-columbus1vrxtv3uyy2c442vx4u279ygx58lee3zj8594hm",
-          "X-columbus162g2l9j7dkyrfvz68tnnph86zdycuq5eh637x8"
+          "X-columbus1t326mc4mxzgv2zk4xw6wql7ld4rmgg7cksvm90",
+          "X-columbus1cgzgtnk6gj9pnws9w6ecya0jqqckc2sm5xexnh",
+          "X-columbus1c5gfpcuvdq378ex8crll8mgkae6hdylnt2jsnq",
+          "X-columbus1u7mucmymjh7w6ffjh7gp4fd68uuaqd6ncmuqkx",
+          "X-columbus1lsr42pxckzvmkd5y9rm2nvnty3ju5gjhudrwd3"
         ],
         "threshold": 3,
         "memo": "568"
       },
       {
-        "alias": "X-columbus17zjxkrmglzcmuwafag4uknacew39ev2ls9tga3",
+        "alias": "X-columbus13rvwcwccp4v72lqrtgnw2gaerrpfmn567scxd3",
         "addresses": [
           "X-columbus1pwfsrcae9kxr4faq5w0upa4stj45q9jzlgjq33",
           "X-columbus1x6my7jdu0wy2zgfeurt0ue0q7ypnrlacx5nzzu",
-          "X-columbus13c69m2kfrr3u83f4fr5zxvp8797wp9fv6vcpud"
+          "X-columbus1g0h99yx8cmklsr223fvuqpx0cyfd6rr2gzp6ld"
         ],
         "threshold": 2,
         "memo": "569"
       },
       {
-        "alias": "X-columbus1kjxmutel336ev5kzfvsal7e4ytvmu7z6t2dwg2",
+        "alias": "X-columbus1dxd66ecwj99xyezr4p5fq7cfwcqqhj29vxlzu9",
         "addresses": [
-          "X-columbus1n7zvnqe63pcjmglwm7jyg3a9n0dter3rv2x3n2",
-          "X-columbus1ujcat254t7askj4tpju3uc70p3k3gm8j649ux5",
-          "X-columbus1l8slwyve2c2pzenapm450fykuh82mw3dlpfx3w"
+          "X-columbus1rwek7nheyyg6vjp4hy67lfr76c3gpq8935hvq6",
+          "X-columbus1d6qztaunws956zdwv7u7csqhysgz7yu6g7dgg5",
+          "X-columbus1u0ywjglrprcutlnkcnk5qtzcgggj4ksusm0hxe"
         ],
         "threshold": 2,
         "memo": "576"
       },
       {
-        "alias": "X-columbus1yumnux0gjuxv2p074gcwqw5hv4cjhpc3gehteh",
+        "alias": "X-columbus1c3kd4e02r5mzg83ezs7yxhwrvyfstqnjpfvrld",
         "addresses": [
-          "X-columbus1ulucvsrhveqzdt37zhfdysycskw0v2f9td222z"
+          "X-columbus1tc85rxtwjxn46uen44rqwfdrry24ha9r8fggkg"
         ],
         "threshold": 1,
         "memo": "602"
@@ -6307,14 +6673,25 @@
         "memo": "675"
       },
       {
-        "alias": "X-columbus1rm36u8p8v2vslddf0z2zmj97shcfx94awvfcgc",
+        "alias": "X-columbus1w9atxlc3rvv7328xclhrvly5rhjzcts5ffy5p6",
         "addresses": [
-          "X-columbus10ghxqewfgujnfzxqz2jjsrcqx8xglr0s7s4c2u",
-          "X-columbus10wq8n5sjctvruhf8wdp4xev4l7ru3ws6707ce9",
-          "X-columbus1nt6kdghwa8j3crxm9t9pa4ehgc0u6f8jy09vdv"
+          "X-columbus1qdwchlnyh9ztsv85pvzyy830l0ur7nhpfelduz",
+          "X-columbus1yugvehun9ztwradyser8ct4pzfkrs4cf0c66cl",
+          "X-columbus1txt459m2yq657yclyx0fuh3eg88uy0kz8v6j6k"
         ],
         "threshold": 1,
         "memo": "682"
+      },
+      {
+        "alias": "X-columbus1ksn7egxazmfm2d4948cxrzwjt60ez867tleqvs",
+        "addresses": [
+          "X-columbus1pzdrxqdnkuxa427gmuc8fg2gnj4hv3w0kt7s2q",
+          "X-columbus1teeklahjnuwwfna5tvudvrswxerm2fdttd0l2e",
+          "X-columbus1h87ampd07hwtnqywpsagrxm9ygkmcr34e2uldc",
+          "X-columbus1at9hu5wd4xpfagvqs4t47yd4p6jx87gp678hqf"
+        ],
+        "threshold": 2,
+        "memo": "689"
       },
       {
         "alias": "X-columbus12hcmkc67wjvcdj7vqlzcqrpehs9lp50y3fpkas",
@@ -6326,38 +6703,38 @@
         "memo": "728"
       },
       {
-        "alias": "X-columbus1p7tlgcxyx8clqq3yvf4pr9gjng22ns9k42lcs0",
+        "alias": "X-columbus1537zcugeec0243matenf36nc90qg0rhh3fggee",
         "addresses": [
-          "X-columbus1yrqhgzgadkyy3wgz3z67vx7zrhm4us06es9d72",
-          "X-columbus1xh62a0ada45g93x342r7vhhv5a9hs7x5wml7nc"
+          "X-columbus1qfwkgqzmrmr9qvhr0l0ytchc9je045ptdgcu00",
+          "X-columbus1yqg7wdnmgdr5230dspa9fc8x0lq6che703dca3"
         ],
         "threshold": 1,
         "memo": "730"
       },
       {
-        "alias": "X-columbus16sw3qmf2m4p6enwfzs9qfhjm538dzpf2ess6dg",
+        "alias": "X-columbus17cm7uuukw5cx68sxlpzg6pzq5e723r9j7he0uy",
         "addresses": [
-          "X-columbus1skv4phaz8n6qcvpwe2jdnsu00gtyzagrwy4va3",
-          "X-columbus1kudhcsk27qtc7zyree2jxj8gm38sn7cp84zjzz"
+          "X-columbus1v9n5mvtwe4t2fdk0qu3n8akysct6s7wv8uw982",
+          "X-columbus1skv4phaz8n6qcvpwe2jdnsu00gtyzagrwy4va3"
         ],
         "threshold": 1,
         "memo": "736"
       },
       {
-        "alias": "X-columbus1ymnp6l60g0ykhr9k484qcdfjjfmdskx4hz5gzk",
+        "alias": "X-columbus18har8esnq6gww24qhgsq39g390mn8p7kq6fhl3",
         "addresses": [
-          "X-columbus13du65yjyrvrfgua8s02ytvx4rslsqzde4mqf80",
-          "X-columbus1ujh4jfc5fa6aa6h44pg33u8jt3q8xaqavzvp5c"
+          "X-columbus1qyp3dqghf3nmyhectuq09peyd4asqgntc6udzx",
+          "X-columbus15r60f5ehfs225n69vwnpuwk43s9zzwed33529n"
         ],
         "threshold": 1,
         "memo": "757"
       },
       {
-        "alias": "X-columbus1yd8u5d2jq4x9nntadxq6zuz0g8k2x5twgme9d8",
+        "alias": "X-columbus1shlcs8lgwxcnsc66gs2yn0k0qqft77hpekmeha",
         "addresses": [
-          "X-columbus1xlr8nhvm78s8ypqr4jpt0353mvzz6xjdtx9x46",
-          "X-columbus1tx2unmz2sw4f56gw5sjkmrtf5u87lccej2nzc4",
-          "X-columbus1h8mwk0rk00pnf5mxueapkuarfj337yazuqqeml"
+          "X-columbus18nxlt5qepw236229nzpvhlgr9l7w9r6qct54f8",
+          "X-columbus1jwg48rzfv2fsykyyh3ypccv670c094vyrf0j8q",
+          "X-columbus1kgcurud2zcf2qczrnx74dd2zp73swfjmyvth08"
         ],
         "threshold": 2,
         "memo": "818"
@@ -6371,33 +6748,33 @@
         "memo": "914"
       },
       {
-        "alias": "X-columbus1v7kdfuh0u2sg26cu7nf6drptz7lzayfm7vqrnk",
+        "alias": "X-columbus194sm66h2qrmtae7gcesnmxdstzqv0mpt7k2snk",
         "addresses": [
-          "X-columbus1vxmf8899y6x7dsam0xnr0hp6syzwz33383z3s7",
-          "X-columbus1w3szy4e5excad4j8xp2ua0ukqcfq2uh425mjj9",
-          "X-columbus10q3dc78tw70m89s8lgl9fgwe9tfu4a0sry5xgd",
-          "X-columbus1kuaaqcggcl8ke6dhm8zmuhl2xc544q8v8khm5v"
+          "X-columbus18pry238vq8uzzpar32wa4x4p2rkyc7wxq8a639",
+          "X-columbus18l0l8dz03vmk7k7y5cgax8k2l5mphj4p73ph4p",
+          "X-columbus1d0ydd4wyq670lzrp0y7xd3wej4z7ysp26md7p6",
+          "X-columbus1h87ampd07hwtnqywpsagrxm9ygkmcr34e2uldc"
         ],
         "threshold": 2,
         "memo": "931"
       },
       {
-        "alias": "X-columbus1ce27vm0mwdkf03ct6vh8gtldur0rm4rdv0uazk",
+        "alias": "X-columbus1z5ykr4vxdhqder6jl0j5je2kl9cqxxlnfu6kkh",
         "addresses": [
-          "X-columbus1vxmf8899y6x7dsam0xnr0hp6syzwz33383z3s7",
-          "X-columbus1w3szy4e5excad4j8xp2ua0ukqcfq2uh425mjj9",
-          "X-columbus10q3dc78tw70m89s8lgl9fgwe9tfu4a0sry5xgd",
-          "X-columbus1kuaaqcggcl8ke6dhm8zmuhl2xc544q8v8khm5v"
+          "X-columbus18pry238vq8uzzpar32wa4x4p2rkyc7wxq8a639",
+          "X-columbus18l0l8dz03vmk7k7y5cgax8k2l5mphj4p73ph4p",
+          "X-columbus1d0ydd4wyq670lzrp0y7xd3wej4z7ysp26md7p6",
+          "X-columbus1h87ampd07hwtnqywpsagrxm9ygkmcr34e2uldc"
         ],
         "threshold": 2,
         "memo": "932"
       },
       {
-        "alias": "X-columbus1vscyf7czawylztn6ghhg0z27swwewxgzzxkyke",
+        "alias": "X-columbus1prxyey5xugn5c6tqusha9m4hd4rvld23ag7y8x",
         "addresses": [
-          "X-columbus1vxmf8899y6x7dsam0xnr0hp6syzwz33383z3s7",
-          "X-columbus10q3dc78tw70m89s8lgl9fgwe9tfu4a0sry5xgd",
-          "X-columbus1kuaaqcggcl8ke6dhm8zmuhl2xc544q8v8khm5v"
+          "X-columbus18pry238vq8uzzpar32wa4x4p2rkyc7wxq8a639",
+          "X-columbus18l0l8dz03vmk7k7y5cgax8k2l5mphj4p73ph4p",
+          "X-columbus1h87ampd07hwtnqywpsagrxm9ygkmcr34e2uldc"
         ],
         "threshold": 2,
         "memo": "933"
@@ -6411,6 +6788,22 @@
         ],
         "threshold": 2,
         "memo": "975"
+      },
+      {
+        "alias": "X-columbus18gw475en5h5jvtkslp7xqed7t7ugq6rmjjvpk2",
+        "addresses": [
+          "X-columbus1qfyvkqnv8yd9rmlf6sv0gdx20dgg4ers4pjp83",
+          "X-columbus1yk9lw48um0r0rn9ydf9fhjfwwfq0qh7qtr9sz7",
+          "X-columbus1fvr4nd743ew0gcy00se24hp2ecpmk4h74sca9g",
+          "X-columbus1dgrg4j4p5e6k5jn8080n6333r934pyum99x6c4",
+          "X-columbus10xf9u6we06ljq20jtq90hj0f6q8l2psp95uzpp",
+          "X-columbus102uap4au55t22m797rr030wyrw0jlgw27m99k0",
+          "X-columbus1c35zu69gd42yu9ecrptzwf0z9g7fhfvr3yu28x",
+          "X-columbus1maff3tql60ndkwn9mvz06ssywvag4uf4d73csa",
+          "X-columbus1lmwsgy9zv8hyxwsek0pvsq7cpejtkvwkq54uvj"
+        ],
+        "threshold": 2,
+        "memo": "999"
       }
     ]
   },

--- a/genesis/genesis_columbus.json
+++ b/genesis/genesis_columbus.json
@@ -12,7 +12,7 @@
     "initialAdmin": "X-columbus1xkprh24vfyx8zghmvt2p60mmskwghzsn3q705m",
     "depositOffers": [
       {
-        "offerID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+        "memo": "presale3y",
         "interestRateNominator": 80000,
         "startOffset": 0,
         "endOffset": 114177600,
@@ -26,7 +26,7 @@
         }
       },
       {
-        "offerID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+        "memo": "team5y",
         "interestRateNominator": 0,
         "startOffset": 0,
         "endOffset": 161481600,
@@ -40,7 +40,7 @@
         }
       },
       {
-        "offerID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+        "memo": "presale4y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 145713600,
@@ -54,7 +54,7 @@
         }
       },
       {
-        "offerID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+        "memo": "presale5y",
         "interestRateNominator": 100000,
         "startOffset": 0,
         "endOffset": 177249600,
@@ -68,7 +68,7 @@
         }
       },
       {
-        "offerID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+        "memo": "undeposittest1y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 34128000,
@@ -82,7 +82,7 @@
         }
       },
       {
-        "offerID": "2v3jKLqt6k49uJCvrm9bXvSGxKyRGg951FCNePFAdxtrWVXaaz",
+        "memo": "flexdeposittest1",
         "interestRateNominator": 110000,
         "startOffset": 0,
         "endOffset": 65664000,
@@ -96,7 +96,7 @@
         }
       },
       {
-        "offerID": "2KcftFNc5i85MfRPXEJ9Zts3z241xpJbhmu8Mc4KhMCZm6uUrh",
+        "memo": "flexdeposittest2",
         "interestRateNominator": 210000,
         "startOffset": 0,
         "endOffset": 65664000,
@@ -142,7 +142,7 @@
             "validatorDuration": 31104000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "2"
           },
           {
@@ -167,7 +167,7 @@
             "validatorDuration": 62208000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "3"
           },
           {
@@ -190,7 +190,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "4"
           },
           {
@@ -228,7 +228,7 @@
           {
             "amount": 100000000000000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "6"
           }
         ]
@@ -246,7 +246,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "7"
           },
           {
@@ -269,7 +269,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "8"
           },
           {
@@ -292,7 +292,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "9"
           },
           {
@@ -315,7 +315,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "10"
           },
           {
@@ -338,7 +338,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "11"
           },
           {
@@ -361,7 +361,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "12"
           },
           {
@@ -400,7 +400,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "14"
           }
         ]
@@ -418,7 +418,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "15"
           },
           {
@@ -441,7 +441,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "16"
           },
           {
@@ -464,7 +464,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "17"
           },
           {
@@ -487,7 +487,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "18"
           },
           {
@@ -510,7 +510,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "19"
           },
           {
@@ -533,7 +533,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "20"
           },
           {
@@ -556,7 +556,7 @@
             "amount": 10000000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "21"
           }
         ]
@@ -574,7 +574,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "22"
           },
           {
@@ -597,7 +597,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "23"
           },
           {
@@ -620,7 +620,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "24"
           },
           {
@@ -643,7 +643,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "25"
           },
           {
@@ -666,7 +666,7 @@
             "amount": 100000000000000,
             "depositDuration": 31536000,
             "timestampOffset": 2592000,
-            "depositOfferID": "oS6QLaeupSMRic7S44skswr6RBgAxzPn5VsXq64i8SpConM9Z",
+            "depositOfferMemo": "undeposittest1y",
             "memo": "26"
           },
           {
@@ -688,7 +688,7 @@
           {
             "amount": 2800000000000000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "27"
           }
         ]
@@ -706,7 +706,7 @@
             "amount": 10000000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "28"
           },
           {
@@ -729,7 +729,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "29"
           },
           {
@@ -752,7 +752,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "30"
           },
           {
@@ -775,7 +775,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "31"
           },
           {
@@ -798,7 +798,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "32"
           },
           {
@@ -821,7 +821,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "33"
           },
           {
@@ -844,7 +844,7 @@
             "amount": 15000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "34"
           },
           {
@@ -867,7 +867,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "35"
           },
           {
@@ -890,7 +890,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "36"
           },
           {
@@ -913,7 +913,7 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "37"
           },
           {
@@ -936,7 +936,7 @@
             "amount": 40000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "38"
           },
           {
@@ -959,7 +959,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "39"
           },
           {
@@ -982,7 +982,7 @@
             "amount": 200000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "40"
           },
           {
@@ -1005,7 +1005,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "41"
           },
           {
@@ -1028,7 +1028,7 @@
             "amount": 20000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "42"
           },
           {
@@ -1051,7 +1051,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "43"
           },
           {
@@ -1074,7 +1074,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "44"
           },
           {
@@ -1097,7 +1097,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "45"
           },
           {
@@ -1120,7 +1120,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "46"
           },
           {
@@ -1143,7 +1143,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "47"
           },
           {
@@ -1166,7 +1166,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "48"
           },
           {
@@ -1189,7 +1189,7 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "49"
           },
           {
@@ -1214,7 +1214,7 @@
             "validatorDuration": 32400000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "50"
           },
           {
@@ -1237,7 +1237,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "51"
           },
           {
@@ -1260,7 +1260,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "52"
           },
           {
@@ -1283,7 +1283,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "53"
           },
           {
@@ -1306,7 +1306,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "54"
           },
           {
@@ -1329,7 +1329,7 @@
             "amount": 600000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "55"
           },
           {
@@ -1352,7 +1352,7 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "56"
           },
           {
@@ -1375,7 +1375,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "57"
           },
           {
@@ -1398,7 +1398,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "58"
           },
           {
@@ -1421,7 +1421,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "59"
           },
           {
@@ -1444,7 +1444,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "60"
           },
           {
@@ -1467,7 +1467,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "61"
           },
           {
@@ -1490,7 +1490,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "62"
           },
           {
@@ -1513,7 +1513,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "63"
           },
           {
@@ -1536,7 +1536,7 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "64"
           },
           {
@@ -1559,7 +1559,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "65"
           },
           {
@@ -1582,7 +1582,7 @@
             "amount": 60000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "66"
           },
           {
@@ -1605,7 +1605,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "67"
           },
           {
@@ -1628,7 +1628,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "68"
           },
           {
@@ -1651,7 +1651,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "69"
           },
           {
@@ -1674,7 +1674,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "70"
           },
           {
@@ -1697,7 +1697,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "71"
           },
           {
@@ -1720,7 +1720,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "72"
           },
           {
@@ -1743,7 +1743,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "73"
           },
           {
@@ -1766,7 +1766,7 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "74"
           },
           {
@@ -1789,7 +1789,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "75"
           },
           {
@@ -1812,7 +1812,7 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "76"
           },
           {
@@ -1835,7 +1835,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "77"
           },
           {
@@ -1858,7 +1858,7 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "78"
           },
           {
@@ -1881,7 +1881,7 @@
             "amount": 25000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "79"
           },
           {
@@ -1904,7 +1904,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "80"
           },
           {
@@ -1927,7 +1927,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "81"
           },
           {
@@ -1950,7 +1950,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "82"
           },
           {
@@ -1973,7 +1973,7 @@
             "amount": 500000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "83"
           },
           {
@@ -1996,7 +1996,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "84"
           },
           {
@@ -2019,7 +2019,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "85"
           },
           {
@@ -2042,7 +2042,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "86"
           },
           {
@@ -2065,7 +2065,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "87"
           },
           {
@@ -2088,7 +2088,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "88"
           },
           {
@@ -2111,7 +2111,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "89"
           },
           {
@@ -2134,7 +2134,7 @@
             "amount": 15000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "90"
           },
           {
@@ -2157,7 +2157,7 @@
             "amount": 1000000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "91"
           },
           {
@@ -2180,7 +2180,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "92"
           },
           {
@@ -2203,7 +2203,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "93"
           },
           {
@@ -2226,7 +2226,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "94"
           },
           {
@@ -2249,7 +2249,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "95"
           },
           {
@@ -2272,7 +2272,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "96"
           },
           {
@@ -2295,7 +2295,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "97"
           },
           {
@@ -2318,7 +2318,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "98"
           },
           {
@@ -2341,7 +2341,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "99"
           },
           {
@@ -2364,7 +2364,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "100"
           },
           {
@@ -2387,7 +2387,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "101"
           },
           {
@@ -2410,7 +2410,7 @@
             "amount": 25000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "102"
           },
           {
@@ -2433,7 +2433,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "103"
           },
           {
@@ -2456,7 +2456,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "104"
           },
           {
@@ -2479,7 +2479,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "105"
           },
           {
@@ -2502,7 +2502,7 @@
             "amount": 1000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "106"
           },
           {
@@ -2525,7 +2525,7 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "107"
           },
           {
@@ -2548,7 +2548,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "108"
           },
           {
@@ -2571,7 +2571,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "109"
           },
           {
@@ -2594,7 +2594,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "110"
           },
           {
@@ -2617,7 +2617,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "111"
           },
           {
@@ -2640,7 +2640,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "112"
           },
           {
@@ -2663,7 +2663,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "113"
           },
           {
@@ -2686,7 +2686,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "114"
           },
           {
@@ -2709,7 +2709,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "115"
           },
           {
@@ -2732,7 +2732,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "116"
           },
           {
@@ -2755,7 +2755,7 @@
             "amount": 400000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "117"
           },
           {
@@ -2778,7 +2778,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "118"
           },
           {
@@ -2801,7 +2801,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "119"
           },
           {
@@ -2824,7 +2824,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "120"
           },
           {
@@ -2847,7 +2847,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "121"
           },
           {
@@ -2870,7 +2870,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "122"
           },
           {
@@ -2893,7 +2893,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "123"
           },
           {
@@ -2916,7 +2916,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "124"
           },
           {
@@ -2939,7 +2939,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "125"
           },
           {
@@ -2962,7 +2962,7 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "126"
           },
           {
@@ -2984,7 +2984,7 @@
           {
             "amount": 300000000000000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "127"
           }
         ]
@@ -3002,7 +3002,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "128"
           },
           {
@@ -3025,7 +3025,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "129"
           },
           {
@@ -3048,7 +3048,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "130"
           },
           {
@@ -3071,7 +3071,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "131"
           },
           {
@@ -3094,7 +3094,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "132"
           },
           {
@@ -3117,7 +3117,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "133"
           },
           {
@@ -3140,7 +3140,7 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "134"
           },
           {
@@ -3163,7 +3163,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "135"
           },
           {
@@ -3186,7 +3186,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "136"
           },
           {
@@ -3209,7 +3209,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "137"
           },
           {
@@ -3232,7 +3232,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "138"
           },
           {
@@ -3255,7 +3255,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "139"
           },
           {
@@ -3278,7 +3278,7 @@
             "amount": 250000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "140"
           },
           {
@@ -3301,7 +3301,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "141"
           },
           {
@@ -3324,7 +3324,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "142"
           },
           {
@@ -3347,7 +3347,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "143"
           },
           {
@@ -3370,7 +3370,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "144"
           },
           {
@@ -3393,7 +3393,7 @@
             "amount": 3000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "145"
           },
           {
@@ -3416,7 +3416,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "146"
           },
           {
@@ -3439,7 +3439,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "147"
           },
           {
@@ -3462,7 +3462,7 @@
             "amount": 30000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "148"
           },
           {
@@ -3485,7 +3485,7 @@
             "amount": 150000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "149"
           },
           {
@@ -3508,7 +3508,7 @@
             "amount": 25000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "150"
           },
           {
@@ -3531,7 +3531,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "151"
           },
           {
@@ -3554,7 +3554,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "152"
           },
           {
@@ -3577,7 +3577,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "153"
           },
           {
@@ -3600,7 +3600,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "154"
           },
           {
@@ -3623,7 +3623,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "155"
           },
           {
@@ -3646,7 +3646,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "156"
           },
           {
@@ -3669,7 +3669,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "157"
           },
           {
@@ -3692,7 +3692,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "158"
           },
           {
@@ -3715,7 +3715,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "159"
           },
           {
@@ -3738,7 +3738,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "160"
           },
           {
@@ -3761,7 +3761,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "161"
           },
           {
@@ -3784,7 +3784,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "162"
           },
           {
@@ -3807,7 +3807,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "163"
           },
           {
@@ -3830,7 +3830,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "164"
           },
           {
@@ -3853,7 +3853,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "165"
           },
           {
@@ -3876,7 +3876,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "166"
           },
           {
@@ -3899,7 +3899,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "167"
           },
           {
@@ -3922,7 +3922,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "168"
           },
           {
@@ -3945,7 +3945,7 @@
             "amount": 400000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "169"
           },
           {
@@ -3968,7 +3968,7 @@
             "amount": 250000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "170"
           },
           {
@@ -3991,7 +3991,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "171"
           },
           {
@@ -4014,7 +4014,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "172"
           },
           {
@@ -4037,7 +4037,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "173"
           },
           {
@@ -4060,7 +4060,7 @@
             "amount": 50000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "174"
           },
           {
@@ -4083,7 +4083,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "175"
           },
           {
@@ -4106,7 +4106,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "176"
           },
           {
@@ -4129,7 +4129,7 @@
             "amount": 75000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "177"
           },
           {
@@ -4152,7 +4152,7 @@
             "amount": 20000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "178"
           },
           {
@@ -4175,7 +4175,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "179"
           },
           {
@@ -4198,7 +4198,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "180"
           },
           {
@@ -4221,7 +4221,7 @@
             "amount": 100000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "181"
           },
           {
@@ -4244,7 +4244,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "182"
           },
           {
@@ -4267,7 +4267,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "183"
           },
           {
@@ -4290,7 +4290,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "184"
           },
           {
@@ -4313,7 +4313,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "185"
           },
           {
@@ -4336,7 +4336,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "186"
           },
           {
@@ -4359,7 +4359,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "187"
           },
           {
@@ -4382,7 +4382,7 @@
             "amount": 25000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "188"
           },
           {
@@ -4405,7 +4405,7 @@
             "amount": 120000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "189"
           },
           {
@@ -4428,7 +4428,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "190"
           },
           {
@@ -4451,7 +4451,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "191"
           },
           {
@@ -4474,7 +4474,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "192"
           },
           {
@@ -4497,7 +4497,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "193"
           },
           {
@@ -4520,7 +4520,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "194"
           },
           {
@@ -4543,7 +4543,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "195"
           },
           {
@@ -4566,7 +4566,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "196"
           },
           {
@@ -4589,7 +4589,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "197"
           },
           {
@@ -4612,7 +4612,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "198"
           },
           {
@@ -4635,7 +4635,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "199"
           },
           {
@@ -4658,7 +4658,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "200"
           },
           {
@@ -4681,7 +4681,7 @@
             "amount": 150000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "201"
           },
           {
@@ -4704,7 +4704,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "202"
           },
           {
@@ -4727,7 +4727,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "203"
           },
           {
@@ -4750,7 +4750,7 @@
             "amount": 50000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "204"
           },
           {
@@ -4773,7 +4773,7 @@
             "amount": 50000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "205"
           },
           {
@@ -4796,7 +4796,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "206"
           },
           {
@@ -4819,7 +4819,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "207"
           },
           {
@@ -4842,7 +4842,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "208"
           },
           {
@@ -4865,7 +4865,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "209"
           },
           {
@@ -4888,7 +4888,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "210"
           },
           {
@@ -4911,7 +4911,7 @@
             "amount": 20000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "211"
           },
           {
@@ -4934,7 +4934,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "212"
           },
           {
@@ -4957,7 +4957,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "213"
           },
           {
@@ -4980,7 +4980,7 @@
             "amount": 10000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "214"
           },
           {
@@ -5003,7 +5003,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "215"
           },
           {
@@ -5026,7 +5026,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "216"
           },
           {
@@ -5049,7 +5049,7 @@
             "amount": 70000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "217"
           },
           {
@@ -5072,7 +5072,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "218"
           },
           {
@@ -5095,7 +5095,7 @@
             "amount": 20000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "219"
           },
           {
@@ -5118,7 +5118,7 @@
             "amount": 10000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "220"
           },
           {
@@ -5141,7 +5141,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "221"
           },
           {
@@ -5164,7 +5164,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "222"
           },
           {
@@ -5187,7 +5187,7 @@
             "amount": 200000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "223"
           },
           {
@@ -5210,7 +5210,7 @@
             "amount": 15000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "224"
           },
           {
@@ -5232,7 +5232,7 @@
           {
             "amount": 4500000000000000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "225"
           }
         ]
@@ -5250,7 +5250,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "226"
           },
           {
@@ -5273,7 +5273,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "227"
           },
           {
@@ -5296,7 +5296,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "228"
           },
           {
@@ -5321,7 +5321,7 @@
             "validatorDuration": 30672000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "229"
           },
           {
@@ -5344,7 +5344,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "230"
           },
           {
@@ -5367,7 +5367,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "231"
           },
           {
@@ -5390,7 +5390,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "232"
           },
           {
@@ -5413,7 +5413,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "233"
           },
           {
@@ -5436,7 +5436,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "234"
           },
           {
@@ -5459,7 +5459,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "235"
           },
           {
@@ -5482,7 +5482,7 @@
             "amount": 150000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "236"
           },
           {
@@ -5507,7 +5507,7 @@
             "validatorDuration": 31536000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "237"
           },
           {
@@ -5530,7 +5530,7 @@
             "amount": 500000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "238"
           },
           {
@@ -5553,7 +5553,7 @@
             "amount": 300000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "239"
           },
           {
@@ -5576,7 +5576,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "240"
           },
           {
@@ -5599,7 +5599,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "241"
           },
           {
@@ -5622,7 +5622,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "242"
           },
           {
@@ -5645,7 +5645,7 @@
             "amount": 400000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "243"
           },
           {
@@ -5668,7 +5668,7 @@
             "amount": 10000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "244"
           },
           {
@@ -5691,7 +5691,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "245"
           },
           {
@@ -5714,7 +5714,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "246"
           },
           {
@@ -5737,7 +5737,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "247"
           },
           {
@@ -5760,7 +5760,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "248"
           },
           {
@@ -5785,7 +5785,7 @@
             "validatorDuration": 30240000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "249"
           },
           {
@@ -5808,7 +5808,7 @@
             "amount": 200000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "250"
           },
           {
@@ -5831,7 +5831,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "251"
           },
           {
@@ -5854,7 +5854,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "252"
           },
           {
@@ -5877,7 +5877,7 @@
             "amount": 300000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "253"
           },
           {
@@ -5900,7 +5900,7 @@
             "amount": 250000000000000,
             "depositDuration": 141912000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2fCQPn66pFuNDKhn3yo6KZka2xrVHnreCT6u7GHReDnZYf9ucX",
+            "depositOfferMemo": "presale4y",
             "memo": "254"
           },
           {
@@ -5923,7 +5923,7 @@
             "amount": 100000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "255"
           },
           {
@@ -5946,7 +5946,7 @@
             "amount": 100000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "256"
           },
           {
@@ -5969,7 +5969,7 @@
             "amount": 1000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "257"
           },
           {
@@ -5992,7 +5992,7 @@
             "amount": 500000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2UMVoKEBYeVP21k5co3gvEDyCpkgE6kmEb5kTy8QxVpnCaczGM",
+            "depositOfferMemo": "presale3y",
             "memo": "258"
           },
           {
@@ -6015,7 +6015,7 @@
             "amount": 1500000000000000,
             "depositDuration": 173448000,
             "timestampOffset": 2592000,
-            "depositOfferID": "2hSSCLqw1uPZPYdW3j3Zwo68QBepguYrMjjnq79FzTkWXT2LnD",
+            "depositOfferMemo": "presale5y",
             "memo": "259"
           },
           {
@@ -6039,7 +6039,7 @@
             "nodeID": "NodeID-5APqagKQK2d9cMrtgR2h3bsC4GrU3UkNr",
             "validatorDuration": 31968000,
             "depositDuration": 157680000,
-            "depositOfferID": "2jfAVePJSFaouYKFBaCYPK7npaE2BTyySLRnC8MZmAkyQM1YQu",
+            "depositOfferMemo": "team5y",
             "memo": "260"
           }
         ]

--- a/genesis/genesis_kopernikus.json
+++ b/genesis/genesis_kopernikus.json
@@ -6,7 +6,7 @@
     "initialAdmin": "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3",
     "depositOffers": [
       {
-        "offerID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi",
+        "memo": "presale3y",
         "interestRateNominator": 80000,
         "startOffset": 0,
         "endOffset": 112795200,
@@ -20,7 +20,7 @@
         }
       },
       {
-        "offerID": "2AySgbKZp8PP95KCsttY68uKJyFbsATHnE73jk1P9fSppmqV45",
+        "memo": "team5y",
         "interestRateNominator": 0,
         "startOffset": 0,
         "endOffset": 160099200,
@@ -34,7 +34,7 @@
         }
       },
       {
-        "offerID": "2uGR8giEWip1mGWQzF1DXNVpUXY8M1futjhVErqV7uJntHmWrh",
+        "memo": "presale4y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 144331200,
@@ -48,7 +48,7 @@
         }
       },
       {
-        "offerID": "2ad2QNdpDQWGUMx7WWRwAG1bxFwx5amEZzfoqGrGF1D7N3HNLp",
+        "memo": "presale5y",
         "interestRateNominator": 100000,
         "startOffset": 0,
         "endOffset": 175867200,
@@ -62,7 +62,7 @@
         }
       },
       {
-        "offerID": "k5VaqN4kFtcKQWfjyJpk4YA8VBwW7TyeRicDGsdzRNRNSG1R1",
+        "memo": "undeposittest1y",
         "interestRateNominator": 90000,
         "startOffset": 0,
         "endOffset": 32745600,
@@ -76,7 +76,7 @@
         }
       },
       {
-        "offerID": "2vGw1ZaUWWGxhAm69Dt13zw5sUvmtCbzVTvvzPp34Ch5qEznBg",
+        "memo": "flexdeposittest1",
         "interestRateNominator": 110000,
         "startOffset": 0,
         "endOffset": 64281600,
@@ -90,7 +90,7 @@
         }
       },
       {
-        "offerID": "24zEuyv4zBvF2pGPbzwVYhCxPQUfuqD4pWDRfJrJapXBhFfxDh",
+        "memo": "flexdeposittest2",
         "interestRateNominator": 210000,
         "startOffset": 0,
         "endOffset": 64281600,
@@ -120,14 +120,14 @@
             "validatorDuration": 31536000,
             "depositDuration": 110376000,
             "timestampOffset": 0,
-            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi",
+            "depositOfferMemo": "presale3y",
             "memo": "KOPERNIKUS"
           },
           {
             "amount": 10000000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 0,
-            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi"
+            "depositOfferMemo": "presale3y"
           },
           {
             "amount": 4000000000000
@@ -150,7 +150,7 @@
             "amount": 600000000000000,
             "depositDuration": 110376000,
             "timestampOffset": 0,
-            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi"
+            "depositOfferMemo": "presale3y"
           }
         ]
       }

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,15 +370,15 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2WTr7jgbMWB4os5swbFNLeoeKCKWie3YkTSPxoYDXmbkR1UG3J",
+			expectedID: "2T2WUBTb9JZU1STkhw9hj3e3yuE3wUdWK2jYAprYoXJdtvjCcM",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "fv6SDDQvnRMJYjnYKhcXoe345FZZr5hc9h8tnwAdQQvVNMZae",
+			expectedID: "ryHKHZ5Cc2e8GbzdjubtMfeWi78yP5rta7xSjHYzCoZSsdXmy",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "2jKs6s57q8eo3kFK1ky7PqvG7atzMD4hJDSZ1BFh8gGmdS558H",
+			expectedID: "29jJZ5u2Vsfsb3gHEPiwuy2923uLfTdqHtZD1gJ74x2x7NdU2j",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,15 +370,15 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2T2WUBTb9JZU1STkhw9hj3e3yuE3wUdWK2jYAprYoXJdtvjCcM",
+			expectedID: "2Xp77XhWks5ByoqyEtGqhu7P7b7ayBgndtBi65N4Zjp9D5VZUb",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "ryHKHZ5Cc2e8GbzdjubtMfeWi78yP5rta7xSjHYzCoZSsdXmy",
+			expectedID: "cjJ1mMfD2LMVqyBCj9JsRTyzGKDpDw1uZwQANEAt5JknckhjJ",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "29jJZ5u2Vsfsb3gHEPiwuy2923uLfTdqHtZD1gJ74x2x7NdU2j",
+			expectedID: "2Aq1D2Jo8NDBo9qFft7UEY837yqunjT4gPz7r4dnRcY62kELod",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/deposit/camino_deposit.go
+++ b/vms/platformvm/deposit/camino_deposit.go
@@ -1,9 +1,11 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deposit
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -25,16 +27,16 @@ var bigInterestRateDenominator = (&big.Int{}).SetInt64(interestRateDenominator)
 type Offer struct {
 	ID ids.ID
 
-	InterestRateNominator   uint64 `serialize:"true"`
-	Start                   uint64 `serialize:"true"`
-	End                     uint64 `serialize:"true"`
-	MinAmount               uint64 `serialize:"true"`
-	MinDuration             uint32 `serialize:"true"`
-	MaxDuration             uint32 `serialize:"true"`
-	UnlockPeriodDuration    uint32 `serialize:"true"`
-	NoRewardsPeriodDuration uint32 `serialize:"true"`
-	Memo                    string `serialize:"true"`
-	Flags                   uint64 `serialize:"true"`
+	InterestRateNominator   uint64 `serialize:"true" json:"InterestRateNominator"`
+	Start                   uint64 `serialize:"true" json:"Start"`
+	End                     uint64 `serialize:"true" json:"End"`
+	MinAmount               uint64 `serialize:"true" json:"MinAmount"`
+	MinDuration             uint32 `serialize:"true" json:"MinDuration"`
+	MaxDuration             uint32 `serialize:"true" json:"MaxDuration"`
+	UnlockPeriodDuration    uint32 `serialize:"true" json:"UnlockPeriodDuration"`
+	NoRewardsPeriodDuration uint32 `serialize:"true" json:"NoRewardsPeriodDuration"`
+	Memo                    []byte `serialize:"true" json:"Memo"`
+	Flags                   uint64 `serialize:"true" json:"Flags"`
 }
 
 // Sets offer id from its bytes hash
@@ -59,6 +61,42 @@ func (o *Offer) EndTime() time.Time {
 
 func (o *Offer) InterestRateFloat64() float64 {
 	return float64(o.InterestRateNominator) / float64(interestRateDenominator)
+}
+
+func (o *Offer) Verify() error {
+	if o.Start >= o.End {
+		return fmt.Errorf(
+			"deposit offer starttime (%v) is not before its endtime (%v)",
+			o.Start,
+			o.End,
+		)
+	}
+
+	if o.MinDuration > o.MaxDuration {
+		return errors.New("deposit minimum duration is greater than maximum duration")
+	}
+
+	if o.MinDuration == 0 {
+		return errors.New("deposit offer has zero minimum duration")
+	}
+
+	if o.MinDuration < o.NoRewardsPeriodDuration {
+		return fmt.Errorf(
+			"deposit offer minimum duration (%v) is less than no-rewards period duration (%v)",
+			o.MinDuration,
+			o.NoRewardsPeriodDuration,
+		)
+	}
+
+	if o.MinDuration < o.UnlockPeriodDuration {
+		return fmt.Errorf(
+			"deposit offer minimum duration (%v) is less than unlock period duration (%v)",
+			o.MinDuration,
+			o.UnlockPeriodDuration,
+		)
+	}
+
+	return nil
 }
 
 type Deposit struct {

--- a/vms/platformvm/deposit/camino_deposit.go
+++ b/vms/platformvm/deposit/camino_deposit.go
@@ -33,6 +33,7 @@ type Offer struct {
 	MaxDuration             uint32 `serialize:"true"`
 	UnlockPeriodDuration    uint32 `serialize:"true"`
 	NoRewardsPeriodDuration uint32 `serialize:"true"`
+	Memo                    string `serialize:"true"`
 	Flags                   uint64 `serialize:"true"`
 }
 

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis
@@ -16,7 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
-	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
@@ -26,13 +26,18 @@ type Camino struct {
 	LockModeBondDeposit      bool                     `serialize:"true"`
 	InitialAdmin             ids.ShortID              `serialize:"true"`
 	AddressStates            []AddressState           `serialize:"true"`
-	DepositOffers            []DepositOffer           `serialize:"true"`
+	DepositOffers            []*deposit.Offer         `serialize:"true"`
 	Blocks                   []*Block                 `serialize:"true"` // arranged in a block order
 	ConsortiumMembersNodeIDs []ConsortiumMemberNodeID `serialize:"true"`
 	InitialMultisigAddresses []MultisigAlias          `serialize:"true"`
 }
 
 func (c *Camino) Init() error {
+	for _, offer := range c.DepositOffers {
+		if err := offer.SetID(); err != nil {
+			return err
+		}
+	}
 	for _, block := range c.Blocks {
 		if err := block.Init(); err != nil {
 			return err
@@ -49,68 +54,6 @@ type ConsortiumMemberNodeID struct {
 type AddressState struct {
 	Address ids.ShortID `serialize:"true"`
 	State   uint64      `serialize:"true"`
-}
-
-type DepositOffer struct {
-	InterestRateNominator   uint64 `serialize:"true" json:"interestRateNominator"`
-	Start                   uint64 `serialize:"true" json:"start"`
-	End                     uint64 `serialize:"true" json:"end"`
-	MinAmount               uint64 `serialize:"true" json:"minAmount"`
-	MinDuration             uint32 `serialize:"true" json:"minDuration"`
-	MaxDuration             uint32 `serialize:"true" json:"maxDuration"`
-	UnlockPeriodDuration    uint32 `serialize:"true" json:"unlockPeriodDuration"`
-	NoRewardsPeriodDuration uint32 `serialize:"true" json:"noRewardsPeriodDuration"`
-	Memo                    string `serialize:"true" json:"memo"`
-	Flags                   uint64 `serialize:"true" json:"flags"`
-}
-
-// Gets offer id from its bytes hash
-func (offer DepositOffer) ID() (ids.ID, error) {
-	bytes, err := blocks.GenesisCodec.Marshal(blocks.Version, offer)
-	if err != nil {
-		return ids.Empty, err
-	}
-	return hashing.ComputeHash256Array(bytes), nil
-}
-
-func (offer DepositOffer) Verify() error {
-	if offer.Start >= offer.End {
-		return fmt.Errorf(
-			"deposit offer starttime (%v) is not before its endtime (%v)",
-			offer.Start,
-			offer.End,
-		)
-	}
-
-	if offer.MinDuration > offer.MaxDuration {
-		return errors.New("deposit minimum duration is greater than maximum duration")
-	}
-
-	if offer.MinDuration == 0 {
-		return errors.New("deposit offer has zero minimum duration")
-	}
-
-	if offer.MinDuration < offer.NoRewardsPeriodDuration {
-		return fmt.Errorf(
-			"deposit offer minimum duration (%v) is less than no-rewards period duration (%v)",
-			offer.MinDuration,
-			offer.NoRewardsPeriodDuration,
-		)
-	}
-
-	if offer.MinDuration < offer.UnlockPeriodDuration {
-		return fmt.Errorf(
-			"deposit offer minimum duration (%v) is less than unlock period duration (%v)",
-			offer.MinDuration,
-			offer.UnlockPeriodDuration,
-		)
-	}
-
-	if offer.Memo == "" {
-		return errors.New("deposit offer has no memo")
-	}
-
-	return nil
 }
 
 type MultisigAlias struct {

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -52,7 +52,6 @@ type AddressState struct {
 }
 
 type DepositOffer struct {
-	OfferID                 ids.ID `serialize:"false"`
 	InterestRateNominator   uint64 `serialize:"true" json:"interestRateNominator"`
 	Start                   uint64 `serialize:"true" json:"start"`
 	End                     uint64 `serialize:"true" json:"end"`
@@ -61,6 +60,7 @@ type DepositOffer struct {
 	MaxDuration             uint32 `serialize:"true" json:"maxDuration"`
 	UnlockPeriodDuration    uint32 `serialize:"true" json:"unlockPeriodDuration"`
 	NoRewardsPeriodDuration uint32 `serialize:"true" json:"noRewardsPeriodDuration"`
+	Memo                    string `serialize:"true" json:"memo"`
 	Flags                   uint64 `serialize:"true" json:"flags"`
 }
 
@@ -106,12 +106,8 @@ func (offer DepositOffer) Verify() error {
 		)
 	}
 
-	calcID, err := offer.ID()
-	if err != nil {
-		return err
-	}
-	if offer.OfferID != calcID {
-		return fmt.Errorf("deposit offer ID (%s) mismatched with the calculated one (%s)", offer.OfferID, calcID)
+	if offer.Memo == "" {
+		return errors.New("deposit offer has no memo")
 	}
 
 	return nil

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -301,14 +301,8 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 	// adding deposit offers
 
 	depositOffers := make(map[ids.ID]*deposit.Offer, len(g.Camino.DepositOffers))
-	for _, genesisOffer := range g.Camino.DepositOffers {
-		genesisOffer := genesisOffer
-		offer, err := ParseDepositOfferFromGenesisOffer(&genesisOffer)
-		if err != nil {
-			return err
-		}
+	for _, offer := range g.Camino.DepositOffers {
 		depositOffers[offer.ID] = offer
-
 		cs.AddDepositOffer(offer)
 	}
 

--- a/vms/platformvm/state/camino_deposit_offer.go
+++ b/vms/platformvm/state/camino_deposit_offer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state
@@ -10,7 +10,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
-	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 )
 
 func (cs *caminoState) AddDepositOffer(offer *deposit.Offer) {
@@ -89,23 +88,4 @@ func (cs *caminoState) writeDepositOffers() error {
 		}
 	}
 	return nil
-}
-
-func ParseDepositOfferFromGenesisOffer(genesisOffer *genesis.DepositOffer) (*deposit.Offer, error) {
-	offer := &deposit.Offer{
-		InterestRateNominator:   genesisOffer.InterestRateNominator,
-		Start:                   genesisOffer.Start,
-		End:                     genesisOffer.End,
-		MinAmount:               genesisOffer.MinAmount,
-		MinDuration:             genesisOffer.MinDuration,
-		MaxDuration:             genesisOffer.MaxDuration,
-		UnlockPeriodDuration:    genesisOffer.UnlockPeriodDuration,
-		NoRewardsPeriodDuration: genesisOffer.NoRewardsPeriodDuration,
-		Memo:                    genesisOffer.Memo,
-		Flags:                   genesisOffer.Flags,
-	}
-	if err := offer.SetID(); err != nil {
-		return nil, err
-	}
-	return offer, nil
 }

--- a/vms/platformvm/state/camino_deposit_offer.go
+++ b/vms/platformvm/state/camino_deposit_offer.go
@@ -101,6 +101,7 @@ func ParseDepositOfferFromGenesisOffer(genesisOffer *genesis.DepositOffer) (*dep
 		MaxDuration:             genesisOffer.MaxDuration,
 		UnlockPeriodDuration:    genesisOffer.UnlockPeriodDuration,
 		NoRewardsPeriodDuration: genesisOffer.NoRewardsPeriodDuration,
+		Memo:                    genesisOffer.Memo,
 		Flags:                   genesisOffer.Flags,
 	}
 	if err := offer.SetID(); err != nil {

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state
@@ -6,17 +6,18 @@ package state
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	root_genesis "github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
-	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	pvm_genesis "github.com/ava-labs/avalanchego/vms/platformvm/genesis"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/platformvm/validator"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
@@ -32,114 +33,134 @@ const (
 )
 
 func TestSupplyInState(t *testing.T) {
-	require := require.New(t)
-
 	tests := map[string]struct {
-		s             *state
-		genesisConfig root_genesis.Config
+		lockModeDepositBond bool
+		withDeposit         bool
+		withCaminoValidator bool
 	}{
-		"LockModeDepositBond: true with NodeID and Deposit": {
-			s:             newEmptyState(t),
-			genesisConfig: defaultConfig(true, initialNodeID, true),
+		"LockModeDepositBond: true with Validator and Deposit": {
+			lockModeDepositBond: true, withDeposit: true, withCaminoValidator: true,
 		},
-		"LockModeDepositBond: true with NodeID": {
-			s:             newEmptyState(t),
-			genesisConfig: defaultConfig(true, initialNodeID, false),
+		"LockModeDepositBond: true with Validator": {
+			lockModeDepositBond: true, withDeposit: false, withCaminoValidator: true,
+		},
+		"LockModeDepositBond: true with Deposit": {
+			lockModeDepositBond: true, withDeposit: true, withCaminoValidator: false,
 		},
 		"LockModeDepositBond: true": {
-			s:             newEmptyState(t),
-			genesisConfig: defaultConfig(true, ids.EmptyNodeID, false),
+			lockModeDepositBond: true, withDeposit: false, withCaminoValidator: false,
 		},
-		"LockModeDepositBond: false with NodeID and Deposit": {
-			s:             newEmptyState(t),
-			genesisConfig: defaultConfig(false, initialNodeID, true),
+		"LockModeDepositBond: false with Validator and Deposit": {
+			lockModeDepositBond: false, withDeposit: true, withCaminoValidator: true,
 		},
-		"LockModeDepositBond: false with NodeID": {
-			s:             newEmptyState(t),
-			genesisConfig: defaultConfig(false, initialNodeID, false),
+		"LockModeDepositBond: false with Validator": {
+			lockModeDepositBond: false, withDeposit: false, withCaminoValidator: true,
+		},
+		"LockModeDepositBond: false with Deposit": {
+			lockModeDepositBond: false, withDeposit: true, withCaminoValidator: false,
 		},
 		"LockModeDepositBond: false": {
-			s:             newEmptyState(t),
-			genesisConfig: defaultConfig(false, ids.EmptyNodeID, false),
+			lockModeDepositBond: false, withDeposit: false, withCaminoValidator: false,
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			genBytes, _, err := root_genesis.FromConfig(&tt.genesisConfig)
+			require := require.New(t)
+
+			genesisConfig := testGenesisConfig(
+				tt.lockModeDepositBond,
+				tt.withCaminoValidator,
+				tt.withDeposit,
+			)
+
+			genBytes, _, err := root_genesis.FromConfig(genesisConfig)
 			require.NoError(err)
 
-			err = tt.s.sync(genBytes)
-			require.NoError(err)
+			state := newEmptyState(t)
+			require.NoError(state.sync(genBytes))
 
-			expectedSupply := getExpectedSupply(tt.genesisConfig, tt.s, genBytes, require)
+			expectedSupply := getExpectedSupply(t, genesisConfig, tt.lockModeDepositBond, state.rewards)
 
-			require.EqualValues(expectedSupply, tt.s.currentSupply)
+			require.EqualValues(expectedSupply, state.currentSupply)
 		})
 	}
 }
 
-func getExpectedSupply(config root_genesis.Config, s *state, genBytes []byte, require *require.Assertions) uint64 {
-	var totalXAmount, totalPAmount, totalIAmount uint64
+func getExpectedSupply(
+	t *testing.T,
+	config *root_genesis.Config,
+	lockModeDepositBond bool,
+	avaxRewardCalc reward.Calculator,
+) uint64 {
+	require := require.New(t)
 
-	for _, alloc := range config.Allocations {
-		totalIAmount += alloc.InitialAmount
+	initialSupply := uint64(0)
+	rewards := uint64(0)
 
-		for _, unlockSchedule := range alloc.UnlockSchedule {
-			totalIAmount += unlockSchedule.Amount
-		}
-	}
-	for _, alloc := range config.Camino.Allocations {
-		totalXAmount += alloc.XAmount
-		for _, palloc := range alloc.PlatformAllocations {
-			totalPAmount += palloc.Amount
-		}
-	}
-
-	allocationsSum := totalXAmount + totalPAmount + totalIAmount
-
-	offers := make(map[string]genesis.DepositOffer, len(config.Camino.DepositOffers))
-	for _, offer := range config.Camino.DepositOffers {
-		offers[offer.Memo] = offer
-	}
-
-	totalRewardAmount := uint64(0)
-	for _, alloc := range config.Camino.Allocations {
-		for _, palloc := range alloc.PlatformAllocations {
-			if palloc.DepositOfferMemo != "" {
-				offer, ok := offers[palloc.DepositOfferMemo]
-				require.True(ok)
-				offerID, err := offer.ID()
-				require.NoError(err)
-				depositOffer, err := s.GetDepositOffer(offerID)
-				require.NoError(err)
-
-				dep := deposit.Deposit{
-					Amount:   palloc.Amount,
-					Duration: uint32(palloc.DepositDuration),
-				}
-
-				totalRewardAmount += dep.TotalReward(depositOffer)
+	if lockModeDepositBond {
+		for _, alloc := range config.Camino.Allocations {
+			initialSupply += alloc.XAmount
+			for _, palloc := range alloc.PlatformAllocations {
+				initialSupply += palloc.Amount
 			}
 		}
-	}
+		offers := make(map[string]root_genesis.DepositOffer, len(config.Camino.DepositOffers))
+		for _, offer := range config.Camino.DepositOffers {
+			offers[offer.Memo] = offer
+		}
 
-	if totalRewardAmount == 0 {
-		genesisState, _ := genesis.ParseState(genBytes)
+		for _, alloc := range config.Camino.Allocations {
+			for _, palloc := range alloc.PlatformAllocations {
+				if palloc.DepositOfferMemo != "" {
+					configOffer, ok := offers[palloc.DepositOfferMemo]
+					require.True(ok)
 
-		for _, vdrTx := range genesisState.Validators {
-			tx, _ := vdrTx.Unsigned.(txs.ValidatorTx)
-			stakeAmount := tx.Weight()
-			stakeDuration := tx.EndTime().Sub(tx.StartTime())
-			totalRewardAmount += s.rewards.Calculate(
-				stakeDuration,
-				stakeAmount,
-				s.currentSupply,
+					offer, err := root_genesis.ParseDepositOfferFromConfig(configOffer)
+					require.NoError(err)
+
+					dep := deposit.Deposit{
+						Amount:   palloc.Amount,
+						Duration: uint32(palloc.DepositDuration),
+					}
+
+					rewards += dep.TotalReward(offer)
+				}
+			}
+		}
+	} else {
+		for _, alloc := range config.Allocations {
+			initialSupply += alloc.InitialAmount
+			for _, unlockSchedule := range alloc.UnlockSchedule {
+				initialSupply += unlockSchedule.Amount
+			}
+		}
+
+		initialStakedFunds := uint64(0)
+		for _, allocAVAXAddr := range config.InitialStakedFunds {
+			for _, alloc := range config.Allocations {
+				if alloc.AVAXAddr != allocAVAXAddr {
+					continue
+				}
+				for _, palloc := range alloc.UnlockSchedule {
+					initialStakedFunds += palloc.Amount
+				}
+			}
+		}
+		stake := initialStakedFunds / uint64(len(config.InitialStakers))
+
+		offset := config.InitialStakeDurationOffset
+		for i := 0; i < len(config.InitialStakers); i++ {
+			reward := avaxRewardCalc.Calculate(
+				time.Duration(config.InitialStakeDuration-offset*uint64(i))*time.Second,
+				stake,
+				initialSupply,
 			)
+			rewards += reward
 		}
 	}
 
-	return allocationsSum + totalRewardAmount
+	return initialSupply + rewards
 }
 
 func TestSyncGenesis(t *testing.T) {
@@ -147,6 +168,7 @@ func TestSyncGenesis(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	s, _ := newInitializedState(require)
+	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
 
 	var (
 		id           = ids.GenerateTestID()
@@ -154,8 +176,6 @@ func TestSyncGenesis(t *testing.T) {
 		shortID2     = ids.GenerateTestShortID()
 		initialAdmin = ids.GenerateTestShortID()
 	)
-
-	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
 
 	outputOwners := secp256k1fx.OutputOwners{
 		Addrs: []ids.ShortID{shortID},
@@ -175,6 +195,7 @@ func TestSyncGenesis(t *testing.T) {
 			UnlockPeriodDuration:    7,
 			NoRewardsPeriodDuration: 8,
 			Flags:                   9,
+			Memo:                    []byte("some memo"),
 		}, {
 			InterestRateNominator:   2,
 			Start:                   3,
@@ -187,47 +208,42 @@ func TestSyncGenesis(t *testing.T) {
 			Flags:                   10,
 		},
 	}
-	require.NoError(depositOffers[0].SetID())
-	require.NoError(depositOffers[1].SetID())
-
-	depositTxs := []*txs.Tx{
-		{
-			Unsigned: &txs.DepositTx{
-				BaseTx:          *generateBaseTx(id, 1, outputOwners, ids.Empty, ids.Empty),
-				DepositOfferID:  depositOffers[0].ID,
-				DepositDuration: 1,
-				RewardsOwner:    &outputOwners,
-			},
-			Creds: nil,
-		},
-		{
-			Unsigned: &txs.DepositTx{
-				BaseTx:          *generateBaseTx(id, 2, outputOwners2, ids.Empty, ids.Empty),
-				DepositOfferID:  depositOffers[1].ID,
-				DepositDuration: 2,
-				RewardsOwner:    &outputOwners2,
-			},
-			Creds: nil,
-		},
+	for _, offer := range depositOffers {
+		require.NoError(offer.SetID())
 	}
-	depositTxs[0].Initialize(utils.RandomBytes(16), utils.RandomBytes(16))
-	depositTxs[1].Initialize(utils.RandomBytes(16), utils.RandomBytes(16))
+
+	depositTx1, err := txs.NewSigned(&txs.DepositTx{
+		BaseTx:          *generateBaseTx(id, 1, outputOwners, ids.Empty, ids.Empty),
+		DepositOfferID:  depositOffers[0].ID,
+		DepositDuration: 1,
+		RewardsOwner:    &outputOwners,
+	}, pvm_genesis.Codec, nil)
+	require.NoError(err)
+
+	depositTx2, err := txs.NewSigned(&txs.DepositTx{
+		BaseTx:          *generateBaseTx(id, 2, outputOwners2, ids.Empty, ids.Empty),
+		DepositOfferID:  depositOffers[1].ID,
+		DepositDuration: 2,
+		RewardsOwner:    &outputOwners2,
+	}, pvm_genesis.Codec, nil)
+	require.NoError(err)
+
+	depositTxs := []*txs.Tx{depositTx1, depositTx2}
 
 	type args struct {
 		s *state
-		g *genesis.State
+		g *pvm_genesis.State
 	}
 	tests := map[string]struct {
-		cs      caminoState
-		args    args
-		want    caminoDiff
-		prepare func(cd caminoDiff)
-		err     error
+		cs   caminoState
+		args args
+		want caminoDiff
+		err  error
 	}{
 		"successful addition of address states, deposits and deposit offers": {
 			args: args{
 				s: s.(*state),
-				g: defaultGenesisState([]genesis.AddressState{
+				g: defaultGenesisState([]pvm_genesis.AddressState{
 					{
 						Address: initialAdmin,
 						State:   txs.AddressStateRoleAdminBit,
@@ -241,7 +257,10 @@ func TestSyncGenesis(t *testing.T) {
 			cs: *wrappers.IgnoreError(newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())).(*caminoState),
 			want: caminoDiff{
 				modifiedAddressStates: map[ids.ShortID]uint64{initialAdmin: txs.AddressStateRoleAdminBit, shortID: txs.AddressStateRoleValidatorBit},
-				modifiedDepositOffers: map[ids.ID]*deposit.Offer{},
+				modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+					depositOffers[0].ID: depositOffers[0],
+					depositOffers[1].ID: depositOffers[1],
+				},
 				modifiedDeposits: map[ids.ID]*deposit.Deposit{
 					depositTxs[0].ID(): {
 						DepositOfferID: depositTxs[0].Unsigned.(*txs.DepositTx).DepositOfferID,
@@ -253,41 +272,40 @@ func TestSyncGenesis(t *testing.T) {
 					},
 				},
 			},
-			prepare: func(cd caminoDiff) {
-				for _, v := range depositOffers {
-					cd.modifiedDepositOffers[v.ID] = v //nolint:nolintlint
-				}
-			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			tt.prepare(tt.want)
+			require.NoError(tt.args.g.Camino.Init())
 			err := tt.cs.SyncGenesis(tt.args.s, tt.args.g)
 			require.ErrorIs(tt.err, err)
 
-			for k, d := range tt.want.modifiedDeposits {
-				require.Equal(d.DepositOfferID, tt.cs.modifiedDeposits[k].DepositOfferID)
-				require.Equal(d.Amount, tt.cs.modifiedDeposits[k].Amount)
+			require.Len(tt.cs.modifiedDeposits, len(tt.want.modifiedDeposits))
+			for expectedModifiedDepositID, expectedModifiedDeposit := range tt.want.modifiedDeposits {
+				actualModifiedDeposit, ok := tt.cs.modifiedDeposits[expectedModifiedDepositID]
+				require.True(ok)
+				require.Equal(expectedModifiedDeposit.DepositOfferID, actualModifiedDeposit.DepositOfferID)
+				require.Equal(expectedModifiedDeposit.Amount, actualModifiedDeposit.Amount)
 			}
-			for i, o := range tt.want.modifiedDepositOffers {
-				require.Equal(o, tt.cs.modifiedDepositOffers[i])
+			for expectedModifiedDepositOfferID, expectedModifiedDepositOffer := range tt.want.modifiedDepositOffers {
+				actualModifiedDepositOffer, ok := tt.cs.modifiedDepositOffers[expectedModifiedDepositOfferID]
+				require.True(ok)
+				require.Equal(expectedModifiedDepositOffer, actualModifiedDepositOffer)
 			}
 			require.Truef(reflect.DeepEqual(tt.want.modifiedAddressStates, tt.cs.caminoDiff.modifiedAddressStates), "\ngot: %v\nwant: %v", tt.want.modifiedAddressStates, tt.cs.caminoDiff.modifiedAddressStates)
 		})
 	}
 }
 
-func defaultConfig(lockModeBondDeposit bool, nodeID ids.NodeID, deposit bool) root_genesis.Config {
+func testGenesisConfig(lockModeBondDeposit bool, validator, deposit bool) *root_genesis.Config {
 	var (
 		defaultMinValidatorStake = 5 * units.MilliAvax
 		minStake                 = root_genesis.GetStakingConfig(testNetworkID).MinValidatorStake
 		minStakeDuration         = uint64(1000)
-		depositOfferMemo         = ""
 		initialAdmin             = ids.GenerateTestShortID()
 	)
 
-	depositOffers := []genesis.DepositOffer{{
+	depositOffer := root_genesis.DepositOffer{
 		InterestRateNominator:   1,
 		Start:                   2,
 		End:                     3,
@@ -297,106 +315,95 @@ func defaultConfig(lockModeBondDeposit bool, nodeID ids.NodeID, deposit bool) ro
 		UnlockPeriodDuration:    7,
 		NoRewardsPeriodDuration: 2,
 		Flags:                   9,
-		Memo:                    "offer memo",
-	}}
+		Memo:                    "some memo",
+	}
 
+	depositOfferMemo := ""
 	if deposit {
-		depositOfferMemo = depositOffers[0].Memo
+		depositOfferMemo = depositOffer.Memo
+	}
+
+	nodeID := ids.EmptyNodeID
+	if validator {
+		nodeID = ids.GenerateTestNodeID()
 	}
 
 	var caminoAllocations []root_genesis.CaminoAllocation
-	var allocations []root_genesis.Allocation
-
-	platformAllocations := []root_genesis.PlatformAllocation{
-		{
-			Amount:            minStake,
-			NodeID:            nodeID,
-			ValidatorDuration: defaultMinValidatorStake,
-			DepositDuration:   5,
-			TimestampOffset:   10,
-			DepositOfferMemo:  depositOfferMemo,
-			Memo:              "",
-		},
-	}
+	var avaxAllocations []root_genesis.Allocation
+	var avaxInitialStakers []root_genesis.Staker
+	var avaxInitialStakerFunds []ids.ShortID
 
 	if lockModeBondDeposit {
-		caminoAllocations = []root_genesis.CaminoAllocation{
-			{
-				ETHAddr:  initialAdmin,
-				AVAXAddr: initialAdmin,
-				XAmount:  10 * defaultMinValidatorStake,
-				AddressStates: root_genesis.AddressStates{
-					ConsortiumMember: true,
-					KYCVerified:      true,
-				},
-				PlatformAllocations: platformAllocations,
+		caminoAllocations = []root_genesis.CaminoAllocation{{
+			ETHAddr:  initialAdmin,
+			AVAXAddr: initialAdmin,
+			XAmount:  10 * defaultMinValidatorStake,
+			AddressStates: root_genesis.AddressStates{
+				ConsortiumMember: true,
+				KYCVerified:      true,
 			},
-		}
+			PlatformAllocations: []root_genesis.PlatformAllocation{{
+				Amount:            minStake,
+				NodeID:            nodeID,
+				ValidatorDuration: defaultMinValidatorStake,
+				DepositDuration:   5,
+				TimestampOffset:   10,
+				DepositOfferMemo:  depositOfferMemo,
+			}},
+		}}
 	} else {
-		allocations = []root_genesis.Allocation{
-			{
-				ETHAddr:       initialAdmin,
-				AVAXAddr:      initialAdmin,
-				InitialAmount: minStake,
-				UnlockSchedule: []root_genesis.LockedAmount{
-					{
-						Amount:   1,
-						Locktime: 0,
-					},
-				},
-			},
-		}
+		avaxInitialStakerFunds = []ids.ShortID{initialAdmin}
+		avaxInitialStakers = []root_genesis.Staker{{
+			NodeID:        nodeID,
+			RewardAddress: initialAdmin,
+		}}
+		avaxAllocations = []root_genesis.Allocation{{
+			ETHAddr:       initialAdmin,
+			AVAXAddr:      initialAdmin,
+			InitialAmount: minStake,
+			UnlockSchedule: []root_genesis.LockedAmount{{
+				Amount:   minStake,
+				Locktime: 0,
+			}},
+		}}
 	}
 
-	config := root_genesis.Config{
-		NetworkID:                  0,
-		Allocations:                allocations,
+	return &root_genesis.Config{
+		Allocations:                avaxAllocations,
 		StartTime:                  10,
 		InitialStakeDuration:       minStakeDuration,
 		InitialStakeDurationOffset: 10,
-		InitialStakedFunds:         []ids.ShortID{initialAdmin},
-		InitialStakers: []root_genesis.Staker{
-			{
-				NodeID:        nodeID,
-				RewardAddress: initialAdmin,
-			},
-		},
+		InitialStakedFunds:         avaxInitialStakerFunds,
+		InitialStakers:             avaxInitialStakers,
 		Camino: root_genesis.Camino{
-			VerifyNodeSignature:      true,
-			LockModeBondDeposit:      lockModeBondDeposit,
-			InitialAdmin:             initialAdmin,
-			DepositOffers:            depositOffers,
-			Allocations:              caminoAllocations,
-			InitialMultisigAddresses: nil,
+			VerifyNodeSignature: true,
+			LockModeBondDeposit: lockModeBondDeposit,
+			InitialAdmin:        initialAdmin,
+			DepositOffers:       []root_genesis.DepositOffer{depositOffer},
+			Allocations:         caminoAllocations,
 		},
-		CChainGenesis: "",
-		Message:       "",
 	}
-
-	return config
 }
 
-func defaultGenesisState(addresses []genesis.AddressState, deposits []*txs.Tx, initialAdmin ids.ShortID) *genesis.State {
-	return &genesis.State{
-		UTXOs: []*avax.UTXO{
-			{
-				UTXOID: avax.UTXOID{
-					TxID:        initialTxID,
-					OutputIndex: 0,
-				},
-				Asset: avax.Asset{ID: initialTxID},
-				Out: &secp256k1fx.TransferOutput{
-					Amt: units.Schmeckle,
-				},
+func defaultGenesisState(addresses []pvm_genesis.AddressState, deposits []*txs.Tx, initialAdmin ids.ShortID) *pvm_genesis.State {
+	return &pvm_genesis.State{
+		UTXOs: []*avax.UTXO{{
+			UTXOID: avax.UTXOID{
+				TxID:        initialTxID,
+				OutputIndex: 0,
 			},
-		},
+			Asset: avax.Asset{ID: initialTxID},
+			Out: &secp256k1fx.TransferOutput{
+				Amt: units.Schmeckle,
+			},
+		}},
 		Chains:        []*txs.Tx{{}},
 		Timestamp:     uint64(initialTime.Unix()),
 		InitialSupply: units.Schmeckle + units.Avax,
-		Camino: genesis.Camino{
+		Camino: pvm_genesis.Camino{
 			AddressStates: addresses,
 			InitialAdmin:  initialAdmin,
-			Blocks: []*genesis.Block{{
+			Blocks: []*pvm_genesis.Block{{
 				Validators: []*txs.Tx{{Unsigned: &txs.CaminoAddValidatorTx{
 					AddValidatorTx: txs.AddValidatorTx{
 						BaseTx:       txs.BaseTx{},
@@ -406,7 +413,7 @@ func defaultGenesisState(addresses []genesis.AddressState, deposits []*txs.Tx, i
 				}}},
 				Deposits: deposits,
 			}},
-			DepositOffers: []genesis.DepositOffer{
+			DepositOffers: []*deposit.Offer{
 				{
 					InterestRateNominator:   1,
 					Start:                   2,
@@ -417,6 +424,7 @@ func defaultGenesisState(addresses []genesis.AddressState, deposits []*txs.Tx, i
 					UnlockPeriodDuration:    7,
 					NoRewardsPeriodDuration: 8,
 					Flags:                   9,
+					Memo:                    []byte("some memo"),
 				},
 				{
 					InterestRateNominator:   2,

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder
@@ -19,7 +19,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
-	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -176,17 +175,15 @@ func TestUnlockDepositTx(t *testing.T) {
 	caminoGenesisConf := api.Camino{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-		DepositOffers: []genesis.DepositOffer{
-			{
-				UnlockPeriodDuration:  60,
-				InterestRateNominator: 0,
-				Start:                 uint64(time.Now().Add(-60 * time.Hour).Unix()),
-				End:                   uint64(time.Now().Add(+60 * time.Hour).Unix()),
-				MinAmount:             1,
-				MinDuration:           60,
-				MaxDuration:           60,
-			},
-		},
+		DepositOffers: []*deposits.Offer{{
+			UnlockPeriodDuration:  60,
+			InterestRateNominator: 0,
+			Start:                 uint64(time.Now().Add(-60 * time.Hour).Unix()),
+			End:                   uint64(time.Now().Add(+60 * time.Hour).Unix()),
+			MinAmount:             1,
+			MinDuration:           60,
+			MaxDuration:           60,
+		}},
 	}
 	testKey, err := testKeyfactory.NewPrivateKey()
 	require.NoError(t, err)

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/nodeid"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/multisig"
-	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -1837,7 +1836,7 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 	currentTime := time.Now()
 
-	testDepositOffer := genesis.DepositOffer{
+	testDepositOffer := &deposits.Offer{
 		InterestRateNominator:   0,
 		Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
 		End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
@@ -1880,7 +1879,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos:          []*avax.UTXO{},
 			generateIns:    noInputs,
@@ -1892,7 +1891,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1918,7 +1917,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1943,7 +1942,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1970,7 +1969,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1996,7 +1995,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers:       []genesis.DepositOffer{testDepositOffer},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2020,18 +2019,16 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					{
-						InterestRateNominator:   0,
-						Start:                   uint64(currentTime.Add(+60 * time.Hour).Unix()),
-						End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
-						MinAmount:               1,
-						MinDuration:             60,
-						MaxDuration:             60,
-						UnlockPeriodDuration:    60,
-						NoRewardsPeriodDuration: 0,
-					},
-				},
+				DepositOffers: []*deposits.Offer{{
+					InterestRateNominator:   0,
+					Start:                   uint64(currentTime.Add(+60 * time.Hour).Unix()),
+					End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
+					MinAmount:               1,
+					MinDuration:             60,
+					MaxDuration:             60,
+					UnlockPeriodDuration:    60,
+					NoRewardsPeriodDuration: 0,
+				}},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2057,18 +2054,16 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					{
-						InterestRateNominator:   0,
-						Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
-						End:                     uint64(currentTime.Add(-60 * time.Hour).Unix()),
-						MinAmount:               1,
-						MinDuration:             60,
-						MaxDuration:             60,
-						UnlockPeriodDuration:    60,
-						NoRewardsPeriodDuration: 0,
-					},
-				},
+				DepositOffers: []*deposits.Offer{{
+					InterestRateNominator:   0,
+					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
+					End:                     uint64(currentTime.Add(-60 * time.Hour).Unix()),
+					MinAmount:               1,
+					MinDuration:             60,
+					MaxDuration:             60,
+					UnlockPeriodDuration:    60,
+					NoRewardsPeriodDuration: 0,
+				}},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2094,18 +2089,16 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					{
-						InterestRateNominator:   0,
-						Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
-						End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
-						MinAmount:               1,
-						MinDuration:             100,
-						MaxDuration:             100,
-						UnlockPeriodDuration:    60,
-						NoRewardsPeriodDuration: 40,
-					},
-				},
+				DepositOffers: []*deposits.Offer{{
+					InterestRateNominator:   0,
+					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
+					End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
+					MinAmount:               1,
+					MinDuration:             100,
+					MaxDuration:             100,
+					UnlockPeriodDuration:    60,
+					NoRewardsPeriodDuration: 40,
+				}},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2131,18 +2124,16 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					{
-						InterestRateNominator:   0,
-						Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
-						End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
-						MinAmount:               1,
-						MinDuration:             60,
-						MaxDuration:             30,
-						UnlockPeriodDuration:    60,
-						NoRewardsPeriodDuration: 0,
-					},
-				},
+				DepositOffers: []*deposits.Offer{{
+					InterestRateNominator:   0,
+					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
+					End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
+					MinAmount:               1,
+					MinDuration:             60,
+					MaxDuration:             30,
+					UnlockPeriodDuration:    60,
+					NoRewardsPeriodDuration: 0,
+				}},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2168,18 +2159,16 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					{
-						InterestRateNominator:   0,
-						Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
-						End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
-						MinAmount:               defaultCaminoValidatorWeight * 2,
-						MinDuration:             60,
-						MaxDuration:             60,
-						UnlockPeriodDuration:    60,
-						NoRewardsPeriodDuration: 0,
-					},
-				},
+				DepositOffers: []*deposits.Offer{{
+					InterestRateNominator:   0,
+					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
+					End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
+					MinAmount:               defaultCaminoValidatorWeight * 2,
+					MinDuration:             60,
+					MaxDuration:             60,
+					UnlockPeriodDuration:    60,
+					NoRewardsPeriodDuration: 0,
+				}},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2205,9 +2194,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, existingTxID),
@@ -2232,9 +2219,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
@@ -2261,9 +2246,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, dummyOutputOwners, ids.Empty, ids.Empty),
@@ -2289,9 +2272,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
@@ -2317,18 +2298,16 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					{
-						InterestRateNominator:   1000 * units.MegaAvax,
-						Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
-						End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
-						MinAmount:               1,
-						MinDuration:             60,
-						MaxDuration:             60,
-						UnlockPeriodDuration:    60,
-						NoRewardsPeriodDuration: 0,
-					},
-				},
+				DepositOffers: []*deposits.Offer{{
+					InterestRateNominator:   1000 * units.MegaAvax,
+					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
+					End:                     uint64(currentTime.Add(+60 * time.Hour).Unix()),
+					MinAmount:               1,
+					MinDuration:             60,
+					MaxDuration:             60,
+					UnlockPeriodDuration:    60,
+					NoRewardsPeriodDuration: 0,
+				}},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2354,9 +2333,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2382,9 +2359,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance+10, outputOwners, ids.Empty, ids.Empty),
@@ -2411,9 +2386,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
@@ -2440,9 +2413,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee+defaultCaminoValidatorWeight/2, outputOwners, ids.Empty, ids.Empty),
@@ -2470,9 +2441,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			caminoGenesisConf: api.Camino{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-				DepositOffers: []genesis.DepositOffer{
-					testDepositOffer,
-				},
+				DepositOffers:       []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2577,20 +2546,18 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 	depositTxID := ids.GenerateTestID()
 	depositTxID2 := ids.GenerateTestID()
 
-	genesisDepositOffer := genesis.DepositOffer{
+	depositOffer := &deposits.Offer{
 		MinAmount:            1,
 		MinDuration:          60,
 		MaxDuration:          100,
 		UnlockPeriodDuration: 50,
 	}
-
-	depositOffer, err := state.ParseDepositOfferFromGenesisOffer(&genesisDepositOffer)
-	require.NoError(t, err)
+	require.NoError(t, depositOffer.SetID())
 
 	caminoGenesisConf := api.Camino{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-		DepositOffers:       []genesis.DepositOffer{genesisDepositOffer},
+		DepositOffers:       []*deposits.Offer{depositOffer},
 	}
 
 	deposit := &deposits.Deposit{


### PR DESCRIPTION
## Why this should be merged
### Deposit offer types (genesis config / platformvm genesis / state)
Before this PR, we had the `platformvm/genesis.DepositOffer` type, which contained offer verification logic and id generation logic (marshal struct, hash bytes). But in platformvm state, ID was generated from a different type (which could theoretically make it inconsistent) - `deposit.Offer` (marshal struct, hash bytes) with duplicated logic. This type also doesn't have its own verify function, and if it would have - it would be duplicated logic.

And at some point we'll need a feature to add new deposit offers with some transaction and we'll need to verify those offers and generate IDs for them.

### Deposit offer memo
There are 2 issues, that this PR solves:
- We need to add an arbitrary text field to deposit offers (could contain offer title, for example) - this PR adds it.
- In genesis json, when we change the start-time or any of the offer values, we then need to regenerate the offer id and update every allocation that uses that offer. This PR replaces the allocation-to-offer link by id with a link by offer memo.

## How this works
Due to the removal of `platformvm/genesis.DepositOffer`, this PR adds a `genesis.DepositOffer` type to which `genesis.UnparsedDepositOffer` will be parsed. The new type doesn't contain any logic and is only used in genesis config.

PlatformVM static service BuildGenesis args will use the deposit.Offer type.
Deposit offer verification logic is moved to deposit.Offer type.

This PR does 2 things regarding deposit offers memo:
- It adds a new `memo` field to deposit offers, which will contain an arbitrary text. In genesis json, this is a plain text, that encoded into hex bytes on genesis build.
- Removes deposit offer ids from genesis json. Allocations are now linked to deposit offers by deposit offer memo. This also means, that all genesis deposit offers must have a non-empty memo. On genesis build allocations and offers are linked by offer ids.

## How this was tested
Unit tests