### PR TITLE
[PVM] Fix nodeID in AddressStateTx validator suspension, use another stakers set for deferred validators

### DIFF
--- a/vms/platformvm/blocks/builder/builder.go
+++ b/vms/platformvm/blocks/builder/builder.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -405,9 +415,9 @@ func getNextStakerToReward(
 		// validator), it's the next staker we will want to remove with a
 		// RewardValidatorTx rather than an AdvanceTimeTx.
 		if priority != txs.SubnetPermissionedValidatorCurrentPriority {
-			return getNextPendingStakerToRemove(chainTimestamp, chainTimestamp.Equal(currentStaker.EndTime), currentStaker, preferredState)
+			return getNextDeferredStakerToRemove(chainTimestamp, chainTimestamp.Equal(currentStaker.EndTime), currentStaker, preferredState)
 		}
 	}
 
-	return getNextPendingStakerToRemove(chainTimestamp, false, &state.Staker{}, preferredState)
+	return getNextDeferredStakerToRemove(chainTimestamp, false, &state.Staker{}, preferredState)
 }

--- a/vms/platformvm/blocks/builder/builder_test.go
+++ b/vms/platformvm/blocks/builder/builder_test.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -292,10 +302,10 @@ func TestGetNextStakerToReward(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockState := tt.stateF(ctrl).(*state.MockChain)
-			pendingStakerIter := state.NewMockStakerIterator(ctrl)
-			pendingStakerIter.EXPECT().Next().Return(false).AnyTimes()
-			pendingStakerIter.EXPECT().Release().AnyTimes()
-			mockState.EXPECT().GetPendingStakerIterator().Return(pendingStakerIter, nil).AnyTimes()
+			deferredStakerIter := state.NewMockStakerIterator(ctrl)
+			deferredStakerIter.EXPECT().Next().Return(false).AnyTimes()
+			deferredStakerIter.EXPECT().Release().AnyTimes()
+			mockState.EXPECT().GetDeferredStakerIterator().Return(deferredStakerIter, nil).AnyTimes()
 
 			txID, shouldReward, err := getNextStakerToReward(tt.timestamp, mockState)
 			if tt.expectedErr != nil {
@@ -676,10 +686,10 @@ func TestBuildBlock(t *testing.T) {
 			defer ctrl.Finish()
 
 			parentState := tt.parentStateF(ctrl).(*state.MockChain)
-			pendingStakerIter := state.NewMockStakerIterator(ctrl)
-			pendingStakerIter.EXPECT().Next().Return(false).AnyTimes()
-			pendingStakerIter.EXPECT().Release().AnyTimes()
-			parentState.EXPECT().GetPendingStakerIterator().Return(pendingStakerIter, nil).AnyTimes()
+			deferredStakerIter := state.NewMockStakerIterator(ctrl)
+			deferredStakerIter.EXPECT().Next().Return(false).AnyTimes()
+			deferredStakerIter.EXPECT().Release().AnyTimes()
+			parentState.EXPECT().GetDeferredStakerIterator().Return(deferredStakerIter, nil).AnyTimes()
 
 			gotBlk, err := buildBlock(
 				tt.builderF(ctrl),

--- a/vms/platformvm/blocks/builder/camino_builder.go
+++ b/vms/platformvm/blocks/builder/camino_builder.go
@@ -53,24 +53,24 @@ func CaminoNew(
 	return builder
 }
 
-func getNextPendingStakerToRemove(
+func getNextDeferredStakerToRemove(
 	chainTimestamp time.Time,
 	shouldRewardNextCurrentStaker bool,
 	nextCurrentStaker *state.Staker,
 	preferredState state.Chain,
 ) (ids.ID, bool, error) {
-	pendingStakerIterator, err := preferredState.GetPendingStakerIterator()
+	deferredStakerIterator, err := preferredState.GetDeferredStakerIterator()
 	if err != nil {
 		return ids.Empty, false, err
 	}
-	defer pendingStakerIterator.Release()
+	defer deferredStakerIterator.Release()
 
-	if pendingStakerIterator.Next() {
-		pendingStaker := pendingStakerIterator.Value()
-		if shouldRewardNextCurrentStaker && !nextCurrentStaker.EndTime.After(pendingStaker.EndTime) {
+	if deferredStakerIterator.Next() {
+		deferredStaker := deferredStakerIterator.Value()
+		if shouldRewardNextCurrentStaker && !nextCurrentStaker.EndTime.After(deferredStaker.EndTime) {
 			return nextCurrentStaker.TxID, shouldRewardNextCurrentStaker, nil
 		}
-		return pendingStaker.TxID, chainTimestamp.Equal(pendingStaker.EndTime), nil
+		return deferredStaker.TxID, chainTimestamp.Equal(deferredStaker.EndTime), nil
 	}
 
 	return nextCurrentStaker.TxID, shouldRewardNextCurrentStaker, nil

--- a/vms/platformvm/blocks/executor/proposal_block_test.go
+++ b/vms/platformvm/blocks/executor/proposal_block_test.go
@@ -252,6 +252,11 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	pendingStakersIt.EXPECT().Release().AnyTimes()
 	onParentAccept.EXPECT().GetPendingStakerIterator().Return(pendingStakersIt, nil).AnyTimes()
 
+	deferredStakersIt := state.NewMockStakerIterator(ctrl)
+	deferredStakersIt.EXPECT().Next().Return(false).AnyTimes() // no deferred stakers
+	deferredStakersIt.EXPECT().Release().AnyTimes()
+	onParentAccept.EXPECT().GetDeferredStakerIterator().Return(deferredStakersIt, nil).AnyTimes()
+
 	env.mockedState.EXPECT().GetUptime(gomock.Any(), gomock.Any()).Return(
 		time.Duration(1000), /*upDuration*/
 		time.Time{},         /*lastUpdated*/

--- a/vms/platformvm/blocks/executor/standard_block_test.go
+++ b/vms/platformvm/blocks/executor/standard_block_test.go
@@ -158,6 +158,12 @@ func TestBanffStandardBlockTimeVerification(t *testing.T) {
 	pendingIt.EXPECT().Release().Return().AnyTimes()
 	onParentAccept.EXPECT().GetPendingStakerIterator().Return(pendingIt, nil).AnyTimes()
 
+	// no deferred stakers
+	deferredStakersIt := state.NewMockStakerIterator(ctrl)
+	deferredStakersIt.EXPECT().Next().Return(false).AnyTimes()
+	deferredStakersIt.EXPECT().Release().AnyTimes()
+	onParentAccept.EXPECT().GetDeferredStakerIterator().Return(deferredStakersIt, nil).AnyTimes()
+
 	onParentAccept.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 
 	txID := ids.GenerateTestID()

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/formatting"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/math"
-	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/keystore"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
@@ -476,13 +475,10 @@ func (s *CaminoService) RegisterNode(_ *http.Request, args *RegisterNodeArgs, re
 
 	reply.TxID = tx.ID()
 
-	errs := wrappers.Errs{}
-	errs.Add(
-		err,
-		s.vm.Builder.AddUnverifiedTx(tx),
-	)
-
-	return errs.Err
+	if err = s.vm.Builder.AddUnverifiedTx(tx); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *CaminoService) GetRegisteredShortIDLink(_ *http.Request, args *api.JSONAddress, response *api.JSONAddress) error {

--- a/vms/platformvm/state/camino_deposit_test.go
+++ b/vms/platformvm/state/camino_deposit_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package state
 
 import (
@@ -5,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -19,6 +23,8 @@ import (
 
 func TestGetDeposit(t *testing.T) {
 	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
+	baseDB := versiondb.New(baseDBManager.Current().Database)
+	validatorsDB := prefixdb.New(validatorsPrefix, baseDB)
 	addr0 := ids.GenerateTestShortID()
 	addresses := set.NewSet[ids.ShortID](0)
 	addresses.Add(addr0)
@@ -41,7 +47,7 @@ func TestGetDeposit(t *testing.T) {
 	}{
 		"retrieve from modified state": {
 			cs: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				return cs
 			}(),
 			args: args{
@@ -54,7 +60,7 @@ func TestGetDeposit(t *testing.T) {
 		},
 		"retrieve from modified state when deposit already in db": {
 			cs: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				return cs
 			}(),
 			args: args{
@@ -71,7 +77,7 @@ func TestGetDeposit(t *testing.T) {
 		},
 		"retrieval fails when deposit already in modified state but with nil value even if present in db": {
 			cs: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				return cs
 			}(),
 			args: args{
@@ -88,7 +94,7 @@ func TestGetDeposit(t *testing.T) {
 		},
 		"retrieve from cache": {
 			cs: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				return cs
 			}(),
 			args: args{
@@ -102,7 +108,7 @@ func TestGetDeposit(t *testing.T) {
 		},
 		"retrieve from cache when deposit already in db": {
 			cs: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				return cs
 			}(),
 			args: args{
@@ -120,7 +126,7 @@ func TestGetDeposit(t *testing.T) {
 		},
 		"retrieve from db": {
 			cs: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				return cs
 			}(),
 			args: args{
@@ -135,7 +141,7 @@ func TestGetDeposit(t *testing.T) {
 		},
 		"db retrieval failed": {
 			cs: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				return cs
 			}(),
 			args: args{
@@ -162,6 +168,8 @@ func TestGetDeposit(t *testing.T) {
 
 func TestWriteDeposits(t *testing.T) {
 	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
+	baseDB := versiondb.New(baseDBManager.Current().Database)
+	validatorsDB := prefixdb.New(validatorsPrefix, baseDB)
 	addr0 := ids.GenerateTestShortID()
 	addresses := set.NewSet[ids.ShortID](0)
 	addresses.Add(addr0)
@@ -181,7 +189,7 @@ func TestWriteDeposits(t *testing.T) {
 	}{
 		"Deposit nil / success db deletion": {
 			prepareFunc: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				cs.modifiedDeposits[testID] = nil
 				return cs
 			},
@@ -189,7 +197,7 @@ func TestWriteDeposits(t *testing.T) {
 		},
 		"Deposit nil / error in db deletion": {
 			prepareFunc: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				cs.modifiedDeposits[testID] = nil
 				cs.depositsDB.Close() // close db connection to cause error on deletion
 				return cs
@@ -198,7 +206,7 @@ func TestWriteDeposits(t *testing.T) {
 		},
 		"Success": {
 			prepareFunc: func() CaminoState {
-				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())
+				cs, _ := newCaminoState(versiondb.New(baseDBManager.Current().Database), validatorsDB, prometheus.NewRegistry())
 				cs.modifiedDeposits[testID] = &deposit1
 				return cs
 			},

--- a/vms/platformvm/state/camino_stakers.go
+++ b/vms/platformvm/state/camino_stakers.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/database"
+
+	"github.com/ava-labs/avalanchego/database/linkeddb"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
+)
+
+func (cs *caminoState) GetDeferredValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker, error) {
+	return cs.deferredStakers.GetValidator(subnetID, nodeID)
+}
+
+func (cs *caminoState) PutDeferredValidator(staker *Staker) {
+	cs.deferredStakers.PutValidator(staker)
+}
+
+func (cs *caminoState) DeleteDeferredValidator(staker *Staker) {
+	cs.deferredStakers.DeleteValidator(staker)
+}
+
+func (cs *caminoState) GetDeferredStakerIterator() (StakerIterator, error) {
+	return cs.deferredStakers.GetStakerIterator(), nil
+}
+
+func (cs *caminoState) loadDeferredValidators(s *state) error {
+	cs.deferredStakers = newBaseStakers()
+
+	validatorIt := cs.deferredValidatorList.NewIterator()
+	defer validatorIt.Release()
+
+	for _, validatorIt := range []database.Iterator{validatorIt} {
+		for validatorIt.Next() {
+			txIDBytes := validatorIt.Key()
+			txID, err := ids.ToID(txIDBytes)
+			if err != nil {
+				return err
+			}
+			tx, _, err := s.GetTx(txID)
+			if err != nil {
+				return err
+			}
+
+			stakerTx, ok := tx.Unsigned.(txs.Staker)
+			if !ok {
+				return fmt.Errorf("expected tx type txs.Staker but got %T", tx.Unsigned)
+			}
+
+			staker, err := NewCurrentStaker(txID, stakerTx, 0)
+			if err != nil {
+				return err
+			}
+
+			validator := cs.deferredStakers.getOrCreateValidator(staker.SubnetID, staker.NodeID)
+			validator.validator = staker
+
+			cs.deferredStakers.stakers.ReplaceOrInsert(staker)
+		}
+	}
+
+	return validatorIt.Error()
+}
+
+func (cs *caminoState) writeDeferredStakers() error {
+	for subnetID, subnetValidatorDiffs := range cs.deferredStakers.validatorDiffs {
+		delete(cs.deferredStakers.validatorDiffs, subnetID)
+
+		validatorDB := cs.deferredValidatorList
+
+		for _, validatorDiff := range subnetValidatorDiffs {
+			err := writeDeferredDiff(
+				validatorDB,
+				validatorDiff,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeDeferredDiff(
+	deferredValidatorList linkeddb.LinkedDB,
+	validatorDiff *diffValidator,
+) error {
+	if validatorDiff.validatorModified {
+		staker := validatorDiff.validator
+
+		var err error
+		if validatorDiff.validatorDeleted {
+			err = deferredValidatorList.Delete(staker.TxID[:])
+		} else {
+			err = deferredValidatorList.Put(staker.TxID[:], nil)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to update deferred validator: %w", err)
+		}
+	}
+	return nil
+}

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -106,3 +106,19 @@ func (s *state) SetNotDistributedValidatorReward(reward uint64) {
 func (s *state) GetNotDistributedValidatorReward() (uint64, error) {
 	return s.caminoState.GetNotDistributedValidatorReward()
 }
+
+func (s *state) GetDeferredValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker, error) {
+	return s.caminoState.GetDeferredValidator(subnetID, nodeID)
+}
+
+func (s *state) PutDeferredValidator(staker *Staker) {
+	s.caminoState.PutDeferredValidator(staker)
+}
+
+func (s *state) DeleteDeferredValidator(staker *Staker) {
+	s.caminoState.DeleteDeferredValidator(staker)
+}
+
+func (s *state) GetDeferredStakerIterator() (StakerIterator, error) {
+	return s.caminoState.GetDeferredStakerIterator()
+}

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	root_genesis "github.com/ava-labs/avalanchego/genesis"
 	"github.com/ava-labs/avalanchego/ids"
@@ -169,6 +170,8 @@ func TestSyncGenesis(t *testing.T) {
 	defer ctrl.Finish()
 	s, _ := newInitializedState(require)
 	baseDBManager := db_manager.NewMemDB(version.Semantic1_0_0)
+	baseDB := versiondb.New(baseDBManager.Current().Database)
+	validatorsDB := prefixdb.New(validatorsPrefix, baseDB)
 
 	var (
 		id           = ids.GenerateTestID()
@@ -254,7 +257,7 @@ func TestSyncGenesis(t *testing.T) {
 					},
 				}, depositTxs, initialAdmin),
 			},
-			cs: *wrappers.IgnoreError(newCaminoState(versiondb.New(baseDBManager.Current().Database), prometheus.NewRegistry())).(*caminoState),
+			cs: *wrappers.IgnoreError(newCaminoState(baseDB, validatorsDB, prometheus.NewRegistry())).(*caminoState),
 			want: caminoDiff{
 				modifiedAddressStates: map[ids.ShortID]uint64{initialAdmin: txs.AddressStateRoleAdminBit, shortID: txs.AddressStateRoleKycBit},
 				modifiedDepositOffers: map[ids.ID]*deposit.Offer{

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -8,6 +8,9 @@
 package state
 
 import (
+	reflect "reflect"
+	time "time"
+
 	ids "github.com/ava-labs/avalanchego/ids"
 	set "github.com/ava-labs/avalanchego/utils/set"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
@@ -18,8 +21,6 @@ import (
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	time "time"
 )
 
 // MockChain is a mock of Chain interface.
@@ -442,6 +443,60 @@ func (m *MockChain) GetPendingValidator(arg0 ids.ID, arg1 ids.NodeID) (*Staker, 
 func (mr *MockChainMockRecorder) GetPendingValidator(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockChain)(nil).GetPendingValidator), arg0, arg1)
+}
+
+// GetDeferredStakerIterator mocks base method.
+func (m *MockChain) GetDeferredStakerIterator() (StakerIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeferredStakerIterator")
+	ret0, _ := ret[0].(StakerIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeferredStakerIterator indicates an expected call of GetDeferredStakerIterator.
+func (mr *MockChainMockRecorder) GetDeferredStakerIterator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeferredStakerIterator", reflect.TypeOf((*MockChain)(nil).GetDeferredStakerIterator))
+}
+
+// GetDeferredValidator mocks base method.
+func (m *MockChain) GetDeferredValidator(arg0 ids.ID, arg1 ids.NodeID) (*Staker, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeferredValidator", arg0, arg1)
+	ret0, _ := ret[0].(*Staker)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeferredValidator indicates an expected call of GetDeferredValidator.
+func (mr *MockChainMockRecorder) GetDeferredValidator(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeferredValidator", reflect.TypeOf((*MockChain)(nil).GetDeferredValidator), arg0, arg1)
+}
+
+// DeleteDeferredValidator mocks base method.
+func (m *MockChain) DeleteDeferredValidator(arg0 *Staker) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteDeferredValidator", arg0)
+}
+
+// DeleteDeferredValidator indicates an expected call of DeleteDeferredValidator.
+func (mr *MockChainMockRecorder) DeleteDeferredValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDeferredValidator", reflect.TypeOf((*MockChain)(nil).DeleteDeferredValidator), arg0)
+}
+
+// PutDeferredValidator mocks base method.
+func (m *MockChain) PutDeferredValidator(arg0 *Staker) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PutDeferredValidator", arg0)
+}
+
+// PutDeferredValidator indicates an expected call of PutDeferredValidator.
+func (mr *MockChainMockRecorder) PutDeferredValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDeferredValidator", reflect.TypeOf((*MockChain)(nil).PutDeferredValidator), arg0)
 }
 
 // GetRewardUTXOs mocks base method.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -8,6 +8,9 @@
 package state
 
 import (
+	reflect "reflect"
+	time "time"
+
 	ids "github.com/ava-labs/avalanchego/ids"
 	set "github.com/ava-labs/avalanchego/utils/set"
 	avax "github.com/ava-labs/avalanchego/vms/components/avax"
@@ -18,8 +21,6 @@ import (
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	time "time"
 )
 
 // MockDiff is a mock of Diff interface.
@@ -466,6 +467,60 @@ func (m *MockDiff) GetPendingValidator(arg0 ids.ID, arg1 ids.NodeID) (*Staker, e
 func (mr *MockDiffMockRecorder) GetPendingValidator(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockDiff)(nil).GetPendingValidator), arg0, arg1)
+}
+
+// GetDeferredStakerIterator mocks base method.
+func (m *MockDiff) GetDeferredStakerIterator() (StakerIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeferredStakerIterator")
+	ret0, _ := ret[0].(StakerIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeferredStakerIterator indicates an expected call of GetDeferredStakerIterator.
+func (mr *MockDiffMockRecorder) GetDeferredStakerIterator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeferredStakerIterator", reflect.TypeOf((*MockDiff)(nil).GetDeferredStakerIterator))
+}
+
+// GetDeferredValidator mocks base method.
+func (m *MockDiff) GetDeferredValidator(arg0 ids.ID, arg1 ids.NodeID) (*Staker, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeferredValidator", arg0, arg1)
+	ret0, _ := ret[0].(*Staker)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeferredValidator indicates an expected call of GetDeferredValidator.
+func (mr *MockDiffMockRecorder) GetDeferredValidator(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeferredValidator", reflect.TypeOf((*MockDiff)(nil).GetDeferredValidator), arg0, arg1)
+}
+
+// DeleteDeferredValidator mocks base method.
+func (m *MockDiff) DeleteDeferredValidator(arg0 *Staker) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteDeferredValidator", arg0)
+}
+
+// DeleteDeferredValidator indicates an expected call of DeleteDeferredValidator.
+func (mr *MockDiffMockRecorder) DeleteDeferredValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDeferredValidator", reflect.TypeOf((*MockDiff)(nil).DeleteDeferredValidator), arg0)
+}
+
+// PutDeferredValidator mocks base method.
+func (m *MockDiff) PutDeferredValidator(arg0 *Staker) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PutDeferredValidator", arg0)
+}
+
+// PutDeferredValidator indicates an expected call of PutDeferredValidator.
+func (mr *MockDiffMockRecorder) PutDeferredValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDeferredValidator", reflect.TypeOf((*MockDiff)(nil).PutDeferredValidator), arg0)
 }
 
 // GetRewardUTXOs mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -8,6 +8,9 @@
 package state
 
 import (
+	reflect "reflect"
+	time "time"
+
 	database "github.com/ava-labs/avalanchego/database"
 	ids "github.com/ava-labs/avalanchego/ids"
 	choices "github.com/ava-labs/avalanchego/snow/choices"
@@ -22,8 +25,6 @@ import (
 	status "github.com/ava-labs/avalanchego/vms/platformvm/status"
 	txs "github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	time "time"
 )
 
 // MockState is a mock of State interface.
@@ -527,6 +528,60 @@ func (m *MockState) GetPendingValidator(arg0 ids.ID, arg1 ids.NodeID) (*Staker, 
 func (mr *MockStateMockRecorder) GetPendingValidator(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingValidator", reflect.TypeOf((*MockState)(nil).GetPendingValidator), arg0, arg1)
+}
+
+// GetDeferredStakerIterator mocks base method.
+func (m *MockState) GetDeferredStakerIterator() (StakerIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeferredStakerIterator")
+	ret0, _ := ret[0].(StakerIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeferredStakerIterator indicates an expected call of GetDeferredStakerIterator.
+func (mr *MockStateMockRecorder) GetDeferredStakerIterator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeferredStakerIterator", reflect.TypeOf((*MockState)(nil).GetDeferredStakerIterator))
+}
+
+// GetDeferredValidator mocks base method.
+func (m *MockState) GetDeferredValidator(arg0 ids.ID, arg1 ids.NodeID) (*Staker, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeferredValidator", arg0, arg1)
+	ret0, _ := ret[0].(*Staker)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeferredValidator indicates an expected call of GetDeferredValidator.
+func (mr *MockStateMockRecorder) GetDeferredValidator(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeferredValidator", reflect.TypeOf((*MockState)(nil).GetDeferredValidator), arg0, arg1)
+}
+
+// DeleteDeferredValidator mocks base method.
+func (m *MockState) DeleteDeferredValidator(arg0 *Staker) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteDeferredValidator", arg0)
+}
+
+// DeleteDeferredValidator indicates an expected call of DeleteDeferredValidator.
+func (mr *MockStateMockRecorder) DeleteDeferredValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDeferredValidator", reflect.TypeOf((*MockState)(nil).DeleteDeferredValidator), arg0)
+}
+
+// PutDeferredValidator mocks base method.
+func (m *MockState) PutDeferredValidator(arg0 *Staker) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PutDeferredValidator", arg0)
+}
+
+// PutDeferredValidator indicates an expected call of PutDeferredValidator.
+func (mr *MockStateMockRecorder) PutDeferredValidator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDeferredValidator", reflect.TypeOf((*MockState)(nil).PutDeferredValidator), arg0)
 }
 
 // GetRewardUTXOs mocks base method.

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -493,7 +493,7 @@ func new(
 		return nil, err
 	}
 
-	caminoState, err := newCaminoState(baseDB, metricsReg)
+	caminoState, err := newCaminoState(baseDB, validatorsDB, metricsReg)
 	if err != nil {
 		return nil, err
 	}
@@ -1066,7 +1066,7 @@ func (s *state) load() error {
 		s.loadCurrentValidators(),
 		s.loadPendingValidators(),
 		s.initValidatorSets(),
-		s.caminoState.Load(),
+		s.caminoState.Load(s),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/executor/camino_chain_event.go
+++ b/vms/platformvm/txs/executor/camino_chain_event.go
@@ -6,11 +6,36 @@ package executor
 import (
 	"time"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 )
 
 // GetNextChainEventTime returns the next chain event time
 // For example: stakers set changed, deposit expired
-func GetNextChainEventTime(_ state.Chain, stakerChangeTime time.Time) (time.Time, error) {
+func GetNextChainEventTime(state state.Chain, stakerChangeTime time.Time) (time.Time, error) {
+	// return stakerChangeTime, nil
+	nextDeferredStakerEndTime, err := getNextDeferredStakerEndTime(state)
+	if err == database.ErrNotFound {
+		return stakerChangeTime, nil
+	} else if err != nil {
+		return time.Time{}, err
+	}
+
+	if nextDeferredStakerEndTime.Before(stakerChangeTime) {
+		return nextDeferredStakerEndTime, nil
+	}
+
 	return stakerChangeTime, nil
+}
+
+func getNextDeferredStakerEndTime(state state.Chain) (time.Time, error) {
+	deferredStakerIterator, err := state.GetDeferredStakerIterator()
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer deferredStakerIterator.Release()
+	if deferredStakerIterator.Next() {
+		return deferredStakerIterator.Value().NextTime, nil
+	}
+	return time.Time{}, database.ErrNotFound
 }

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1144,11 +1144,16 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 	txID := e.Tx.ID()
 
 	if tx.State == txs.AddressStateNodeDeferred {
+		nodeShortID, err := e.State.GetShortIDLink(tx.Address, state.ShortLinkKeyRegisterNode)
+		if err != nil {
+			return fmt.Errorf("couldn't get consortium member registered nodeID: %w", err)
+		}
+		nodeID := ids.NodeID(nodeShortID)
 		if tx.Remove {
 			// transfer staker to from pending to current stakers set
-			stakerToRemove, err := e.State.GetPendingValidator(constants.PrimaryNetworkID, ids.NodeID(tx.Address))
+			stakerToRemove, err := e.State.GetPendingValidator(constants.PrimaryNetworkID, nodeID)
 			if err != nil {
-				return fmt.Errorf("validator with nodeID %s, does not exist in pending stakers set: %w", ids.NodeID(tx.Address), errValidatorNotFound)
+				return fmt.Errorf("validator with nodeID %s, does not exist in pending stakers set: %w", nodeID, errValidatorNotFound)
 			}
 			e.State.DeletePendingValidator(stakerToRemove)
 			stakerToAdd := copyStaker(stakerToRemove)
@@ -1158,9 +1163,9 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 			e.State.PutCurrentValidator(stakerToAdd)
 		} else {
 			// transfer staker to from current to pending stakers set
-			stakerToRemove, err := e.State.GetCurrentValidator(constants.PrimaryNetworkID, ids.NodeID(tx.Address))
+			stakerToRemove, err := e.State.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
 			if err != nil {
-				return fmt.Errorf("validator with nodeID %s, does not exist in current stakers set: %w", ids.NodeID(tx.Address), errValidatorNotFound)
+				return fmt.Errorf("validator with nodeID %s, does not exist in current stakers set: %w", nodeID, errValidatorNotFound)
 			}
 			e.State.DeleteCurrentValidator(stakerToRemove)
 			stakerToAdd := copyStaker(stakerToRemove)

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -3824,8 +3824,7 @@ func TestCaminoStandardTxExecutorSuspendValidator(t *testing.T) {
 				stakerToTransfer, err := state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
 				require.NoError(t, err)
 				state.DeleteCurrentValidator(stakerToTransfer)
-				stakerToTransfer.StartTime = stakerToTransfer.EndTime
-				state.PutPendingValidator(stakerToTransfer)
+				state.PutDeferredValidator(stakerToTransfer)
 			},
 			expectedErr: nil,
 		},
@@ -3892,7 +3891,7 @@ func TestCaminoStandardTxExecutorSuspendValidator(t *testing.T) {
 				stakerIterator, err = onAcceptState.GetCurrentStakerIterator()
 				require.NoError(t, err)
 			} else {
-				stakerIterator, err = onAcceptState.GetPendingStakerIterator()
+				stakerIterator, err = onAcceptState.GetDeferredStakerIterator()
 				require.NoError(t, err)
 			}
 			require.True(t, stakerIterator.Next())


### PR DESCRIPTION
## Why this should be merged
### AddressStateTx.Address 
AddressStateTx.Address is an address, not nodeID. But in case of validator suspension, executor expects nodeID in this field. Its confusing. This PR fixes that - executor will expect consortium member address that owns the node.
### Deferred stakers set
In https://github.com/chain4travel/caminogo/pull/176 PR we introduced "defer staker" feature, which removes validator from current stakers set and puts it into pending, until its end time comes or until manual reactivation. But this approach with using pending stakers set resulted in some issues and wasn't the cleanest one. So, this PR instead implements deferred stakers set and uses it for storing deferred validators. Most of the implementation is taken from https://github.com/chain4travel/caminogo/pull/159.
## How this works
See https://github.com/chain4travel/caminogo/pull/159. This PR only adapts this implementation and applies a few minor fixes along with some cleanup.
## How this was tested
Unit tests, integration tests
## Co-authors
@charalarg (most of the implementation) https://github.com/chain4travel/caminogo/pull/159