### PR TITLE
[INPUT] Allow math.Uint32 wildcard in sigIndices

### DIFF
--- a/utils/camino_sorting.go
+++ b/utils/camino_sorting.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utils
+
+import "math"
+
+// Returns true if the elements in [s] are unique and sorted.
+// math.MaxUint32 is skipped because they are used as wildcard
+func IsSortedAndUniqueOrderedSigIndices(s []uint32) bool {
+	var last uint32
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] != math.MaxUint32 {
+			last = s[i]
+		}
+		if s[i+1] != math.MaxUint32 {
+			if last >= s[i+1] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/vms/secp256k1fx/input.go
+++ b/vms/secp256k1fx/input.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -36,7 +46,7 @@ func (in *Input) Verify() error {
 	switch {
 	case in == nil:
 		return errNilInput
-	case !utils.IsSortedAndUniqueOrdered(in.SigIndices):
+	case !utils.IsSortedAndUniqueOrderedSigIndices(in.SigIndices):
 		return errNotSortedUnique
 	default:
 		return nil


### PR DESCRIPTION
## Why this should be merged
With multisig support we introduced a modified Cred checking, which doesn't necessarily require Input:sigIndices.
Although we still check sigIndices, we allow a wildcardNumber (math.Uint32) which prevents checking for sigIndex.

Input verification requires in general implementation a sorted, unique list of sigIndices, which does not work with our wildcard logic.
This PR ignores math.Uint32 values in the list of sigIndices

## How this works
The previous simple loop for checking sorted / unique was extended to skip math.Uint32 values.
Non-Max-values are still checked to be unique and in order.
