### PR TITLE
TECH-534: Implementation of suspension/reactivation of validators

### DIFF
--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,15 +370,15 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2Xp77XhWks5ByoqyEtGqhu7P7b7ayBgndtBi65N4Zjp9D5VZUb",
+			expectedID: "2VvNJbQdTe3Trkq4oEfsxhRjS7xaV2wbT1FkT4p3SY1KLk3KSX",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "cjJ1mMfD2LMVqyBCj9JsRTyzGKDpDw1uZwQANEAt5JknckhjJ",
+			expectedID: "SFNSB6ng4g4zrkf6HEDMKz2fAmfKmSXVPLDWvZDtUmCh2PcXx",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "2Aq1D2Jo8NDBo9qFft7UEY837yqunjT4gPz7r4dnRcY62kELod",
+			expectedID: "29Qy13d6hKWAmTfZ3nRRYLNw2Q2usHX4FcTXxBi8ZJXE5ToQuK",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/blocks/builder/builder.go
+++ b/vms/platformvm/blocks/builder/builder.go
@@ -405,8 +405,9 @@ func getNextStakerToReward(
 		// validator), it's the next staker we will want to remove with a
 		// RewardValidatorTx rather than an AdvanceTimeTx.
 		if priority != txs.SubnetPermissionedValidatorCurrentPriority {
-			return currentStaker.TxID, chainTimestamp.Equal(currentStaker.EndTime), nil
+			return getNextPendingStakerToRemove(chainTimestamp, chainTimestamp.Equal(currentStaker.EndTime), currentStaker, preferredState)
 		}
 	}
-	return ids.Empty, false, nil
+
+	return getNextPendingStakerToRemove(chainTimestamp, false, &state.Staker{}, preferredState)
 }

