### PR TITLE
[PVM] Add missing serialize tag to RewardsImportTx

### DIFF
--- a/vms/platformvm/txs/camino_rewards_import_tx.go
+++ b/vms/platformvm/txs/camino_rewards_import_tx.go
@@ -26,7 +26,7 @@ var (
 // RewardsImportTx is an unsigned rewardsImportTx
 type RewardsImportTx struct {
 	// Metadata, imported inputs and resulting output
-	BaseTx
+	BaseTx `serialize:"true"`
 }
 
 func (tx *RewardsImportTx) SyntacticVerify(ctx *snow.Context) error {


### PR DESCRIPTION
Fixes critical issue. Tx will be all zeroes after serialization without this tag.