### PR TITLE
[PVM] bugfix for loop closure issue when registering shortidlinks for…

### DIFF
--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -287,6 +287,7 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 	// adding consortium member nodes
 
 	for _, consortiumMemberNode := range g.Camino.ConsortiumMembersNodeIDs {
+		consortiumMemberNode := consortiumMemberNode
 		cs.SetShortIDLink(
 			ids.ShortID(consortiumMemberNode.NodeID),
 			ShortLinkKeyRegisterNode,


### PR DESCRIPTION
## Why this should be merged
Fixes the for loop closure which makes all nodes to appear registered under the same address.

## How this works
The getRegisteredShortIDLink API returns the same owner for all nodes when using the for example the genesis.json from the Camino Network runner. The issue is caused by the for loop closure on the variable consortiumMemberNode.
The fix introduces a local variable inside the for loop which shadows the "original" one.

## How this was tested
By using the getRegisteredShortIDLink API.
eg 
``curl -X POST --data '{
  "jsonrpc":"2.0",
  "id"     : 1,
  "method" :"platform.getRegisteredShortIDLink",
  "params" :{
      "address":"NodeID-PM2LqrGsxudhZSP49upMonevbQvnvAciv"
  }
}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P | jq
``