--- a/vms/platformvm/blocks/builder/builder_test.go
+++ b/vms/platformvm/blocks/builder/builder_test.go
@@ -291,8 +291,13 @@ func TestGetNextStakerToReward(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			state := tt.stateF(ctrl)
-			txID, shouldReward, err := getNextStakerToReward(tt.timestamp, state)
+			mockState := tt.stateF(ctrl).(*state.MockChain)
+			pendingStakerIter := state.NewMockStakerIterator(ctrl)
+			pendingStakerIter.EXPECT().Next().Return(false).AnyTimes()
+			pendingStakerIter.EXPECT().Release().AnyTimes()
+			mockState.EXPECT().GetPendingStakerIterator().Return(pendingStakerIter, nil).AnyTimes()
+
+			txID, shouldReward, err := getNextStakerToReward(tt.timestamp, mockState)
 			if tt.expectedErr != nil {
 				require.Equal(tt.expectedErr, err)
 				return
@@ -670,13 +675,19 @@ func TestBuildBlock(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
+			parentState := tt.parentStateF(ctrl).(*state.MockChain)
+			pendingStakerIter := state.NewMockStakerIterator(ctrl)
+			pendingStakerIter.EXPECT().Next().Return(false).AnyTimes()
+			pendingStakerIter.EXPECT().Release().AnyTimes()
+			parentState.EXPECT().GetPendingStakerIterator().Return(pendingStakerIter, nil).AnyTimes()
+
 			gotBlk, err := buildBlock(
 				tt.builderF(ctrl),
 				parentID,
 				height,
 				tt.timestamp,
 				tt.forceAdvanceTime,
-				tt.parentStateF(ctrl),
+				parentState,
 			)
 			if tt.expectedErr != nil {
 				require.ErrorIs(err, tt.expectedErr)

--- a/vms/platformvm/blocks/builder/camino_builder.go
+++ b/vms/platformvm/blocks/builder/camino_builder.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package builder
+
+import (
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+)
+
+func getNextPendingStakerToRemove(
+	chainTimestamp time.Time,
+	shouldRewardNextCurrentStaker bool,
+	nextCurrentStaker *state.Staker,
+	preferredState state.Chain,
+) (ids.ID, bool, error) {
+	pendingStakerIterator, err := preferredState.GetPendingStakerIterator()
+	if err != nil {
+		return ids.Empty, false, err
+	}
+	defer pendingStakerIterator.Release()
+
+	if pendingStakerIterator.Next() {
+		pendingStaker := pendingStakerIterator.Value()
+		if shouldRewardNextCurrentStaker && !nextCurrentStaker.EndTime.After(pendingStaker.EndTime) {
+			return nextCurrentStaker.TxID, shouldRewardNextCurrentStaker, nil
+		}
+		return pendingStaker.TxID, chainTimestamp.Equal(pendingStaker.EndTime), nil
+	}
+
+	return nextCurrentStaker.TxID, shouldRewardNextCurrentStaker, nil
+}

--- a/vms/platformvm/blocks/builder/camino_builder_test.go
+++ b/vms/platformvm/blocks/builder/camino_builder_test.go
@@ -1,0 +1,148 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package builder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+)
+
+func TestGetNextStakerToRewardWithTwoIterations(t *testing.T) {
+	type test struct {
+		name                       string
+		timestamp                  time.Time
+		stateF                     func(*gomock.Controller) state.Chain
+		firstExpectedTxID          ids.ID
+		secondExpectedTxID         ids.ID
+		firstExpectedShouldReward  bool
+		secondExpectedShouldReward bool
+		expectedErr                error
+	}
+
+	var (
+		now         = time.Now()
+		currentTxID = ids.GenerateTestID()
+		pendingTxID = ids.GenerateTestID()
+	)
+	tests := []test{
+		{
+			name:      "End time reached for both next current and pending - first reward current and then pending",
+			timestamp: now,
+			stateF: func(ctrl *gomock.Controller) state.Chain {
+				currentStakerIter := state.NewMockStakerIterator(ctrl)
+				pendingStakerIter := state.NewMockStakerIterator(ctrl)
+
+				currentStakerIter.EXPECT().Next().Return(true).AnyTimes()
+				pendingStakerIter.EXPECT().Next().Return(true).AnyTimes()
+				firstCurrentStakerIter := currentStakerIter.EXPECT().Value().Return(&state.Staker{
+					TxID:     currentTxID,
+					Priority: txs.PrimaryNetworkValidatorCurrentPriority,
+					EndTime:  now,
+				})
+				secondCurrentStakerIter := currentStakerIter.EXPECT().Value().Return(&state.Staker{
+					TxID:     currentTxID,
+					Priority: txs.PrimaryNetworkValidatorCurrentPriority,
+					EndTime:  now.Add(1 * time.Hour),
+				})
+				pendingStakerIter.EXPECT().Value().Return(&state.Staker{
+					TxID:     pendingTxID,
+					Priority: txs.PrimaryNetworkValidatorCurrentPriority,
+					EndTime:  now,
+				}).AnyTimes()
+				gomock.InOrder(
+					firstCurrentStakerIter,
+					secondCurrentStakerIter,
+				)
+				currentStakerIter.EXPECT().Release().AnyTimes()
+				pendingStakerIter.EXPECT().Release().AnyTimes()
+
+				s := state.NewMockChain(ctrl)
+				s.EXPECT().GetCurrentStakerIterator().Return(currentStakerIter, nil).AnyTimes()
+				s.EXPECT().GetPendingStakerIterator().Return(pendingStakerIter, nil).AnyTimes()
+
+				return s
+			},
+			firstExpectedTxID:          currentTxID,
+			secondExpectedTxID:         pendingTxID,
+			firstExpectedShouldReward:  true,
+			secondExpectedShouldReward: true,
+		},
+		{
+			name:      "End time reached only for pending - reward pending and then nothing",
+			timestamp: now,
+			stateF: func(ctrl *gomock.Controller) state.Chain {
+				currentStakerIter := state.NewMockStakerIterator(ctrl)
+				pendingStakerIter := state.NewMockStakerIterator(ctrl)
+
+				currentStakerIter.EXPECT().Next().Return(true).AnyTimes()
+				pendingStakerIter.EXPECT().Next().Return(true).AnyTimes()
+				currentStakerIter.EXPECT().Value().Return(&state.Staker{
+					TxID:     currentTxID,
+					Priority: txs.PrimaryNetworkValidatorCurrentPriority,
+					EndTime:  now.Add(1 * time.Hour),
+				}).AnyTimes()
+				firstPendingStakerIter := pendingStakerIter.EXPECT().Value().Return(&state.Staker{
+					TxID:     pendingTxID,
+					Priority: txs.PrimaryNetworkValidatorCurrentPriority,
+					EndTime:  now,
+				})
+				secondPendingStakerIter := pendingStakerIter.EXPECT().Value().Return(&state.Staker{
+					TxID:     pendingTxID,
+					Priority: txs.PrimaryNetworkValidatorCurrentPriority,
+					EndTime:  now.Add(1 * time.Hour),
+				})
+				gomock.InOrder(
+					firstPendingStakerIter,
+					secondPendingStakerIter,
+				)
+				currentStakerIter.EXPECT().Release().AnyTimes()
+				pendingStakerIter.EXPECT().Release().AnyTimes()
+
+				s := state.NewMockChain(ctrl)
+				s.EXPECT().GetCurrentStakerIterator().Return(currentStakerIter, nil).AnyTimes()
+				s.EXPECT().GetPendingStakerIterator().Return(pendingStakerIter, nil).AnyTimes()
+
+				return s
+			},
+			firstExpectedTxID:          pendingTxID,
+			secondExpectedTxID:         pendingTxID,
+			firstExpectedShouldReward:  true,
+			secondExpectedShouldReward: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			state := tt.stateF(ctrl)
+			txID, shouldReward, err := getNextStakerToReward(tt.timestamp, state)
+			if tt.expectedErr != nil {
+				require.Equal(tt.expectedErr, err)
+				return
+			}
+			require.NoError(err)
+			require.Equal(tt.firstExpectedTxID, txID)
+			require.Equal(tt.firstExpectedShouldReward, shouldReward)
+
+			txID, shouldReward, err = getNextStakerToReward(tt.timestamp, state)
+			if tt.expectedErr != nil {
+				require.ErrorIs(err, tt.expectedErr)
+				return
+			}
+			require.NoError(err)
+			require.Equal(tt.secondExpectedTxID, txID)
+			require.Equal(tt.secondExpectedShouldReward, shouldReward)
+		})
+	}
+}

--- a/vms/platformvm/camino_service_test.go
+++ b/vms/platformvm/camino_service_test.go
@@ -170,7 +170,7 @@ func TestGetCaminoBalance(t *testing.T) {
 }
 
 func defaultCaminoService(t *testing.T, camino api.Camino, utxos []api.UTXO) *CaminoService {
-	vm, _, _ := newCaminoVM(camino, utxos)
+	vm := newCaminoVM(camino, utxos)
 
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -1,0 +1,343 @@
+// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package platformvm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/json"
+	"github.com/ava-labs/avalanchego/utils/nodeid"
+	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+	"github.com/ava-labs/avalanchego/vms/platformvm/status"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	smcon "github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	blockexecutor "github.com/ava-labs/avalanchego/vms/platformvm/blocks/executor"
+	txexecutor "github.com/ava-labs/avalanchego/vms/platformvm/txs/executor"
+)
+
+func TestRewardSuspendedValidator(t *testing.T) {
+	require := require.New(t)
+	addr := caminoPreFundedKeys[0].Address()
+	hrp := constants.NetworkIDToHRP[testNetworkID]
+	bech32Addr, err := address.FormatBech32(hrp, addr.Bytes())
+	require.NoError(err)
+
+	nodeKey, nodeID := nodeid.GenerateCaminoNodeKeyAndID()
+	nodeAddress := nodeKey.PublicKey().Address()
+
+	outputOwners := &secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{addr},
+	}
+	caminoGenesisConf := api.Camino{
+		VerifyNodeSignature: true,
+		LockModeBondDeposit: true,
+		InitialAdmin:        addr,
+	}
+	genesisUTXOs := []api.UTXO{
+		{
+			Amount:  json.Uint64(defaultCaminoValidatorWeight),
+			Address: bech32Addr,
+		},
+	}
+
+	vm := newCaminoVM(caminoGenesisConf, genesisUTXOs)
+	vm.ctx.Lock.Lock()
+	defer func() {
+		require.NoError(vm.Shutdown(context.Background()))
+		vm.ctx.Lock.Unlock()
+	}()
+
+	// Add the validator
+	vm.state.SetShortIDLink(ids.ShortID(nodeID), state.ShortLinkKeyRegisterNode, &addr)
+	startTime := vm.clock.Time().Add(txexecutor.SyncBound).Add(1 * time.Second)
+	endTime := defaultValidateEndTime.Add(-1 * time.Hour)
+	addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
+		vm.Config.MinValidatorStake,
+		uint64(startTime.Unix()),
+		uint64(endTime.Unix()),
+		nodeID,
+		ids.ShortEmpty,
+		reward.PercentDenominator,
+		[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], nodeKey},
+		ids.ShortEmpty,
+	)
+	require.NoError(err)
+
+	staker, err := state.NewCurrentStaker(
+		addValidatorTx.ID(),
+		addValidatorTx.Unsigned.(*txs.CaminoAddValidatorTx),
+		0,
+	)
+	require.NoError(err)
+	vm.state.PutCurrentValidator(staker)
+	vm.state.AddTx(addValidatorTx, status.Committed)
+	err = vm.state.Commit()
+	require.NoError(err)
+
+	utxo := generateTestUTXO(ids.GenerateTestID(), avaxAssetID, defaultBalance, *outputOwners, ids.Empty, ids.Empty)
+	vm.state.AddUTXO(utxo)
+	err = vm.state.Commit()
+	require.NoError(err)
+
+	// Suspend the validator
+	tx, err := vm.txBuilder.NewAddressStateTx(
+		nodeAddress,
+		false,
+		txs.AddressStateNodeDeferred,
+		[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0]},
+		outputOwners,
+	)
+	require.NoError(err)
+	err = vm.Builder.AddUnverifiedTx(tx)
+	require.NoError(err)
+	blk, err := vm.Builder.BuildBlock(context.Background())
+	require.NoError(err)
+	err = blk.Verify(context.Background())
+	require.NoError(err)
+	err = blk.Accept(context.Background())
+	require.NoError(err)
+	err = vm.SetPreference(context.Background(), vm.manager.LastAccepted())
+	require.NoError(err)
+
+	// Verify that the validator is suspended (moved from current to pending stakers set)
+	_, err = vm.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(err, database.ErrNotFound)
+	_, err = vm.state.GetPendingValidator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(err)
+
+	// Fast-forward clock to time for validator to be rewarded
+	vm.clock.Set(endTime)
+	blk, err = vm.Builder.BuildBlock(context.Background())
+	require.NoError(err)
+	err = blk.Verify(context.Background())
+	require.NoError(err)
+
+	// Assert preferences are correct
+	block := blk.(smcon.OracleBlock)
+	options, err := block.Options(context.Background())
+	require.NoError(err)
+
+	commit := options[1].(*blockexecutor.Block)
+	_, ok := commit.Block.(*blocks.BanffCommitBlock)
+	require.True(ok)
+
+	abort := options[0].(*blockexecutor.Block)
+	_, ok = abort.Block.(*blocks.BanffAbortBlock)
+	require.True(ok)
+
+	require.NoError(block.Accept(context.Background()))
+	require.NoError(commit.Verify(context.Background()))
+	require.NoError(abort.Verify(context.Background()))
+
+	txID := blk.(blocks.Block).Txs()[0].ID()
+	{
+		onAccept, ok := vm.manager.GetState(abort.ID())
+		require.True(ok)
+
+		_, txStatus, err := onAccept.GetTx(txID)
+		require.NoError(err)
+		require.Equal(status.Aborted, txStatus)
+	}
+
+	require.NoError(commit.Accept(context.Background()))
+	require.NoError(vm.SetPreference(context.Background(), vm.manager.LastAccepted()))
+
+	_, txStatus, err := vm.state.GetTx(txID)
+	require.NoError(err)
+	require.Equal(status.Committed, txStatus)
+
+	// Verify that the validator is rewarded
+	_, err = vm.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(err, database.ErrNotFound)
+	_, err = vm.state.GetPendingValidator(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(err, database.ErrNotFound)
+
+	timestamp := vm.state.GetTimestamp()
+	require.Equal(endTime.Unix(), timestamp.Unix())
+}
+
+func TestRewardReactivatedValidator(t *testing.T) {
+	require := require.New(t)
+	addr := caminoPreFundedKeys[0].Address()
+	hrp := constants.NetworkIDToHRP[testNetworkID]
+	bech32Addr, err := address.FormatBech32(hrp, addr.Bytes())
+	require.NoError(err)
+
+	nodeKey, nodeID := nodeid.GenerateCaminoNodeKeyAndID()
+	nodeAddress := nodeKey.PublicKey().Address()
+
+	outputOwners := &secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{addr},
+	}
+	caminoGenesisConf := api.Camino{
+		VerifyNodeSignature: true,
+		LockModeBondDeposit: true,
+		InitialAdmin:        addr,
+	}
+	genesisUTXOs := []api.UTXO{
+		{
+			Amount:  json.Uint64(defaultCaminoValidatorWeight),
+			Address: bech32Addr,
+		},
+	}
+
+	vm := newCaminoVM(caminoGenesisConf, genesisUTXOs)
+	vm.ctx.Lock.Lock()
+	defer func() {
+		require.NoError(vm.Shutdown(context.Background()))
+		vm.ctx.Lock.Unlock()
+	}()
+
+	// Add the validator
+	vm.state.SetShortIDLink(ids.ShortID(nodeID), state.ShortLinkKeyRegisterNode, &addr)
+	startTime := vm.clock.Time().Add(txexecutor.SyncBound).Add(1 * time.Second)
+	endTime := defaultValidateEndTime.Add(-1 * time.Hour)
+	addValidatorTx, err := vm.txBuilder.NewAddValidatorTx(
+		vm.Config.MinValidatorStake,
+		uint64(startTime.Unix()),
+		uint64(endTime.Unix()),
+		nodeID,
+		ids.ShortEmpty,
+		reward.PercentDenominator,
+		[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], nodeKey},
+		ids.ShortEmpty,
+	)
+	require.NoError(err)
+
+	staker, err := state.NewCurrentStaker(
+		addValidatorTx.ID(),
+		addValidatorTx.Unsigned.(*txs.CaminoAddValidatorTx),
+		0,
+	)
+	require.NoError(err)
+	vm.state.PutCurrentValidator(staker)
+	vm.state.AddTx(addValidatorTx, status.Committed)
+	err = vm.state.Commit()
+	require.NoError(err)
+
+	utxo := generateTestUTXO(ids.GenerateTestID(), avaxAssetID, defaultBalance, *outputOwners, ids.Empty, ids.Empty)
+	vm.state.AddUTXO(utxo)
+	err = vm.state.Commit()
+	require.NoError(err)
+
+	// Suspend the validator
+	tx, err := vm.txBuilder.NewAddressStateTx(
+		nodeAddress,
+		false,
+		txs.AddressStateNodeDeferred,
+		[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0]},
+		outputOwners,
+	)
+	require.NoError(err)
+	err = vm.Builder.AddUnverifiedTx(tx)
+	require.NoError(err)
+	blk, err := vm.Builder.BuildBlock(context.Background())
+	require.NoError(err)
+	err = blk.Verify(context.Background())
+	require.NoError(err)
+	err = blk.Accept(context.Background())
+	require.NoError(err)
+	err = vm.SetPreference(context.Background(), vm.manager.LastAccepted())
+	require.NoError(err)
+
+	// Verify that the validator is suspended (moved from current to pending stakers set)
+	_, err = vm.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(err, database.ErrNotFound)
+	_, err = vm.state.GetPendingValidator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(err)
+
+	// Reactivate the validator
+	tx, err = vm.txBuilder.NewAddressStateTx(
+		nodeAddress,
+		true,
+		txs.AddressStateNodeDeferred,
+		[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0]},
+		outputOwners,
+	)
+	require.NoError(err)
+	err = vm.Builder.AddUnverifiedTx(tx)
+	require.NoError(err)
+	blk, err = vm.Builder.BuildBlock(context.Background())
+	require.NoError(err)
+	err = blk.Verify(context.Background())
+	require.NoError(err)
+	err = blk.Accept(context.Background())
+	require.NoError(err)
+	err = vm.SetPreference(context.Background(), vm.manager.LastAccepted())
+	require.NoError(err)
+
+	// Verify that the validator is activated again (moved from pending to current stakers set)
+	_, err = vm.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.NoError(err)
+	_, err = vm.state.GetPendingValidator(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(err, database.ErrNotFound)
+
+	// Fast-forward clock to time for validator to be rewarded
+	vm.clock.Set(endTime)
+	blk, err = vm.Builder.BuildBlock(context.Background())
+	require.NoError(err)
+	err = blk.Verify(context.Background())
+	require.NoError(err)
+
+	// Assert preferences are correct
+	block := blk.(smcon.OracleBlock)
+	options, err := block.Options(context.Background())
+	require.NoError(err)
+
+	commit := options[1].(*blockexecutor.Block)
+	_, ok := commit.Block.(*blocks.BanffCommitBlock)
+	require.True(ok)
+
+	abort := options[0].(*blockexecutor.Block)
+	_, ok = abort.Block.(*blocks.BanffAbortBlock)
+	require.True(ok)
+
+	require.NoError(block.Accept(context.Background()))
+	require.NoError(commit.Verify(context.Background()))
+	require.NoError(abort.Verify(context.Background()))
+
+	txID := blk.(blocks.Block).Txs()[0].ID()
+	{
+		onAccept, ok := vm.manager.GetState(abort.ID())
+		require.True(ok)
+
+		_, txStatus, err := onAccept.GetTx(txID)
+		require.NoError(err)
+		require.Equal(status.Aborted, txStatus)
+	}
+
+	require.NoError(commit.Accept(context.Background()))
+	require.NoError(vm.SetPreference(context.Background(), vm.manager.LastAccepted()))
+
+	_, txStatus, err := vm.state.GetTx(txID)
+	require.NoError(err)
+	require.Equal(status.Committed, txStatus)
+
+	// Verify that the validator is rewarded
+	_, err = vm.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(err, database.ErrNotFound)
+	_, err = vm.state.GetPendingValidator(constants.PrimaryNetworkID, nodeID)
+	require.ErrorIs(err, database.ErrNotFound)
+
+	timestamp := vm.state.GetTimestamp()
+	require.Equal(endTime.Unix(), timestamp.Unix())
+}

