### PR TITLE
[PVM] Adjustment of validator uptime on reactivation

### DIFF
--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -389,6 +389,13 @@ func (d *diff) GetDeferredStakerIterator() (StakerIterator, error) {
 	return d.caminoDiff.deferredStakerDiffs.GetStakerIterator(parentIterator), nil
 }
 
+func (d *diff) SetValidatorUptime(subnetID ids.ID, nodeID ids.NodeID, uptime time.Duration) {
+	if d.caminoDiff.modifiedUptimes[nodeID] == nil {
+		d.caminoDiff.modifiedUptimes[nodeID] = make(map[ids.ID]time.Duration)
+	}
+	d.caminoDiff.modifiedUptimes[nodeID][subnetID] = uptime
+}
+
 // Finally apply all changes
 func (d *diff) ApplyCaminoState(baseState State) {
 	if d.caminoDiff.modifiedNotDistributedValidatorReward != nil {
@@ -435,6 +442,12 @@ func (d *diff) ApplyCaminoState(baseState State) {
 			case deleted:
 				baseState.DeleteDeferredValidator(validatorDiff.validator)
 			}
+		}
+	}
+
+	for nodeID, subnetMap := range d.caminoDiff.modifiedUptimes {
+		for subnetID, uptime := range subnetMap {
+			baseState.SetValidatorUptime(subnetID, nodeID, uptime)
 		}
 	}
 }

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -16,6 +16,10 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 )
 
