### PR TITLE
[PVM, GENESIS] Add ValidatorRewardsStartTime, refactor camino config in genesis

### DIFF
--- a/genesis/camino_config.go
+++ b/genesis/camino_config.go
@@ -16,21 +16,23 @@ import (
 )
 
 type Camino struct {
-	VerifyNodeSignature      bool                    `json:"verifyNodeSignature"`
-	LockModeBondDeposit      bool                    `json:"lockModeBondDeposit"`
-	InitialAdmin             ids.ShortID             `json:"initialAdmin"`
-	DepositOffers            []DepositOffer          `json:"depositOffers"`
-	Allocations              []CaminoAllocation      `json:"allocations"`
-	InitialMultisigAddresses []genesis.MultisigAlias `json:"initialMultisigAddresses"`
+	VerifyNodeSignature       bool                    `json:"verifyNodeSignature"`
+	LockModeBondDeposit       bool                    `json:"lockModeBondDeposit"`
+	ValidatorRewardsStartTime uint64                  `json:"validatorRewardsStartTime"`
+	InitialAdmin              ids.ShortID             `json:"initialAdmin"`
+	DepositOffers             []DepositOffer          `json:"depositOffers"`
+	Allocations               []CaminoAllocation      `json:"allocations"`
+	InitialMultisigAddresses  []genesis.MultisigAlias `json:"initialMultisigAddresses"`
 }
 
 func (c Camino) Unparse(networkID uint32, starttime uint64) (UnparsedCamino, error) {
 	uc := UnparsedCamino{
-		VerifyNodeSignature:      c.VerifyNodeSignature,
-		LockModeBondDeposit:      c.LockModeBondDeposit,
-		DepositOffers:            make([]UnparsedDepositOffer, len(c.DepositOffers)),
-		Allocations:              make([]UnparsedCaminoAllocation, len(c.Allocations)),
-		InitialMultisigAddresses: make([]UnparsedMultisigAlias, len(c.InitialMultisigAddresses)),
+		VerifyNodeSignature:       c.VerifyNodeSignature,
+		LockModeBondDeposit:       c.LockModeBondDeposit,
+		ValidatorRewardsStartTime: c.ValidatorRewardsStartTime,
+		DepositOffers:             make([]UnparsedDepositOffer, len(c.DepositOffers)),
+		Allocations:               make([]UnparsedCaminoAllocation, len(c.Allocations)),
+		InitialMultisigAddresses:  make([]UnparsedMultisigAlias, len(c.InitialMultisigAddresses)),
 	}
 
 	avaxAddr, err := address.Format(

--- a/genesis/camino_genesis.go
+++ b/genesis/camino_genesis.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/nftfx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	pchaintxs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -203,12 +204,15 @@ func validateCaminoConfig(config *Config) error {
 	return nil
 }
 
-func caminoArgFromConfig(config *Config) api.Camino {
+func caminoArgFromConfig(cfg *Config) api.Camino {
 	return api.Camino{
-		VerifyNodeSignature:      config.Camino.VerifyNodeSignature,
-		LockModeBondDeposit:      config.Camino.LockModeBondDeposit,
-		InitialAdmin:             config.Camino.InitialAdmin,
-		InitialMultisigAddresses: config.Camino.InitialMultisigAddresses,
+		Config: config.CaminoGenesisConfig{
+			VerifyNodeSignature:       cfg.Camino.VerifyNodeSignature,
+			LockModeBondDeposit:       cfg.Camino.LockModeBondDeposit,
+			ValidatorRewardsStartTime: cfg.Camino.ValidatorRewardsStartTime,
+		},
+		InitialAdmin:             cfg.Camino.InitialAdmin,
+		InitialMultisigAddresses: cfg.Camino.InitialMultisigAddresses,
 	}
 }
 
@@ -495,7 +499,7 @@ func GenesisChainData(genesisBytes []byte, vmIDs []ids.ID) ([]*pchaintxs.Tx, boo
 			return nil, false, fmt.Errorf("couldn't find blockchain with VM ID %s", vmID)
 		}
 	}
-	return result, genesis.Camino.LockModeBondDeposit, nil
+	return result, genesis.Camino.Config.LockModeBondDeposit, nil
 }
 
 func GetGenesisBlocksIDs(genesisBytes []byte, genesis *genesis.Genesis) ([]ids.ID, error) {

--- a/genesis/camino_unparsed_config.go
+++ b/genesis/camino_unparsed_config.go
@@ -19,21 +19,23 @@ import (
 var errCannotParseInitialAdmin = errors.New("cannot parse initialAdmin from genesis")
 
 type UnparsedCamino struct {
-	VerifyNodeSignature      bool                       `json:"verifyNodeSignature"`
-	LockModeBondDeposit      bool                       `json:"lockModeBondDeposit"`
-	InitialAdmin             string                     `json:"initialAdmin"`
-	DepositOffers            []UnparsedDepositOffer     `json:"depositOffers"`
-	Allocations              []UnparsedCaminoAllocation `json:"allocations"`
-	InitialMultisigAddresses []UnparsedMultisigAlias    `json:"initialMultisigAddresses"`
+	VerifyNodeSignature       bool                       `json:"verifyNodeSignature"`
+	LockModeBondDeposit       bool                       `json:"lockModeBondDeposit"`
+	ValidatorRewardsStartTime uint64                     `json:"validatorRewardsStartTime"`
+	InitialAdmin              string                     `json:"initialAdmin"`
+	DepositOffers             []UnparsedDepositOffer     `json:"depositOffers"`
+	Allocations               []UnparsedCaminoAllocation `json:"allocations"`
+	InitialMultisigAddresses  []UnparsedMultisigAlias    `json:"initialMultisigAddresses"`
 }
 
 func (uc UnparsedCamino) Parse(startTime uint64) (Camino, error) {
 	c := Camino{
-		VerifyNodeSignature:      uc.VerifyNodeSignature,
-		LockModeBondDeposit:      uc.LockModeBondDeposit,
-		DepositOffers:            make([]DepositOffer, len(uc.DepositOffers)),
-		Allocations:              make([]CaminoAllocation, len(uc.Allocations)),
-		InitialMultisigAddresses: make([]genesis.MultisigAlias, len(uc.InitialMultisigAddresses)),
+		VerifyNodeSignature:       uc.VerifyNodeSignature,
+		LockModeBondDeposit:       uc.LockModeBondDeposit,
+		ValidatorRewardsStartTime: uc.ValidatorRewardsStartTime,
+		DepositOffers:             make([]DepositOffer, len(uc.DepositOffers)),
+		Allocations:               make([]CaminoAllocation, len(uc.Allocations)),
+		InitialMultisigAddresses:  make([]genesis.MultisigAlias, len(uc.InitialMultisigAddresses)),
 	}
 
 	_, _, avaxAddrBytes, err := address.Parse(uc.InitialAdmin)

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -208,7 +208,7 @@ func TestGenesisFromFile(t *testing.T) {
 		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
-			expected:     "e505cde775294a30c34e0d9ad52957f1ee41437b4fdc70373679b5168c29951d",
+			expected:     "a7a108f54a0211529d4a7f83c4cd5041fa45490759a6eaafe18a0f1818dd5d40",
 		},
 		"custom (networkID mismatch)": {
 			networkID:    9999,
@@ -290,7 +290,7 @@ func TestGenesisFromFlag(t *testing.T) {
 		"custom": {
 			networkID:    9999,
 			customConfig: customGenesisConfigJSON,
-			expected:     "e505cde775294a30c34e0d9ad52957f1ee41437b4fdc70373679b5168c29951d",
+			expected:     "a7a108f54a0211529d4a7f83c4cd5041fa45490759a6eaafe18a0f1818dd5d40",
 		},
 		"custom (networkID mismatch)": {
 			networkID:    9999,
@@ -362,27 +362,27 @@ func TestGenesis(t *testing.T) {
 	}{
 		{
 			networkID:  constants.MainnetID,
-			expectedID: "2eP2teFA41Pb61nQyQYJY38onkCqkrJDPSVeQz8v9ahbEma18S",
+			expectedID: "Xkj35wayDQs6eG5TBZpTjUMbP3ppAPTmngaXFfUskghNdHiSH",
 		},
 		{
 			networkID:  constants.FujiID,
-			expectedID: "2fAKF9ph6o4jxr12QVWmbww8dVfkNKepBt547QFEJ5eyD9x2Z9",
+			expectedID: "2tnvZSBadkJidWwMZGu8Xr9bLn1mjYwytx3roJjbFbhFTn5DTw",
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2Xp77XhWks5ByoqyEtGqhu7P7b7ayBgndtBi65N4Zjp9D5VZUb",
+			expectedID: "W7gR4gBg3dyBzRXaUA4uVSBC2BCSXVLwAuX34iinJnvSjMeTs",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "cjJ1mMfD2LMVqyBCj9JsRTyzGKDpDw1uZwQANEAt5JknckhjJ",
+			expectedID: "2vYtAz4YC1Zj17p8Z6L5U4un4ky9An6tTVkZe1vpKMDyBK5jVC",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "2Aq1D2Jo8NDBo9qFft7UEY837yqunjT4gPz7r4dnRcY62kELod",
+			expectedID: "2b7EnGqirVn6Jb8n6euMXBzJLwPoHE7gh38b2UqDPRnYUgjgEi",
 		},
 		{
 			networkID:  constants.LocalID,
-			expectedID: "294HrmVEniYX2mrvLjww9AmpV9NZnFhEi6eRrCsAzxZ2PkvdVb",
+			expectedID: "MeUKdmy7vSDwEEKWB1kEKLfF1K1UfX4MZTqh89aAyK2XtjY7s",
 		},
 	}
 	for _, test := range tests {

--- a/vms/platformvm/api/camino.go
+++ b/vms/platformvm/api/camino.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
@@ -37,21 +38,19 @@ type UTXODeposit struct {
 }
 
 type Camino struct {
-	VerifyNodeSignature        bool                    `json:"verifyNodeSignature"`
-	LockModeBondDeposit        bool                    `json:"lockModeBondDeposit"`
-	InitialAdmin               ids.ShortID             `json:"initialAdmin"`
-	AddressStates              []genesis.AddressState  `json:"addressStates"`
-	DepositOffers              []*deposit.Offer        `json:"depositOffers"`
-	ValidatorDeposits          [][]UTXODeposit         `json:"validatorDeposits"`
-	ValidatorConsortiumMembers []ids.ShortID           `json:"validatorConsortiumMembers"`
-	UTXODeposits               []UTXODeposit           `json:"utxoDeposits"`
-	InitialMultisigAddresses   []genesis.MultisigAlias `json:"initialMultisigAddresses"`
+	Config                     config.CaminoGenesisConfig `json:"config"`
+	InitialAdmin               ids.ShortID                `json:"initialAdmin"`
+	AddressStates              []genesis.AddressState     `json:"addressStates"`
+	DepositOffers              []*deposit.Offer           `json:"depositOffers"`
+	ValidatorDeposits          [][]UTXODeposit            `json:"validatorDeposits"`
+	ValidatorConsortiumMembers []ids.ShortID              `json:"validatorConsortiumMembers"`
+	UTXODeposits               []UTXODeposit              `json:"utxoDeposits"`
+	InitialMultisigAddresses   []genesis.MultisigAlias    `json:"initialMultisigAddresses"`
 }
 
 func (c Camino) ParseToGenesis() genesis.Camino {
 	return genesis.Camino{
-		VerifyNodeSignature:      c.VerifyNodeSignature,
-		LockModeBondDeposit:      c.LockModeBondDeposit,
+		Config:                   c.Config,
 		InitialAdmin:             c.InitialAdmin,
 		AddressStates:            c.AddressStates,
 		DepositOffers:            c.DepositOffers,
@@ -61,7 +60,7 @@ func (c Camino) ParseToGenesis() genesis.Camino {
 
 // BuildGenesis build the genesis state of the Platform Chain (and thereby the Avalanche network.)
 func buildCaminoGenesis(args *BuildGenesisArgs, reply *BuildGenesisReply) error {
-	if !args.Camino.LockModeBondDeposit {
+	if !args.Camino.Config.LockModeBondDeposit {
 		return errWrongLockMode
 	}
 	if len(args.Camino.UTXODeposits) != len(args.UTXOs) {

--- a/vms/platformvm/api/camino_test.go
+++ b/vms/platformvm/api/camino_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
@@ -79,8 +80,10 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				}},
 				Chains: []Chain{},
 				Camino: Camino{
-					VerifyNodeSignature:        true,
-					LockModeBondDeposit:        true,
+					Config: config.CaminoGenesisConfig{
+						VerifyNodeSignature: true,
+						LockModeBondDeposit: true,
+					},
 					ValidatorConsortiumMembers: []ids.ShortID{addr},
 					ValidatorDeposits: [][]UTXODeposit{{{
 						depositOffer.ID,
@@ -294,11 +297,13 @@ func TestBuildCaminoGenesis(t *testing.T) {
 					},
 					Chains: []*txs.Tx{},
 					Camino: genesis.Camino{
-						VerifyNodeSignature: true,
-						LockModeBondDeposit: true,
-						InitialAdmin:        ids.ShortEmpty,
-						AddressStates:       []genesis.AddressState{},
-						DepositOffers:       []*deposit.Offer{depositOffer},
+						Config: config.CaminoGenesisConfig{
+							VerifyNodeSignature: true,
+							LockModeBondDeposit: true,
+						},
+						InitialAdmin:  ids.ShortEmpty,
+						AddressStates: []genesis.AddressState{},
+						DepositOffers: []*deposit.Offer{depositOffer},
 						Blocks: []*genesis.Block{
 							{
 								Timestamp:  0,
@@ -350,8 +355,10 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				},
 				Chains: []Chain{},
 				Camino: Camino{
-					VerifyNodeSignature: true,
-					LockModeBondDeposit: false,
+					Config: config.CaminoGenesisConfig{
+						VerifyNodeSignature: true,
+						LockModeBondDeposit: false,
+					},
 					ValidatorConsortiumMembers: []ids.ShortID{
 						ids.GenerateTestShortID(),
 					},
@@ -395,8 +402,10 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				Time:       5,
 				Encoding:   formatting.Hex,
 				Camino: Camino{
-					VerifyNodeSignature: true,
-					LockModeBondDeposit: true,
+					Config: config.CaminoGenesisConfig{
+						VerifyNodeSignature: true,
+						LockModeBondDeposit: true,
+					},
 					UTXODeposits: []UTXODeposit{
 						{
 							ids.GenerateTestID(),
@@ -439,8 +448,10 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				Time:     5,
 				Encoding: formatting.Hex,
 				Camino: Camino{
-					VerifyNodeSignature: true,
-					LockModeBondDeposit: true,
+					Config: config.CaminoGenesisConfig{
+						VerifyNodeSignature: true,
+						LockModeBondDeposit: true,
+					},
 					ValidatorDeposits: [][]UTXODeposit{
 						{
 							{
@@ -484,8 +495,10 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				Time:     5,
 				Encoding: formatting.Hex,
 				Camino: Camino{
-					VerifyNodeSignature: true,
-					LockModeBondDeposit: true,
+					Config: config.CaminoGenesisConfig{
+						VerifyNodeSignature: true,
+						LockModeBondDeposit: true,
+					},
 					ValidatorConsortiumMembers: []ids.ShortID{
 						ids.GenerateTestShortID(),
 					},
@@ -533,8 +546,10 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				},
 				Chains: []Chain{},
 				Camino: Camino{
-					VerifyNodeSignature: true,
-					LockModeBondDeposit: true,
+					Config: config.CaminoGenesisConfig{
+						VerifyNodeSignature: true,
+						LockModeBondDeposit: true,
+					},
 					ValidatorConsortiumMembers: []ids.ShortID{
 						ids.GenerateTestShortID(),
 					},

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -216,7 +216,7 @@ func bech32ToID(addrStr string) (ids.ShortID, error) {
 func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, reply *BuildGenesisReply) error {
 	// Specify the UTXOs on the Platform chain that exist at genesis.
 	var vdrs txheap.TimedHeap
-	if args.Camino.LockModeBondDeposit {
+	if args.Camino.Config.LockModeBondDeposit {
 		return buildCaminoGenesis(args, reply)
 	}
 

--- a/vms/platformvm/blocks/executor/proposal_block_test.go
+++ b/vms/platformvm/blocks/executor/proposal_block_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
@@ -101,7 +102,7 @@ func TestApricotProposalBlockTimeVerification(t *testing.T) {
 	}
 
 	// setup state to validate proposal block transaction
-	onParentAccept.EXPECT().CaminoConfig().Return(&state.CaminoConfig{}, nil)
+	onParentAccept.EXPECT().CaminoConfig().Return(&config.CaminoGenesisConfig{}, nil)
 	onParentAccept.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 
 	currentStakersIt := state.NewMockStakerIterator(ctrl)
@@ -185,7 +186,7 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	env.mockedState.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 
 	onParentAccept := state.NewMockDiff(ctrl)
-	onParentAccept.EXPECT().CaminoConfig().Return(&state.CaminoConfig{}, nil)
+	onParentAccept.EXPECT().CaminoConfig().Return(&config.CaminoGenesisConfig{}, nil)
 	onParentAccept.EXPECT().GetTimestamp().Return(parentTime).AnyTimes()
 	onParentAccept.EXPECT().GetCurrentSupply(constants.PrimaryNetworkID).Return(uint64(1000), nil).AnyTimes()
 

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -570,6 +570,26 @@ func (s *CaminoService) GetClaimables(_ *http.Request, args *GetClaimablesArgs, 
 	return nil
 }
 
+// GetHeight returns the height of the last accepted block
+func (s *Service) GetLastAcceptedBlock(r *http.Request, _ *struct{}, reply *api.GetBlockResponse) error {
+	s.vm.ctx.Log.Debug("Platform: GetLastAcceptedBlock called")
+
+	ctx := r.Context()
+	lastAcceptedID, err := s.vm.LastAccepted(ctx)
+	if err != nil {
+		return fmt.Errorf("couldn't get last accepted block ID: %w", err)
+	}
+	block, err := s.vm.manager.GetStatelessBlock(lastAcceptedID)
+	if err != nil {
+		return fmt.Errorf("couldn't get block with id %s: %w", lastAcceptedID, err)
+	}
+
+	block.InitCtx(s.vm.ctx)
+	reply.Encoding = formatting.JSON
+	reply.Block = block
+	return nil
+}
+
 func (s *Service) getKeystoreKeys(creds *api.UserPass, from *api.JSONFromAddrs) (*secp256k1fx.Keychain, error) {
 	// Parse the from addresses
 	fromAddrs, err := avax.ParseServiceAddresses(s.addrManager, from.From)

--- a/vms/platformvm/camino_service_test.go
+++ b/vms/platformvm/camino_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/version"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/stretchr/testify/require"
@@ -41,9 +42,9 @@ func TestGetCaminoBalance(t *testing.T) {
 		expectedError   error
 	}{
 		"Genesis Validator with added balance": {
-			camino: api.Camino{
+			camino: api.Camino{Config: config.CaminoGenesisConfig{
 				LockModeBondDeposit: true,
-			},
+			}},
 			genesisUTXOs: []api.UTXO{
 				{
 					Amount:  json.Uint64(defaultBalance),
@@ -54,9 +55,9 @@ func TestGetCaminoBalance(t *testing.T) {
 			bonded:  defaultWeight,
 		},
 		"Genesis Validator with deposited amount": {
-			camino: api.Camino{
+			camino: api.Camino{Config: config.CaminoGenesisConfig{
 				LockModeBondDeposit: true,
-			},
+			}},
 			genesisUTXOs: []api.UTXO{
 				{
 					Amount:  json.Uint64(defaultBalance),
@@ -68,9 +69,9 @@ func TestGetCaminoBalance(t *testing.T) {
 			deposited: defaultBalance,
 		},
 		"Genesis Validator with depositedBonded amount": {
-			camino: api.Camino{
+			camino: api.Camino{Config: config.CaminoGenesisConfig{
 				LockModeBondDeposit: true,
-			},
+			}},
 			genesisUTXOs: []api.UTXO{
 				{
 					Amount:  json.Uint64(defaultBalance),
@@ -82,9 +83,9 @@ func TestGetCaminoBalance(t *testing.T) {
 			depositedBonded: defaultBalance,
 		},
 		"Genesis Validator with added balance and disabled LockModeBondDeposit": {
-			camino: api.Camino{
+			camino: api.Camino{Config: config.CaminoGenesisConfig{
 				LockModeBondDeposit: false,
-			},
+			}},
 			genesisUTXOs: []api.UTXO{
 				{
 					Amount:  json.Uint64(defaultBalance),
@@ -95,9 +96,9 @@ func TestGetCaminoBalance(t *testing.T) {
 			bonded:  defaultWeight,
 		},
 		"Error - Empty address ": {
-			camino: api.Camino{
+			camino: api.Camino{Config: config.CaminoGenesisConfig{
 				LockModeBondDeposit: true,
-			},
+			}},
 			expectedError: fmt.Errorf("couldn't parse address %q: %s", "P-", ""),
 		},
 	}
@@ -152,7 +153,7 @@ func TestGetCaminoBalance(t *testing.T) {
 			require.NoError(t, err)
 			expectedBalance := json.Uint64(defaultBalance + tt.bonded + tt.deposited + tt.depositedBonded)
 
-			if !tt.camino.LockModeBondDeposit {
+			if !tt.camino.Config.LockModeBondDeposit {
 				response := responseWrapper.avax
 				require.Equal(t, json.Uint64(defaultBalance), response.Balance, "Wrong balance. Expected %d ; Returned %d", json.Uint64(defaultBalance), response.Balance)
 				require.Equal(t, json.Uint64(0), response.LockedStakeable, "Wrong locked stakeable balance. Expected %d ; Returned %d", 0, response.LockedStakeable)

--- a/vms/platformvm/config/camino.go
+++ b/vms/platformvm/config/camino.go
@@ -7,3 +7,9 @@ type CaminoConfig struct {
 	DaoProposalBondAmount  uint64
 	ValidatorsRewardPeriod uint64
 }
+
+type CaminoGenesisConfig struct {
+	VerifyNodeSignature       bool   `serialize:"true"`
+	LockModeBondDeposit       bool   `serialize:"true"`
+	ValidatorRewardsStartTime uint64 `serialize:"true"`
+}

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -16,20 +16,20 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
 // Camino genesis args
 type Camino struct {
-	VerifyNodeSignature      bool                     `serialize:"true"`
-	LockModeBondDeposit      bool                     `serialize:"true"`
-	InitialAdmin             ids.ShortID              `serialize:"true"`
-	AddressStates            []AddressState           `serialize:"true"`
-	DepositOffers            []*deposit.Offer         `serialize:"true"`
-	Blocks                   []*Block                 `serialize:"true"` // arranged in a block order
-	ConsortiumMembersNodeIDs []ConsortiumMemberNodeID `serialize:"true"`
-	InitialMultisigAddresses []MultisigAlias          `serialize:"true"`
+	Config                   config.CaminoGenesisConfig `serialize:"true"`
+	InitialAdmin             ids.ShortID                `serialize:"true"`
+	AddressStates            []AddressState             `serialize:"true"`
+	DepositOffers            []*deposit.Offer           `serialize:"true"`
+	Blocks                   []*Block                   `serialize:"true"` // arranged in a block order
+	ConsortiumMembersNodeIDs []ConsortiumMemberNodeID   `serialize:"true"`
+	InitialMultisigAddresses []MultisigAlias            `serialize:"true"`
 }
 
 func (c *Camino) Init() error {

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -82,7 +82,7 @@ func (d *diff) Config() (*config.Config, error) {
 	return parentState.Config()
 }
 
-func (d *diff) CaminoConfig() (*CaminoConfig, error) {
+func (d *diff) CaminoConfig() (*config.CaminoGenesisConfig, error) {
 	parentState, ok := d.stateVersions.GetState(d.parentID)
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -43,7 +43,7 @@ func (s *state) Config() (*config.Config, error) {
 	return s.cfg, nil
 }
 
-func (s *state) CaminoConfig() (*CaminoConfig, error) {
+func (s *state) CaminoConfig() (*config.CaminoGenesisConfig, error) {
 	return s.caminoState.CaminoConfig(), nil
 }
 

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -130,10 +130,10 @@ func (mr *MockChainMockRecorder) AddUTXO(arg0 interface{}) *gomock.Call {
 }
 
 // CaminoConfig mocks base method.
-func (m *MockChain) CaminoConfig() (*CaminoConfig, error) {
+func (m *MockChain) CaminoConfig() (*config.CaminoGenesisConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CaminoConfig")
-	ret0, _ := ret[0].(*CaminoConfig)
+	ret0, _ := ret[0].(*config.CaminoGenesisConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -154,10 +154,10 @@ func (mr *MockDiffMockRecorder) ApplyCaminoState(arg0 interface{}) *gomock.Call 
 }
 
 // CaminoConfig mocks base method.
-func (m *MockDiff) CaminoConfig() (*CaminoConfig, error) {
+func (m *MockDiff) CaminoConfig() (*config.CaminoGenesisConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CaminoConfig")
-	ret0, _ := ret[0].(*CaminoConfig)
+	ret0, _ := ret[0].(*config.CaminoGenesisConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -158,10 +158,10 @@ func (mr *MockStateMockRecorder) AddUTXO(arg0 interface{}) *gomock.Call {
 }
 
 // CaminoConfig mocks base method.
-func (m *MockState) CaminoConfig() (*CaminoConfig, error) {
+func (m *MockState) CaminoConfig() (*config.CaminoGenesisConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CaminoConfig")
-	ret0, _ := ret[0].(*CaminoConfig)
+	ret0, _ := ret[0].(*config.CaminoGenesisConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -28,10 +29,10 @@ import (
 )
 
 func TestCaminoEnv(t *testing.T) {
-	caminoGenesisConf := api.Camino{
+	caminoGenesisConf := api.Camino{Config: config.CaminoGenesisConfig{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-	}
+	}}
 	env := newCaminoEnvironment( /*postBanff*/ false, caminoGenesisConf)
 	env.ctx.Lock.Lock()
 	defer func() {
@@ -42,10 +43,10 @@ func TestCaminoEnv(t *testing.T) {
 }
 
 func TestCaminoBuilderTxAddressState(t *testing.T) {
-	caminoConfig := api.Camino{
+	caminoConfig := api.Camino{Config: config.CaminoGenesisConfig{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-	}
+	}}
 
 	env := newCaminoEnvironment(true, caminoConfig)
 	env.ctx.Lock.Lock()
@@ -118,28 +119,28 @@ func TestCaminoBuilderNewAddSubnetValidatorTxNodeSig(t *testing.T) {
 		expectedErr  error
 	}{
 		"Happy path, LockModeBondDeposit false, VerifyNodeSignature true": {
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-			},
+			}},
 			nodeID:      nodeID1,
 			nodeKey:     nodeKey1,
 			expectedErr: nil,
 		},
 		"NodeId node and signature mismatch, LockModeBondDeposit false, VerifyNodeSignature true": {
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-			},
+			}},
 			nodeID:      nodeID1,
 			nodeKey:     nodeKey2,
 			expectedErr: errKeyMissing,
 		},
 		"NodeId node and signature mismatch, LockModeBondDeposit true, VerifyNodeSignature true": {
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-			},
+			}},
 			nodeID:      nodeID1,
 			nodeKey:     nodeKey2,
 			expectedErr: errKeyMissing,
@@ -173,8 +174,10 @@ func TestCaminoBuilderNewAddSubnetValidatorTxNodeSig(t *testing.T) {
 
 func TestUnlockDepositTx(t *testing.T) {
 	caminoGenesisConf := api.Camino{
-		VerifyNodeSignature: true,
-		LockModeBondDeposit: true,
+		Config: config.CaminoGenesisConfig{
+			VerifyNodeSignature: true,
+			LockModeBondDeposit: true,
+		},
 		DepositOffers: []*deposits.Offer{{
 			UnlockPeriodDuration:  60,
 			InterestRateNominator: 0,
@@ -271,7 +274,7 @@ func TestUnlockDepositTx(t *testing.T) {
 }
 
 func TestNewClaimRewardTx(t *testing.T) {
-	caminoConfig := &state.CaminoConfig{
+	caminoConfig := &config.CaminoGenesisConfig{
 		LockModeBondDeposit: true,
 	}
 

--- a/vms/platformvm/txs/executor/camino_chain_event.go
+++ b/vms/platformvm/txs/executor/camino_chain_event.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 )
 
@@ -30,16 +31,16 @@ func GetNextChainEventTime(state state.Chain, stakerChangeTime time.Time) (time.
 	validatorsRewardTime := getNextValidatorsRewardTime(
 		uint64(state.GetTimestamp().Unix()),
 		cfg.CaminoConfig.ValidatorsRewardPeriod,
+		caminoConfig.ValidatorRewardsStartTime,
 	)
 
-	if stakerChangeTime.Before(validatorsRewardTime) ||
-		uint64(validatorsRewardTime.Unix()) < caminoConfig.ValidatorRewardsStartTime {
+	if stakerChangeTime.Before(validatorsRewardTime) {
 		return stakerChangeTime, nil
 	}
 
 	return validatorsRewardTime, nil
 }
 
-func getNextValidatorsRewardTime(chainTime uint64, validatorsRewardPeriod uint64) time.Time {
-	return time.Unix(int64(chainTime-chainTime%validatorsRewardPeriod+validatorsRewardPeriod), 0)
+func getNextValidatorsRewardTime(chainTime, rewardPeriod, rewardStartTime uint64) time.Time {
+	return time.Unix(int64(math.Max(chainTime-chainTime%rewardPeriod+rewardPeriod, rewardStartTime)), 0)
 }

--- a/vms/platformvm/txs/executor/camino_chain_event.go
+++ b/vms/platformvm/txs/executor/camino_chain_event.go
@@ -22,12 +22,18 @@ func GetNextChainEventTime(state state.Chain, stakerChangeTime time.Time) (time.
 		return stakerChangeTime, nil
 	}
 
+	caminoConfig, err := state.CaminoConfig()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("couldn't get camino config: %w", err)
+	}
+
 	validatorsRewardTime := getNextValidatorsRewardTime(
 		uint64(state.GetTimestamp().Unix()),
 		cfg.CaminoConfig.ValidatorsRewardPeriod,
 	)
 
-	if stakerChangeTime.Before(validatorsRewardTime) {
+	if stakerChangeTime.Before(validatorsRewardTime) ||
+		uint64(validatorsRewardTime.Unix()) < caminoConfig.ValidatorRewardsStartTime {
 		return stakerChangeTime, nil
 	}
 

--- a/vms/platformvm/txs/executor/camino_state_changes.go
+++ b/vms/platformvm/txs/executor/camino_state_changes.go
@@ -88,9 +88,15 @@ func caminoAdvanceTimeTo(
 		return nil
 	}
 
+	caminoConfig, err := parentState.CaminoConfig()
+	if err != nil {
+		return err
+	}
+
 	nextValidatorsRewardTime := getNextValidatorsRewardTime(
 		uint64(parentState.GetTimestamp().Unix()),
 		backend.Config.CaminoConfig.ValidatorsRewardPeriod,
+		caminoConfig.ValidatorRewardsStartTime,
 	)
 
 	if !nextValidatorsRewardTime.After(newChainTime) {

--- a/vms/platformvm/txs/executor/camino_state_changes_test.go
+++ b/vms/platformvm/txs/executor/camino_state_changes_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 func TestCaminoAdvanceTimeTo(t *testing.T) {
-	caminoGenesisConf := api.Camino{
+	caminoGenesisConf := api.Camino{Config: config.CaminoGenesisConfig{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-	}
+	}}
 	caminoVMConfig := config.CaminoConfig{
 		ValidatorsRewardPeriod: 10,
 	}

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/golang/mock/gomock"
 
@@ -34,10 +35,10 @@ import (
 )
 
 func TestCaminoEnv(t *testing.T) {
-	caminoGenesisConf := api.Camino{
+	caminoGenesisConf := api.Camino{Config: config.CaminoGenesisConfig{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-	}
+	}}
 	env := newCaminoEnvironment( /*postBanff*/ false, true, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
@@ -48,10 +49,10 @@ func TestCaminoEnv(t *testing.T) {
 }
 
 func TestCaminoStandardTxExecutorAddValidatorTx(t *testing.T) {
-	caminoGenesisConf := api.Camino{
+	caminoGenesisConf := api.Camino{Config: config.CaminoGenesisConfig{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-	}
+	}}
 	env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
@@ -292,10 +293,10 @@ func TestCaminoStandardTxExecutorAddValidatorTx(t *testing.T) {
 }
 
 func TestCaminoStandardTxExecutorAddSubnetValidatorTx(t *testing.T) {
-	caminoGenesisConf := api.Camino{
+	caminoGenesisConf := api.Camino{Config: config.CaminoGenesisConfig{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-	}
+	}}
 	env := newCaminoEnvironment( /*postBanff*/ true, true, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
@@ -574,10 +575,10 @@ func TestCaminoStandardTxExecutorAddSubnetValidatorTx(t *testing.T) {
 }
 
 func TestCaminoStandardTxExecutorAddValidatorTxBody(t *testing.T) {
-	caminoGenesisConf := api.Camino{
+	caminoGenesisConf := api.Camino{Config: config.CaminoGenesisConfig{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-	}
+	}}
 	env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
 	env.ctx.Lock.Lock()
 	defer func() {
@@ -754,10 +755,10 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			},
 			ins:         []*avax.TransferableInput{},
 			expectedErr: locked.ErrWrongOutType,
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-			},
+			}},
 		},
 		"Locked in - LockModeBondDeposit: true": {
 			outs: []*avax.TransferableOutput{},
@@ -765,10 +766,10 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 				generateTestIn(ids.ID{}, defaultCaminoValidatorWeight, ids.GenerateTestID(), ids.Empty, sigIndices),
 			},
 			expectedErr: locked.ErrWrongInType,
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-			},
+			}},
 		},
 		"Locked out - LockModeBondDeposit: false": {
 			outs: []*avax.TransferableOutput{
@@ -776,10 +777,10 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			},
 			ins:         []*avax.TransferableInput{},
 			expectedErr: locked.ErrWrongOutType,
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-			},
+			}},
 		},
 		"Locked in - LockModeBondDeposit: false": {
 			outs: []*avax.TransferableOutput{},
@@ -787,10 +788,10 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 				generateTestIn(ids.ID{}, defaultCaminoValidatorWeight, ids.GenerateTestID(), ids.Empty, sigIndices),
 			},
 			expectedErr: locked.ErrWrongInType,
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-			},
+			}},
 		},
 		"Stakeable out - LockModeBondDeposit: true": {
 			outs: []*avax.TransferableOutput{
@@ -798,10 +799,10 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			},
 			ins:         []*avax.TransferableInput{},
 			expectedErr: locked.ErrWrongOutType,
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-			},
+			}},
 		},
 		"Stakeable in - LockModeBondDeposit: true": {
 			outs: []*avax.TransferableOutput{},
@@ -809,10 +810,10 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 				generateTestStakeableIn(avaxAssetID, defaultCaminoValidatorWeight, uint64(defaultMinStakingDuration), sigIndices),
 			},
 			expectedErr: locked.ErrWrongInType,
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-			},
+			}},
 		},
 		"Stakeable out - LockModeBondDeposit: false": {
 			outs: []*avax.TransferableOutput{
@@ -820,10 +821,10 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 			},
 			ins:         []*avax.TransferableInput{},
 			expectedErr: locked.ErrWrongOutType,
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-			},
+			}},
 		},
 		"Stakeable in - LockModeBondDeposit: false": {
 			outs: []*avax.TransferableOutput{},
@@ -831,10 +832,10 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 				generateTestStakeableIn(avaxAssetID, defaultCaminoValidatorWeight, uint64(defaultMinStakingDuration), sigIndices),
 			},
 			expectedErr: locked.ErrWrongInType,
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-			},
+			}},
 		},
 	}
 
@@ -1125,10 +1126,10 @@ func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
 		expectedErr  error
 	}{
 		"Happy path, LockModeBondDeposit false, VerifyNodeSignature true": {
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-			},
+			}},
 			nodeID:  nodeID1,
 			nodeKey: nodeKey1,
 			utxos: []*avax.UTXO{
@@ -1143,10 +1144,10 @@ func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
 			expectedErr: nil,
 		},
 		"NodeId node and signature mismatch, LockModeBondDeposit false, VerifyNodeSignature true": {
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: false,
-			},
+			}},
 			nodeID:  nodeID1,
 			nodeKey: nodeKey2,
 			utxos: []*avax.UTXO{
@@ -1161,10 +1162,10 @@ func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
 			expectedErr: errNodeSignatureMissing,
 		},
 		"NodeId node and signature mismatch, LockModeBondDeposit true, VerifyNodeSignature true": {
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
-			},
+			}},
 			nodeID:  nodeID1,
 			nodeKey: nodeKey2,
 			utxos: []*avax.UTXO{
@@ -1176,10 +1177,10 @@ func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
 			expectedErr: errNodeSignatureMissing,
 		},
 		"Inputs and credentials mismatch, LockModeBondDeposit true, VerifyNodeSignature false": {
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: false,
 				LockModeBondDeposit: true,
-			},
+			}},
 			nodeID:  nodeID1,
 			nodeKey: nodeKey2,
 			utxos: []*avax.UTXO{
@@ -1191,10 +1192,10 @@ func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
 			expectedErr: errUnauthorizedSubnetModification,
 		},
 		"Inputs and credentials mismatch, LockModeBondDeposit false, VerifyNodeSignature false": {
-			caminoConfig: api.Camino{
+			caminoConfig: api.Camino{Config: config.CaminoGenesisConfig{
 				VerifyNodeSignature: false,
 				LockModeBondDeposit: false,
-			},
+			}},
 			nodeID:  nodeID1,
 			nodeKey: nodeKey1,
 			utxos: []*avax.UTXO{
@@ -1277,8 +1278,10 @@ func TestCaminoAddSubnetValidatorTxNodeSig(t *testing.T) {
 
 func TestCaminoRewardValidatorTx(t *testing.T) {
 	caminoGenesisConf := api.Camino{
-		VerifyNodeSignature: true,
-		LockModeBondDeposit: true,
+		Config: config.CaminoGenesisConfig{
+			VerifyNodeSignature: true,
+			LockModeBondDeposit: true,
+		},
 	}
 
 	env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
@@ -1555,8 +1558,10 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 	)
 
 	caminoGenesisConf := api.Camino{
-		VerifyNodeSignature: true,
-		LockModeBondDeposit: true,
+		Config: config.CaminoGenesisConfig{
+			VerifyNodeSignature: true,
+			LockModeBondDeposit: true,
+		},
 	}
 
 	env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
@@ -1823,9 +1828,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 	}{
 		"Wrong lockModeBondDeposit flag": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: false,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: false,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos:          []*avax.UTXO{},
 			generateIns:    noInputs,
@@ -1835,9 +1842,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Stakeable ins": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1861,9 +1870,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Stakeable outs": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1886,9 +1897,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Inputs and utxos length mismatch": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1913,9 +1926,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Inputs and credentials length mismatch": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1939,9 +1954,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Not existing deposit offer ID": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -1963,8 +1980,10 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Deposit is not active yet": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
 				DepositOffers: []*deposits.Offer{{
 					InterestRateNominator:   0,
 					Start:                   uint64(currentTime.Add(+60 * time.Hour).Unix()),
@@ -1998,8 +2017,10 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Deposit offer has expired": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
 				DepositOffers: []*deposits.Offer{{
 					InterestRateNominator:   0,
 					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
@@ -2033,8 +2054,10 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Deposit's duration is too small": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
 				DepositOffers: []*deposits.Offer{{
 					InterestRateNominator:   0,
 					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
@@ -2068,8 +2091,10 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Deposit's duration is too big": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
 				DepositOffers: []*deposits.Offer{{
 					InterestRateNominator:   0,
 					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
@@ -2103,8 +2128,10 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Deposit's amount is too small": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
 				DepositOffers: []*deposits.Offer{{
 					InterestRateNominator:   0,
 					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
@@ -2138,9 +2165,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"No fee burning": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, existingTxID),
@@ -2163,9 +2192,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Deposit already deposited amount": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
@@ -2190,9 +2221,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Deposit amount of not owned utxos": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, dummyOutputOwners, ids.Empty, ids.Empty),
@@ -2216,9 +2249,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Not enough balance to deposit": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoValidatorWeight, outputOwners, ids.Empty, ids.Empty),
@@ -2242,8 +2277,10 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Supply overflow": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
 				DepositOffers: []*deposits.Offer{{
 					InterestRateNominator:   1000 * units.MegaAvax,
 					Start:                   uint64(currentTime.Add(-60 * time.Hour).Unix()),
@@ -2277,9 +2314,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Happy path deposit unlocked": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2303,9 +2342,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Happy path deposit unlocked, fee change to new address": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance+10, outputOwners, ids.Empty, ids.Empty),
@@ -2330,9 +2371,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Happy path deposit bonded": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee, outputOwners, ids.Empty, ids.Empty),
@@ -2357,9 +2400,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Happy path deposit bonded and unlocked": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultTxFee+defaultCaminoValidatorWeight/2, outputOwners, ids.Empty, ids.Empty),
@@ -2385,9 +2430,11 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		},
 		"Happy path, deposited amount transferred to another owner": {
 			caminoGenesisConf: api.Camino{
-				VerifyNodeSignature: true,
-				LockModeBondDeposit: true,
-				DepositOffers:       []*deposits.Offer{testDepositOffer},
+				Config: config.CaminoGenesisConfig{
+					VerifyNodeSignature: true,
+					LockModeBondDeposit: true,
+				},
+				DepositOffers: []*deposits.Offer{testDepositOffer},
 			},
 			utxos: []*avax.UTXO{
 				generateTestUTXO(ids.ID{1}, avaxAssetID, defaultCaminoBalance, outputOwners, ids.Empty, ids.Empty),
@@ -2501,9 +2548,11 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 	require.NoError(t, depositOffer.SetID())
 
 	caminoGenesisConf := api.Camino{
-		VerifyNodeSignature: true,
-		LockModeBondDeposit: true,
-		DepositOffers:       []*deposits.Offer{depositOffer},
+		Config: config.CaminoGenesisConfig{
+			VerifyNodeSignature: true,
+			LockModeBondDeposit: true,
+		},
+		DepositOffers: []*deposits.Offer{depositOffer},
 	}
 
 	deposit := &deposits.Deposit{
@@ -3077,8 +3126,10 @@ func TestCaminoStandardTxExecutorClaimRewardTx(t *testing.T) {
 	timestamp := time.Now()
 
 	caminoGenesisConf := api.Camino{
-		VerifyNodeSignature: true,
-		LockModeBondDeposit: true,
+		Config: config.CaminoGenesisConfig{
+			VerifyNodeSignature: true,
+			LockModeBondDeposit: true,
+		},
 	}
 
 	baseState := func(c *gomock.Controller) *state.MockState {
@@ -3102,7 +3153,7 @@ func TestCaminoStandardTxExecutorClaimRewardTx(t *testing.T) {
 		"Stakeable ins": {
 			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().CaminoConfig().Return(&config.CaminoGenesisConfig{LockModeBondDeposit: true}, nil)
 				return s
 			},
 			ins: []*avax.TransferableInput{
@@ -3113,7 +3164,7 @@ func TestCaminoStandardTxExecutorClaimRewardTx(t *testing.T) {
 		"Stakeable outs": {
 			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().CaminoConfig().Return(&config.CaminoGenesisConfig{LockModeBondDeposit: true}, nil)
 				return s
 			},
 			ins: []*avax.TransferableInput{feeInput},
@@ -3130,7 +3181,7 @@ func TestCaminoStandardTxExecutorClaimRewardTx(t *testing.T) {
 			},
 			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().CaminoConfig().Return(&config.CaminoGenesisConfig{LockModeBondDeposit: true}, nil)
 				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
 				s.EXPECT().GetTimestamp().Return(timestamp)
 				s.EXPECT().GetTx(depositTxID).Return(nil, status.Unknown, database.ErrNotFound)
@@ -3149,7 +3200,7 @@ func TestCaminoStandardTxExecutorClaimRewardTx(t *testing.T) {
 			},
 			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().CaminoConfig().Return(&config.CaminoGenesisConfig{LockModeBondDeposit: true}, nil)
 				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
 				s.EXPECT().GetTimestamp().Return(timestamp)
 				s.EXPECT().GetTx(depositTxID).Return(
@@ -3174,7 +3225,7 @@ func TestCaminoStandardTxExecutorClaimRewardTx(t *testing.T) {
 			},
 			state: func(c *gomock.Controller, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().CaminoConfig().Return(&config.CaminoGenesisConfig{LockModeBondDeposit: true}, nil)
 				s.EXPECT().GetUTXO(feeUTXO.InputID()).Return(feeUTXO, nil)
 				s.EXPECT().GetTimestamp().Return(timestamp)
 				s.EXPECT().GetTx(depositTxID).Return(


### PR DESCRIPTION
## Why this should be merged
We have validator rewards that are collected on C-chain and then exported to P-chain. They are imported every X seconds (defined in vm params) on P-chain from genesis start time. And if the start time is in the past (which is the case), this results in a lot of these import blocks for every X seconds after the start time. This PR fixes this by adding validatorRewardsStartTime value in genesis - reward import will only happen if chaintime is not less, than this value.

This PR also puts camino config values in genesis into a single struct and makes genesis generation use that struct.

## How this works
`GetNextChainEventTime` func will now get camino genesis config and then checks if validatorsRewardTime is before validatorRewardsStartTime. If it is - then it ignores it and returns stakerChangeTime.

## How this was tested
Unit tests for genesis generation