--- a/vms/platformvm/txs/camino_address_state_tx.go
+++ b/vms/platformvm/txs/camino_address_state_tx.go
@@ -20,15 +20,19 @@ const (
 	AddressStateRoleBits     = uint64(0b11)
 
 	AddressStateKycVerified    = uint8(32)
-	AddressStateKycVerifiedBit = uint64(0b00100000000000000000000000000000000)
+	AddressStateKycVerifiedBit = uint64(0b0100000000000000000000000000000000)
 	AddressStateKycExpired     = uint8(33)
-	AddressStateKycExpiredBit  = uint64(0b01000000000000000000000000000000000)
-	AddressStateConsortium     = uint8(34)
-	AddressStateConsortiumBit  = uint64(0b10000000000000000000000000000000000)
-	AddressStateKycBits        = uint64(0b11100000000000000000000000000000000)
+	AddressStateKycExpiredBit  = uint64(0b1000000000000000000000000000000000)
+	AddressStateKycBits        = uint64(0b1100000000000000000000000000000000)
+
+	AddressStateConsortium      = uint8(38)
+	AddressStateConsortiumBit   = uint64(0b0100000000000000000000000000000000000000)
+	AddressStateNodeDeferred    = uint8(39)
+	AddressStateNodeDeferredBit = uint64(0b1000000000000000000000000000000000000000)
+	AddressStateVoteBits        = uint64(0b1100000000000000000000000000000000000000)
 
 	AddressStateMax       = uint8(63)
-	AddressStateValidBits = AddressStateRoleBits | AddressStateKycBits
+	AddressStateValidBits = AddressStateRoleBits | AddressStateKycBits | AddressStateVoteBits
 )
 
 var (

--- a/vms/platformvm/txs/executor/camino_advance_time_test.go
+++ b/vms/platformvm/txs/executor/camino_advance_time_test.go
@@ -1,0 +1,389 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package executor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+
+	"github.com/ava-labs/avalanchego/utils/nodeid"
+
+	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
+
+	"github.com/ava-labs/avalanchego/vms/platformvm/api"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/vms/platformvm/state"
+	"github.com/ava-labs/avalanchego/vms/platformvm/status"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+)
+
+func TestDeferredStakers(t *testing.T) {
+	type stakerStatus uint
+	const (
+		pending stakerStatus = iota
+		current
+		expired
+	)
+
+	type staker struct {
+		nodeID                          ids.NodeID
+		nodeKey                         *crypto.PrivateKeySECP256K1R
+		startTime, endTime, suspendTime time.Time
+	}
+	type test struct {
+		description           string
+		stakers               []staker
+		subnetStakers         []staker
+		suspendedStakers      []staker
+		advanceTimeTo         []time.Time
+		expectedStakers       map[ids.NodeID]stakerStatus
+		expectedSubnetStakers map[ids.NodeID]stakerStatus
+	}
+
+	// Chronological order (not in scale):
+	// Staker1:    			|----------------------------------------------------------|
+	// Staker2:        			|------------------------|
+	// Staker3:            			|------------------------|
+	// Staker3sub:             			|----------------|
+	// staker4:                                 		 |---|
+	// staker5Suspended	        |---|--------------------|
+
+	nodeIDs := make([]ids.NodeID, 6)
+	nodeKeys := make([]*crypto.PrivateKeySECP256K1R, 6)
+	for i := range [6]int{} {
+		nodeKeys[i], nodeIDs[i] = nodeid.GenerateCaminoNodeKeyAndID()
+	}
+
+	staker1 := staker{
+		nodeID:    nodeIDs[0],
+		nodeKey:   nodeKeys[0],
+		startTime: defaultGenesisTime.Add(1 * time.Minute),
+		endTime:   defaultGenesisTime.Add(10 * defaultMinStakingDuration).Add(1 * time.Minute),
+	}
+	staker2 := staker{
+		nodeID:    nodeIDs[1],
+		nodeKey:   nodeKeys[1],
+		startTime: staker1.startTime.Add(1 * time.Minute),
+		endTime:   staker1.startTime.Add(1 * time.Minute).Add(defaultMinStakingDuration),
+	}
+	staker3 := staker{
+		nodeID:    nodeIDs[2],
+		nodeKey:   nodeKeys[2],
+		startTime: staker2.startTime.Add(1 * time.Minute),
+		endTime:   staker2.endTime.Add(1 * time.Minute),
+	}
+	staker3Sub := staker{
+		nodeID:    nodeIDs[2],
+		nodeKey:   nodeKeys[2],
+		startTime: staker3.startTime.Add(1 * time.Minute),
+		endTime:   staker3.endTime.Add(-1 * time.Minute),
+	}
+	staker4 := staker{
+		nodeID:    nodeIDs[4],
+		nodeKey:   nodeKeys[4],
+		startTime: staker2.endTime,
+		endTime:   staker3.endTime,
+	}
+	staker5 := staker{
+		nodeID:      nodeIDs[5],
+		nodeKey:     nodeKeys[5],
+		startTime:   staker2.startTime,
+		endTime:     staker2.endTime,
+		suspendTime: staker3.startTime,
+	}
+
+	tests := []test{
+		{
+			description:   "Staker 5 still in pending set",
+			stakers:       []staker{staker1, staker2, staker3, staker4, staker5},
+			subnetStakers: []staker{staker1, staker2, staker3, staker4, staker5},
+			advanceTimeTo: []time.Time{staker1.startTime.Add(-1 * time.Second)},
+			expectedStakers: map[ids.NodeID]stakerStatus{
+				staker1.nodeID: pending,
+				staker2.nodeID: pending,
+				staker3.nodeID: pending,
+				staker4.nodeID: pending,
+				staker5.nodeID: pending,
+			},
+			expectedSubnetStakers: map[ids.NodeID]stakerStatus{
+				staker1.nodeID: pending,
+				staker2.nodeID: pending,
+				staker3.nodeID: pending,
+				staker4.nodeID: pending,
+				staker5.nodeID: pending,
+			},
+		},
+		{
+			description:      "Staker 5 in current set",
+			stakers:          []staker{staker1, staker2, staker3, staker4, staker5},
+			suspendedStakers: []staker{staker5},
+			advanceTimeTo:    []time.Time{staker1.startTime, staker2.startTime},
+			expectedStakers: map[ids.NodeID]stakerStatus{
+				staker1.nodeID: current,
+				staker2.nodeID: current,
+				staker3.nodeID: pending,
+				staker4.nodeID: pending,
+				staker5.nodeID: current,
+			},
+		},
+		{
+			description:      "Staker 5 suspended but still validating subnet",
+			stakers:          []staker{staker1, staker2, staker3, staker4, staker5},
+			subnetStakers:    []staker{staker1, staker2, staker3Sub, staker4, staker5},
+			suspendedStakers: []staker{staker5},
+			advanceTimeTo:    []time.Time{staker1.startTime, staker2.startTime, staker3.startTime},
+			expectedStakers: map[ids.NodeID]stakerStatus{
+				staker1.nodeID: current,
+				staker2.nodeID: current,
+				staker3.nodeID: current,
+				staker4.nodeID: pending,
+				staker5.nodeID: pending,
+			},
+			expectedSubnetStakers: map[ids.NodeID]stakerStatus{
+				staker1.nodeID: current,
+				staker2.nodeID: current,
+				staker3.nodeID: pending,
+				staker4.nodeID: pending,
+				staker5.nodeID: current,
+			},
+		},
+		{
+			description:      "Staker 5 expired",
+			stakers:          []staker{staker1, staker2, staker3, staker4, staker5},
+			subnetStakers:    []staker{staker1, staker2, staker3Sub, staker4, staker5},
+			suspendedStakers: []staker{staker5},
+			advanceTimeTo:    []time.Time{staker1.startTime, staker2.startTime, staker3.startTime, staker3Sub.startTime, staker5.endTime},
+			expectedStakers: map[ids.NodeID]stakerStatus{
+				staker1.nodeID: current,
+				staker2.nodeID: current,
+				staker3.nodeID: current,
+				staker4.nodeID: current,
+				staker5.nodeID: pending,
+			},
+			expectedSubnetStakers: map[ids.NodeID]stakerStatus{
+				staker1.nodeID: current,
+				staker2.nodeID: expired,
+				staker3.nodeID: expired,
+				staker4.nodeID: current,
+				staker5.nodeID: expired,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(ts *testing.T) {
+			require := require.New(ts)
+			caminoGenesisConf := api.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+			}
+			env := newCaminoEnvironment( /*postBanff*/ true, true, caminoGenesisConf, nil)
+			env.ctx.Lock.Lock()
+			defer func() {
+				if err := shutdownCaminoEnvironment(env); err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			dummyHeight := uint64(1)
+
+			subnetID := testSubnet1.ID()
+			env.config.WhitelistedSubnets.Add(subnetID)
+			env.config.Validators.Add(subnetID, validators.NewSet())
+
+			for _, staker := range test.stakers {
+				_, err := addCaminoPendingValidator(
+					env,
+					staker.startTime,
+					staker.endTime,
+					staker.nodeID,
+					[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], staker.nodeKey},
+				)
+				require.NoError(err)
+			}
+
+			for _, staker := range test.subnetStakers {
+				tx, err := env.txBuilder.NewAddSubnetValidatorTx(
+					10, // Weight
+					uint64(staker.startTime.Unix()),
+					uint64(staker.endTime.Unix()),
+					staker.nodeID, // validator ID
+					subnetID,      // Subnet ID
+					[]*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0], caminoPreFundedKeys[1], staker.nodeKey},
+					ids.ShortEmpty,
+				)
+				require.NoError(err)
+
+				staker, err := state.NewPendingStaker(
+					tx.ID(),
+					tx.Unsigned.(*txs.AddSubnetValidatorTx),
+				)
+				require.NoError(err)
+
+				env.state.PutPendingValidator(staker)
+				env.state.AddTx(tx, status.Committed)
+			}
+			env.state.SetHeight(dummyHeight)
+			require.NoError(env.state.Commit())
+
+			for _, newTime := range test.advanceTimeTo {
+				env.clk.Set(newTime)
+				tx, err := env.txBuilder.NewAdvanceTimeTx(newTime)
+				require.NoError(err)
+
+				onCommitState, err := state.NewDiff(lastAcceptedID, env)
+				require.NoError(err)
+
+				onAbortState, err := state.NewDiff(lastAcceptedID, env)
+				require.NoError(err)
+
+				executor := ProposalTxExecutor{
+					OnCommitState: onCommitState,
+					OnAbortState:  onAbortState,
+					Backend:       &env.backend,
+					Tx:            tx,
+				}
+				require.NoError(tx.Unsigned.Visit(&executor))
+				executor.OnCommitState.Apply(env.state)
+
+				env.state.SetHeight(dummyHeight)
+				require.NoError(env.state.Commit())
+
+				for _, staker := range test.suspendedStakers {
+					if newTime == staker.suspendTime {
+						_, err = suspendValidator(env, ids.ShortID(staker.nodeID), caminoPreFundedKeys[0])
+						require.NoError(err)
+					}
+				}
+			}
+
+			for stakerNodeID, status := range test.expectedStakers {
+				switch status {
+				case pending:
+					_, err := env.state.GetPendingValidator(constants.PrimaryNetworkID, stakerNodeID)
+					require.NoError(err)
+					require.False(validators.Contains(env.config.Validators, constants.PrimaryNetworkID, stakerNodeID))
+				case current:
+					_, err := env.state.GetCurrentValidator(constants.PrimaryNetworkID, stakerNodeID)
+					require.NoError(err)
+					require.True(validators.Contains(env.config.Validators, constants.PrimaryNetworkID, stakerNodeID))
+				case expired:
+					_, err := env.state.GetCurrentValidator(constants.PrimaryNetworkID, stakerNodeID)
+					require.Error(err)
+					_, err = env.state.GetPendingValidator(constants.PrimaryNetworkID, stakerNodeID)
+					require.Error(err)
+				}
+			}
+
+			for stakerNodeID, status := range test.expectedSubnetStakers {
+				switch status {
+				case pending:
+					_, err := env.state.GetPendingValidator(subnetID, stakerNodeID)
+					require.NoError(err)
+					require.False(validators.Contains(env.config.Validators, subnetID, stakerNodeID))
+				case current:
+					_, err := env.state.GetCurrentValidator(subnetID, stakerNodeID)
+					require.NoError(err)
+					require.True(validators.Contains(env.config.Validators, subnetID, stakerNodeID))
+				case expired:
+					_, err := env.state.GetCurrentValidator(subnetID, stakerNodeID)
+					require.Error(err)
+					_, err = env.state.GetPendingValidator(subnetID, stakerNodeID)
+					require.Error(err)
+				}
+			}
+		})
+	}
+}
+
+func addCaminoPendingValidator(
+	env *caminoEnvironment,
+	startTime time.Time,
+	endTime time.Time,
+	nodeID ids.NodeID,
+	keys []*crypto.PrivateKeySECP256K1R,
+) (*txs.Tx, error) {
+	addPendingValidatorTx, err := env.txBuilder.NewAddValidatorTx(
+		env.config.MinValidatorStake,
+		uint64(startTime.Unix()),
+		uint64(endTime.Unix()),
+		nodeID,
+		ids.ShortID(nodeID),
+		reward.PercentDenominator,
+		keys,
+		ids.ShortEmpty,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	staker, err := state.NewPendingStaker(
+		addPendingValidatorTx.ID(),
+		addPendingValidatorTx.Unsigned.(*txs.CaminoAddValidatorTx),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	env.state.PutPendingValidator(staker)
+	env.state.AddTx(addPendingValidatorTx, status.Committed)
+	dummyHeight := uint64(1)
+	env.state.SetHeight(dummyHeight)
+	if err := env.state.Commit(); err != nil {
+		return nil, err
+	}
+	return addPendingValidatorTx, nil
+}
+
+func suspendValidator(env *caminoEnvironment, nodeAddress ids.ShortID, key *crypto.PrivateKeySECP256K1R) (*txs.Tx, error) {
+	outputOwners := &secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{key.Address()},
+	}
+
+	tx, err := env.txBuilder.NewAddressStateTx(
+		nodeAddress,
+		false,
+		txs.AddressStateNodeDeferred,
+		[]*crypto.PrivateKeySECP256K1R{key},
+		outputOwners,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	onAcceptState, err := state.NewDiff(lastAcceptedID, env)
+	if err != nil {
+		return nil, err
+	}
+
+	executor := CaminoStandardTxExecutor{
+		StandardTxExecutor{
+			Backend: &env.backend,
+			State:   onAcceptState,
+			Tx:      tx,
+		},
+	}
+	err = tx.Unsigned.Visit(&executor)
+	if err != nil {
+		return nil, err
+	}
+
+	executor.State.Apply(env.state)
+
+	if err := env.state.Commit(); err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ava-labs/avalanchego/utils/constants"
+
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/golang/mock/gomock"
@@ -3399,6 +3401,130 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedNodeID, ids.NodeID(registeredNode))
 			}
+		})
+	}
+}
+
+func TestCaminoStandardTxExecutorSuspendValidator(t *testing.T) {
+	addr := caminoPreFundedKeys[0].Address()
+	nodeAddress := caminoPreFundedNodeKeys[0].Address()
+	outputOwners := &secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{addr},
+	}
+
+	type args struct {
+		address    ids.ShortID
+		remove     bool
+		keys       []*crypto.PrivateKeySECP256K1R
+		changeAddr *secp256k1fx.OutputOwners
+	}
+	tests := map[string]struct {
+		generateArgs func() args
+		preExecute   func(*testing.T, *txs.Tx, state.State)
+		expectedErr  error
+		assert       func(*testing.T)
+	}{
+		"Happy path set state to deferred": {
+			generateArgs: func() args {
+				return args{
+					address:    nodeAddress,
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0]},
+					changeAddr: outputOwners,
+				}
+			},
+			preExecute:  func(t *testing.T, tx *txs.Tx, state state.State) {},
+			expectedErr: nil,
+		},
+		"Happy path set state to active": {
+			generateArgs: func() args {
+				return args{
+					address:    nodeAddress,
+					remove:     true,
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0]},
+					changeAddr: outputOwners,
+				}
+			},
+			preExecute: func(t *testing.T, tx *txs.Tx, state state.State) {
+				stakerToTransfer, err := state.GetCurrentValidator(constants.PrimaryNetworkID, ids.NodeID(nodeAddress))
+				require.NoError(t, err)
+				state.DeleteCurrentValidator(stakerToTransfer)
+				stakerToTransfer.StartTime = stakerToTransfer.EndTime
+				state.PutPendingValidator(stakerToTransfer)
+			},
+			expectedErr: nil,
+		},
+		"Remove deferred state of an active validator": {
+			generateArgs: func() args {
+				return args{
+					address:    nodeAddress,
+					remove:     true,
+					keys:       []*crypto.PrivateKeySECP256K1R{caminoPreFundedKeys[0]},
+					changeAddr: outputOwners,
+				}
+			},
+			preExecute:  func(t *testing.T, tx *txs.Tx, state state.State) {},
+			expectedErr: errValidatorNotFound,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			caminoGenesisConf := api.Camino{
+				VerifyNodeSignature: true,
+				LockModeBondDeposit: true,
+				InitialAdmin:        addr,
+			}
+			env := newCaminoEnvironment( /*postBanff*/ true, false, caminoGenesisConf, nil)
+			env.ctx.Lock.Lock()
+			defer func() {
+				if err := shutdownCaminoEnvironment(env); err != nil {
+					t.Fatal(err)
+				}
+			}()
+
+			env.config.BanffTime = env.state.GetTimestamp()
+			require.NoError(t, env.state.Commit())
+
+			setAddressStateArgs := tt.generateArgs()
+			tx, err := env.txBuilder.NewAddressStateTx(
+				setAddressStateArgs.address,
+				setAddressStateArgs.remove,
+				txs.AddressStateNodeDeferred,
+				setAddressStateArgs.keys,
+				setAddressStateArgs.changeAddr,
+			)
+			require.NoError(t, err)
+
+			tt.preExecute(t, tx, env.state)
+			onAcceptState, err := state.NewDiff(lastAcceptedID, env)
+			require.NoError(t, err)
+
+			executor := CaminoStandardTxExecutor{
+				StandardTxExecutor{
+					Backend: &env.backend,
+					State:   onAcceptState,
+					Tx:      tx,
+				},
+			}
+
+			err = tx.Unsigned.Visit(&executor)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+				return
+			}
+			var stakerIterator state.StakerIterator
+			if setAddressStateArgs.remove {
+				stakerIterator, err = onAcceptState.GetCurrentStakerIterator()
+				require.NoError(t, err)
+			} else {
+				stakerIterator, err = onAcceptState.GetPendingStakerIterator()
+				require.NoError(t, err)
+			}
+			require.True(t, stakerIterator.Next())
+			stakerToRemove := stakerIterator.Value()
+			stakerIterator.Release()
+			require.Equal(t, stakerToRemove.NodeID, ids.NodeID(setAddressStateArgs.address))
 		})
 	}
 }

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -141,6 +141,9 @@ func AdvanceTimeTo(
 		if stakerToRemove.StartTime.After(newChainTime) {
 			break
 		}
+		if stakerToRemove.EndTime.Equal(stakerToRemove.StartTime) {
+			continue
+		}
 
 		stakerToAdd := *stakerToRemove
 		stakerToAdd.NextTime = stakerToRemove.EndTime


### PR DESCRIPTION
## Description ##
This PR adds a new functionality in `addressStateTx` in order to set state for an already existing validator. Currently there are two states (active, suspended). If the validator is active and the admin chooses to suspend it, the validator is being moved from the current validators set to the pending ones by setting its `startTime` equal to its `endTime`. If the admin chooses to make it active, its returned back to the current validators set. 

More details can be found in [this](https://c4t.atlassian.net/browse/TECH-322) epic.   

## Changes ##
- Implemented the new states on addressStateTx's executor.
- Added the functionality of removing validators from the pending set at their end time with the `rewardValidatorTx`.
- Prohibited the transfer of pending to the current set of the suspended validators at their end time.
- Added tests. 