+func (s *state) CaminoState() (CaminoState, error) {
+	return s.caminoState, nil
+}
+
 func (s *state) LockedUTXOs(txIDs set.Set[ids.ID], addresses set.Set[ids.ShortID], lockState locked.State) ([]*avax.UTXO, error) {
 	retUtxos := []*avax.UTXO{}
 	for address := range addresses {
@@ -138,4 +142,8 @@ func (s *state) DeleteDeferredValidator(staker *Staker) {
 
 func (s *state) GetDeferredStakerIterator() (StakerIterator, error) {
 	return s.caminoState.GetDeferredStakerIterator()
+}
+
+func (s *state) SetValidatorUptime(subnetID ids.ID, nodeID ids.NodeID, uptime time.Duration) {
+	s.caminoState.SetValidatorUptime(subnetID, nodeID, uptime)
 }

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -830,3 +830,30 @@ func (mr *MockChainMockRecorder) RemoveDeposit(arg0, arg1 interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDeposit", reflect.TypeOf((*MockChain)(nil).RemoveDeposit), arg0, arg1)
 }
+
+// SetValidatorUptime mocks base method.
+func (m *MockChain) SetValidatorUptime(arg0 ids.ID, arg1 ids.NodeID, arg2 time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetValidatorUptime", arg0, arg1, arg2)
+}
+
+// SetValidatorUptime indicates an expected call of SetValidatorUptime.
+func (mr *MockChainMockRecorder) SetValidatorUptime(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidatorUptime", reflect.TypeOf((*MockDiff)(nil).SetValidatorUptime), arg0, arg1, arg2)
+}
+
+// CaminoState mocks base method.
+func (m *MockChain) CaminoState() (CaminoState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaminoState")
+	ret0, _ := ret[0].(CaminoState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CaminoState indicates an expected call of CaminoState.
+func (mr *MockChainMockRecorder) CaminoState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaminoState", reflect.TypeOf((*MockChain)(nil).CaminoState))
+}

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -841,3 +841,30 @@ func (mr *MockDiffMockRecorder) RemoveDeposit(arg0, arg1 interface{}) *gomock.Ca
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDeposit", reflect.TypeOf((*MockDiff)(nil).RemoveDeposit), arg0, arg1)
 }
+
+// SetValidatorUptime mocks base method.
+func (m *MockDiff) SetValidatorUptime(arg0 ids.ID, arg1 ids.NodeID, arg2 time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetValidatorUptime", arg0, arg1, arg2)
+}
+
+// SetValidatorUptime indicates an expected call of SetValidatorUptime.
+func (mr *MockDiffMockRecorder) SetValidatorUptime(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidatorUptime", reflect.TypeOf((*MockDiff)(nil).SetValidatorUptime), arg0, arg1, arg2)
+}
+
+// CaminoState mocks base method.
+func (m *MockDiff) CaminoState() (CaminoState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaminoState")
+	ret0, _ := ret[0].(CaminoState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CaminoState indicates an expected call of CaminoState.
+func (mr *MockDiffMockRecorder) CaminoState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaminoState", reflect.TypeOf((*MockChain)(nil).CaminoState))
+}

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -1049,3 +1049,30 @@ func (mr *MockStateMockRecorder) RemoveDeposit(arg0, arg1 interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDeposit", reflect.TypeOf((*MockState)(nil).RemoveDeposit), arg0, arg1)
 }
+
+// SetValidatorUptime mocks base method.
+func (m *MockState) SetValidatorUptime(arg0 ids.ID, arg1 ids.NodeID, arg2 time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetValidatorUptime", arg0, arg1, arg2)
+}
+
+// SetValidatorUptime indicates an expected call of SetValidatorUptime.
+func (mr *MockStateMockRecorder) SetValidatorUptime(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidatorUptime", reflect.TypeOf((*MockDiff)(nil).SetValidatorUptime), arg0, arg1, arg2)
+}
+
+// CaminoState mocks base method.
+func (m *MockState) CaminoState() (CaminoState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaminoState")
+	ret0, _ := ret[0].(CaminoState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CaminoState indicates an expected call of CaminoState.
+func (mr *MockStateMockRecorder) CaminoState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaminoState", reflect.TypeOf((*MockChain)(nil).CaminoState))
+}

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -498,12 +498,7 @@ func new(
 		return nil, err
 	}
 
-	caminoState, err := newCaminoState(baseDB, validatorsDB, metricsReg)
-	if err != nil {
-		return nil, err
-	}
-
-	return &state{
+	state := state{
 		validatorUptimes: newValidatorUptimes(),
 
 		cfg:          cfg,
@@ -519,8 +514,6 @@ func new(
 
 		currentStakers: newBaseStakers(),
 		pendingStakers: newBaseStakers(),
-
-		caminoState: caminoState,
 
 		validatorsDB:                 validatorsDB,
 		currentValidatorsDB:          currentValidatorsDB,
@@ -575,7 +568,15 @@ func new(
 		chainDBCache: chainDBCache,
 
 		singletonDB: prefixdb.New(singletonPrefix, baseDB),
-	}, nil
+	}
+
+	caminoState, err := newCaminoState(&state, baseDB, validatorsDB, metricsReg)
+	if err != nil {
+		return nil, err
+	}
+	state.caminoState = caminoState
+
+	return &state, nil
 }
 
 func (s *state) GetCurrentValidator(subnetID ids.ID, nodeID ids.NodeID) (*Staker, error) {

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1456,6 +1456,7 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 			}
 			e.State.DeleteDeferredValidator(stakerToReactivate)
 			e.State.PutCurrentValidator(stakerToReactivate)
+			e.State.SetValidatorUptime(constants.PrimaryNetworkID, nodeID, e.Clk.Time().Sub(stakerToReactivate.StartTime))
 		} else {
 			// transfer staker to from current to deferred stakers set
 			stakerToDefer, err := e.State.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)


### PR DESCRIPTION
## Description ##

This PR adjusts the uptime of a suspended validator at its reactivation time because by default when its moved back to the current set, its uptime starts from 0 but the uptime percentage is calculated from its initial start time ending up in an invalid value. 

**Important note:** This invalid value is only stored on a mapping in state and not on disc. And this happens because when we reactivate the validator, the `LoadUptime` is being called which is not altering anything on disc. So, if we boot up a brand new node and request the uptime of the reactivated validator it will be calculated from its initial value.

With this PR we are updating the uptime of the reactivated validator both on the mapping and in db's state, thus they will be in sync.  

## Changes ##

- Added the `setValidatorUptime` call on validator reactivation
- implemented the `setValidatorUptime` function in state 
- In order to call state's original `setUptime`function we needed to make a cross reference between `state` and `caminoState`.

## Remarks ##

This implementation is just a POC proving that the uptime update works. 
Further discussions, thoughts and tests needed in order to conclude to this implementation    