### PR TITLE
Fix evaluation if a node is linked

### DIFF
--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -786,7 +786,7 @@ func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error 
 
 	linkedNodeID, err := e.State.GetShortIDLink(tx.ConsortiumMemberAddress, state.ShortLinkKeyRegisterNode)
 	haslinkedNode := err != database.ErrNotFound
-	if err != nil {
+	if haslinkedNode && err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Why this should be merged
The current verification if an address has a nodeID linked fails with an error if there is no node yet.
This causes RegisterNode to not work as expected
