### PR TITLE
[MSig] TraverseOwner for fake keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tmp/
 .idea/
 
 *logs/
+*.diff
 
 .vscode*
 

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -324,7 +324,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}})
 				// deposits
 				depositTx := &txs.Tx{Unsigned: &txs.DepositTx{RewardsOwner: &rewardOwner1}}
 				s.EXPECT().GetTx(depositTxID1).Return(depositTx, status.Committed, nil)
@@ -354,7 +354,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}, rewardOwner2Addr: {}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}, rewardOwner2Addr: {}})
 				// deposits
 				depositTx1 := &txs.Tx{Unsigned: &txs.DepositTx{RewardsOwner: &rewardOwner1}}
 				depositTx2 := &txs.Tx{Unsigned: &txs.DepositTx{RewardsOwner: &rewardOwner2}}
@@ -387,7 +387,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}, rewardOwner2Addr: {}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}, rewardOwner2Addr: {}})
 				// deposits
 				depositTx1 := &txs.Tx{Unsigned: &txs.DepositTx{
 					RewardsOwner: &secp256k1fx.OutputOwners{
@@ -428,11 +428,11 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}})
 				// claimables
 				claimable := &state.Claimable{Owner: &rewardOwner1, DepositReward: 10, ValidatorReward: 100}
 				s.EXPECT().GetClaimable(claimableOwnerID).Return(claimable, nil)
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{treasury.Addr: {treasuryUTXO}}, true)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{treasury.Addr: {treasuryUTXO}})
 				return s
 			},
 			args: args{
@@ -468,7 +468,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}, rewardOwner2Addr: {}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}, rewardOwner2Addr: {}})
 				// deposits
 				depositTx1 := &txs.Tx{Unsigned: &txs.DepositTx{
 					RewardsOwner: &secp256k1fx.OutputOwners{
@@ -480,7 +480,7 @@ func TestNewClaimTx(t *testing.T) {
 				// claimables
 				claimable := &state.Claimable{Owner: &rewardOwner1, DepositReward: 10, ValidatorReward: 100}
 				s.EXPECT().GetClaimable(claimableOwnerID).Return(claimable, nil)
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{treasury.Addr: {treasuryUTXO}}, true)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{treasury.Addr: {treasuryUTXO}})
 				return s
 			},
 			args: args{
@@ -519,7 +519,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}})
 				// deposits
 				s.EXPECT().GetTx(depositTxID1).Return(nil, status.Unknown, database.ErrNotFound)
 				return s
@@ -536,7 +536,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}})
 				// deposits
 				s.EXPECT().GetTx(depositTxID1).Return(nil, status.Unknown, nil)
 				return s
@@ -553,7 +553,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}})
 				// deposits
 				s.EXPECT().GetTx(depositTxID1).Return(
 					&txs.Tx{Unsigned: &txs.CaminoAddValidatorTx{}},
@@ -574,7 +574,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}})
 				// deposits
 				s.EXPECT().GetTx(depositTxID1).Return(
 					&txs.Tx{Unsigned: &txs.DepositTx{RewardsOwner: &avax.TransferableOutput{}}},
@@ -595,7 +595,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}})
 				// deposits
 				s.EXPECT().GetTx(depositTxID1).Return(
 					&txs.Tx{Unsigned: &txs.DepositTx{RewardsOwner: &rewardOwner1}},
@@ -616,7 +616,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}})
 				// claimables
 				s.EXPECT().GetClaimable(claimableOwnerID).Return(nil, database.ErrNotFound)
 				return s
@@ -634,7 +634,7 @@ func TestNewClaimTx(t *testing.T) {
 				s := state.NewMockState(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				// fee
-				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}}, false)
+				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}})
 				// claimables
 				claimable := &state.Claimable{Owner: &rewardOwner1}
 				s.EXPECT().GetClaimable(claimableOwnerID).Return(claimable, nil)

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -632,7 +632,7 @@ func newCaminoBuilderWithMocks(postBanff bool, state state.State, sharedMemory a
 	return caminoBuilder, baseDB
 }
 
