### PR TITLE
[PVM] Make RewardsImportTx include BaseTx

### DIFF
--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -576,14 +576,18 @@ func (b *caminoBuilder) NewRewardsImportTx() (*txs.Tx, error) {
 	avax.SortTransferableInputs(ins)
 
 	utx := &txs.RewardsImportTx{
-		ImportedInputs: ins,
-		Out: &avax.TransferableOutput{
-			Asset: avax.Asset{ID: b.ctx.AVAXAssetID},
-			Out: &secp256k1fx.TransferOutput{
-				Amt:          importedAmount,
-				OutputOwners: *treasury.Owner,
-			},
-		},
+		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+			NetworkID:    b.ctx.NetworkID,
+			BlockchainID: b.ctx.ChainID,
+			Ins:          ins,
+			Outs: []*avax.TransferableOutput{{
+				Asset: avax.Asset{ID: b.ctx.AVAXAssetID},
+				Out: &secp256k1fx.TransferOutput{
+					Amt:          importedAmount,
+					OutputOwners: *treasury.Owner,
+				},
+			}},
+		}},
 	}
 	tx, err := txs.NewSigned(utx, txs.Codec, nil)
 	if err != nil {

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -641,14 +641,20 @@ func TestNewRewardsImportTx(t *testing.T) {
 				},
 			},
 			expectedTx: func(t *testing.T, utxos []*avax.TimedUTXO) *txs.Tx {
-				tx, err := txs.NewSigned(&txs.RewardsImportTx{
-					ImportedInputs: []*avax.TransferableInput{
-						generateTestInFromUTXO(&utxos[0].UTXO, []uint32{0}),
-						generateTestInFromUTXO(&utxos[2].UTXO, []uint32{0}),
+				tx, err := txs.NewSigned(&txs.RewardsImportTx{BaseTx: txs.BaseTx{
+					BaseTx: avax.BaseTx{
+						NetworkID:    ctx.NetworkID,
+						BlockchainID: ctx.ChainID,
+						Ins: []*avax.TransferableInput{
+							generateTestInFromUTXO(&utxos[0].UTXO, []uint32{0}),
+							generateTestInFromUTXO(&utxos[2].UTXO, []uint32{0}),
+						},
+						Outs: []*avax.TransferableOutput{
+							generateTestOut(ctx.AVAXAssetID, 101, *treasury.Owner, ids.Empty, ids.Empty),
+						},
 					},
-					Out:                   generateTestOut(ctx.AVAXAssetID, 101, *treasury.Owner, ids.Empty, ids.Empty),
 					SyntacticallyVerified: true,
-				}, txs.Codec, nil)
+				}}, txs.Codec, nil)
 				require.NoError(t, err)
 				return tx
 			},

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -949,11 +949,11 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 
 		// Verifying that utxos match inputs
 
-		if len(tx.ImportedInputs) != len(utxos) {
-			return fmt.Errorf("there are %d inputs and %d utxos: %w", len(tx.ImportedInputs), len(utxos), errInputsUTXOSMismatch)
+		if len(tx.Ins) != len(utxos) {
+			return fmt.Errorf("there are %d inputs and %d utxos: %w", len(tx.Ins), len(utxos), errInputsUTXOSMismatch)
 		}
 
-		for i, in := range tx.ImportedInputs {
+		for i, in := range tx.Ins {
 			utxo := utxos[i]
 
 			if utxo.InputID() != in.InputID() {
@@ -1004,7 +1004,7 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 		return err
 	}
 
-	amountToDistribute, err := math.Add64(tx.Out.Out.Amount(), notDistributedAmount)
+	amountToDistribute, err := math.Add64(tx.Outs[0].Out.Amount(), notDistributedAmount)
 	if err != nil {
 		return err
 	}
@@ -1052,10 +1052,10 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 
 	utxo.Produce(e.State, e.Tx.ID(), outs)
 
-	utxoIDs := make([][]byte, len(tx.ImportedInputs))
-	e.Inputs = set.NewSet[ids.ID](len(tx.ImportedInputs))
-	for i := range tx.ImportedInputs {
-		utxoID := tx.ImportedInputs[i].InputID()
+	utxoIDs := make([][]byte, len(tx.Ins))
+	e.Inputs = set.NewSet[ids.ID](len(tx.Ins))
+	for i := range tx.Ins {
+		utxoID := tx.Ins[i].InputID()
 		e.Inputs.Add(utxoID)
 		utxoIDs[i] = utxoID[:]
 	}

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -3511,13 +3511,17 @@ func TestCaminoStandardTxExecutorRewardsImportTx(t *testing.T) {
 			},
 			sharedMemory: shmWithUTXOs,
 			utx: func(utxos []*avax.TimedUTXO) *txs.RewardsImportTx {
-				return &txs.RewardsImportTx{
-					Out: generateTestOut(ctx.AVAXAssetID, 2, *treasury.Owner, ids.Empty, ids.Empty),
-					ImportedInputs: []*avax.TransferableInput{
+				return &txs.RewardsImportTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Ins: []*avax.TransferableInput{
 						generateTestInFromUTXO(&utxos[0].UTXO, []uint32{0}),
 						generateTestInFromUTXO(&utxos[1].UTXO, []uint32{0}),
 					},
-				}
+					Outs: []*avax.TransferableOutput{
+						generateTestOut(ctx.AVAXAssetID, 2, *treasury.Owner, ids.Empty, ids.Empty),
+					},
+				}}}
 			},
 			utxos: []*avax.TimedUTXO{
 				{
@@ -3545,12 +3549,16 @@ func TestCaminoStandardTxExecutorRewardsImportTx(t *testing.T) {
 			},
 			sharedMemory: shmWithUTXOs,
 			utx: func(utxos []*avax.TimedUTXO) *txs.RewardsImportTx {
-				return &txs.RewardsImportTx{
-					Out: generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-					ImportedInputs: []*avax.TransferableInput{
+				return &txs.RewardsImportTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Ins: []*avax.TransferableInput{
 						generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
 					},
-				}
+					Outs: []*avax.TransferableOutput{
+						generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
+					},
+				}}}
 			},
 			utxos: []*avax.TimedUTXO{{
 				UTXO:      *generateTestUTXO(ids.ID{1}, ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
@@ -3568,9 +3576,10 @@ func TestCaminoStandardTxExecutorRewardsImportTx(t *testing.T) {
 			},
 			sharedMemory: shmWithUTXOs,
 			utx: func(utxos []*avax.TimedUTXO) *txs.RewardsImportTx {
-				return &txs.RewardsImportTx{
-					Out: generateTestOut(ctx.AVAXAssetID, 2, *treasury.Owner, ids.Empty, ids.Empty),
-					ImportedInputs: []*avax.TransferableInput{{
+				return &txs.RewardsImportTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Ins: []*avax.TransferableInput{{
 						UTXOID: utxos[0].UTXOID,
 						Asset:  avax.Asset{ID: ctx.AVAXAssetID},
 						In: &secp256k1fx.TransferInput{
@@ -3578,7 +3587,10 @@ func TestCaminoStandardTxExecutorRewardsImportTx(t *testing.T) {
 							Input: secp256k1fx.Input{SigIndices: []uint32{0}},
 						},
 					}},
-				}
+					Outs: []*avax.TransferableOutput{
+						generateTestOut(ctx.AVAXAssetID, 2, *treasury.Owner, ids.Empty, ids.Empty),
+					},
+				}}}
 			},
 			utxos: []*avax.TimedUTXO{{
 				UTXO:      *generateTestUTXO(ids.ID{1}, ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
@@ -3667,21 +3679,25 @@ func TestCaminoStandardTxExecutorRewardsImportTx(t *testing.T) {
 
 				s.EXPECT().AddUTXO(&avax.UTXO{
 					UTXOID: avax.UTXOID{TxID: txID},
-					Asset:  utx.Out.Asset,
-					Out:    utx.Out.Out,
+					Asset:  utx.Outs[0].Asset,
+					Out:    utx.Outs[0].Out,
 				})
 
 				return s
 			},
 			sharedMemory: shmWithUTXOs,
 			utx: func(utxos []*avax.TimedUTXO) *txs.RewardsImportTx {
-				return &txs.RewardsImportTx{
-					ImportedInputs: []*avax.TransferableInput{
+				return &txs.RewardsImportTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Ins: []*avax.TransferableInput{
 						generateTestInFromUTXO(&utxos[0].UTXO, []uint32{0}),
 						generateTestInFromUTXO(&utxos[2].UTXO, []uint32{0}),
 					},
-					Out: generateTestOut(ctx.AVAXAssetID, 4, *treasury.Owner, ids.Empty, ids.Empty),
-				}
+					Outs: []*avax.TransferableOutput{
+						generateTestOut(ctx.AVAXAssetID, 4, *treasury.Owner, ids.Empty, ids.Empty),
+					},
+				}}}
 			},
 			utxos: []*avax.TimedUTXO{
 				{


### PR DESCRIPTION
## Why this should be merged
This makes RewardImportTx to derive from BaseTx in order to have more consistency with other txs (important for magellan) and include missing fields like blockchainID and networkID.
## How this works
Embed BasedTx into RewardImportTx, update build, syntactic check, execution and tests accordingly. 
## How this was tested
Unit-tests