### PR TITLE
[PVM] Fixes RewardsImportTx bootstrap error

### DIFF
--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -3556,9 +3556,6 @@ func TestCaminoStandardTxExecutorRewardsImportTx(t *testing.T) {
 				UTXO:      *generateTestUTXO(ids.ID{1}, ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
 				Timestamp: uint64(blockTime.Unix()) - atomic.SharedMemorySyncBound,
 			}},
-			expectedAtomicInputs: func(utxos []*avax.TimedUTXO) set.Set[ids.ID] {
-				return set.Set[ids.ID]{}
-			},
 			expectedErr: errImportedUTXOMissmatch,
 		},
 		"Input & utxo amount missmatch": {
@@ -3587,9 +3584,6 @@ func TestCaminoStandardTxExecutorRewardsImportTx(t *testing.T) {
 				UTXO:      *generateTestUTXO(ids.ID{1}, ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
 				Timestamp: uint64(blockTime.Unix()) - atomic.SharedMemorySyncBound,
 			}},
-			expectedAtomicInputs: func(utxos []*avax.TimedUTXO) set.Set[ids.ID] {
-				return set.Set[ids.ID]{}
-			},
 			expectedErr: errInputAmountMissmatch,
 		},
 		"OK": {


### PR DESCRIPTION
## Why this should be merged
This PR fixes bootstrap error when node tried to verify RewardsImportTx transaction.
## How this works
Executor shouldn't try to get utxos from shared memory while node still bootstraps, cause other chains could be still step behind with bootstrapping. This PR adds check if node is bootstrapped to RewardsImportTx executor, just like ImportTx does.
## How this was tested
Reproduced error by starting new node, applied fix, started node again, see that it finished bootstrapping