-func expectLock(s *state.MockState, allUTXOs map[ids.ShortID][]*avax.UTXO, fakeKeys bool) {
+func expectLock(s *state.MockState, allUTXOs map[ids.ShortID][]*avax.UTXO) {
 	for addr, utxos := range allUTXOs {
 		utxoids := make([]ids.ID, len(utxos))
 		for i := range utxos {
@@ -641,9 +641,7 @@ func expectLock(s *state.MockState, allUTXOs map[ids.ShortID][]*avax.UTXO, fakeK
 		s.EXPECT().UTXOIDs(addr.Bytes(), ids.Empty, math.MaxInt).Return(utxoids, nil)
 		for _, utxo := range utxos {
 			s.EXPECT().GetUTXO(utxo.InputID()).Return(utxo, nil)
-			if !fakeKeys {
-				s.EXPECT().GetMultisigAlias(addr).Return(nil, database.ErrNotFound)
-			}
+			s.EXPECT().GetMultisigAlias(addr).Return(nil, database.ErrNotFound)
 		}
 	}
 }

--- a/vms/secp256k1fx/camino_fx.go
+++ b/vms/secp256k1fx/camino_fx.go
@@ -185,12 +185,16 @@ func (fx *Fx) verifyMultisigCredentials(tx UnsignedTx, in *Input, cred *Credenti
 	}
 
 	tf := func(
+		alias bool,
 		addr ids.ShortID,
 		depth int,
 		visited,
 		verified,
 		totalVisited uint32,
 	) (bool, error) {
+		if alias {
+			return false, nil
+		}
 		// check that input sig index matches
 		if totalVisited >= uint32(len(cred.Sigs)) {
 			return false, errTooFewSigIndices
@@ -223,7 +227,10 @@ func (fx *Fx) verifyMultisigUnorderedCredentials(tx UnsignedTx, cred *Credential
 		return err
 	}
 
-	tf := func(addr ids.ShortID, _ int, _, _, _ uint32) (bool, error) {
+	tf := func(alias bool, addr ids.ShortID, _ int, _, _, _ uint32) (bool, error) {
+		if alias {
+			return false, nil
+		}
 		if _, exists := resolved[addr]; exists {
 			return true, nil
 		}

--- a/vms/secp256k1fx/camino_keychain_test.go
+++ b/vms/secp256k1fx/camino_keychain_test.go
@@ -85,12 +85,12 @@ func TestSpendMultiSigFakeKeys(t *testing.T) {
 type TestGetter struct{}
 
 func (*TestGetter) GetMultisigAlias(addr ids.ShortID) (*multisig.Alias, error) {
-	if addr.String() == addrs[2] {
+	if addr == msigAddress {
 		return &multisig.Alias{
 			Owners: &OutputOwners{
 				Threshold: 1,
 				Addrs: []ids.ShortID{
-					addr,
+					msigAddress,
 				},
 			},
 		}, nil
@@ -123,7 +123,7 @@ func TestSpendMultiSigCycle(t *testing.T) {
 			Threshold: 2,
 			Addrs: []ids.ShortID{
 				addresses[1],
-				addresses[2],
+				msigAddress,
 			},
 		},
 	}

--- a/vms/secp256k1fx/keychain_test.go
+++ b/vms/secp256k1fx/keychain_test.go
@@ -24,6 +24,7 @@ var (
 		"P5wdRuZeaDt28eHMP5S3w9ZdoBfo7wuzF",
 		"Q4MzFZZDPHRPAHFeDs3NiyyaZDvxHKivf",
 	}
+	msigAddress = ids.ShortID{255, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
 )
 
 func TestNewKeychain(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged
In the current implementation we use avax spend instead our MultiSig verification if the first key in keychain is a fake key (aka key used for builder to get UTXOs even they are from multisig without existing private key)
This leads to conditions here and there, to make it cleaner now the check was removed and fakekeys are also handled using TraverseOwner function.

## How this works
The callback (tf / TransferFunction) is also called for alias. If the keychain includes a (fake) key for an alias, the address is markes as verified and no deeper signature checking is done (instead the msig alias is treated as valid even it could fail later when testing the complete alias tree)

## How this was tested
Unit Tests
