### PR TITLE
Peak3d/msig

### DIFF
--- a/genesis/genesis_kopernikus.json
+++ b/genesis/genesis_kopernikus.json
@@ -108,7 +108,7 @@
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
         "avaxAddr": "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3",
-        "xAmount": 987990000000000000,
+        "xAmount": 986990000000000000,
         "addressStates": {
           "consortiumMember": true,
           "kycVerified": true
@@ -172,6 +172,25 @@
             "depositOfferMemo": "presale3y"
           }
         ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-kopernikus1t3qjau2pf3ys83yallqt4y5xc3l6ya5f8yu5ex",
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000
+          },
+          {
+            "amount": 600000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 0,
+            "depositOfferMemo": "presale3y"
+          }
+        ]
       }
     ],
     "initialMultisigAddresses": [
@@ -181,6 +200,14 @@
           "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
         ],
         "threshold": 1
+      },
+      {
+        "alias": "X-kopernikus1k4przmfu79ypp4u7y98glmdpzwk0u3sc7saazy",
+        "addresses": [
+          "X-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68",
+          "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
+        ],
+        "threshold": 2
       }
     ]
   },

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -378,7 +378,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "QZNa6k9hGXpTLiyCwEvxdUcpPQV1PuTNUqRKf1cHPHWWe8q9D",
+			expectedID: "9NuXnsVNuFgLUuQyot7gt4eUAfHYUAkPx9pZxFtFNygtFKQv4",
 		},
 		{
 			networkID:  constants.LocalID,
@@ -439,7 +439,7 @@ func TestVMGenesis(t *testing.T) {
 			vmTest: []vmTest{
 				{
 					vmID:       constants.AVMID,
-					expectedID: "hVq6QUyVgZarJXxeyjSYoDNjhrqNMnbPozwRi9t9Qi8h2xZLZ",
+					expectedID: "2vWvKYWPer37aW2Mu7FvQD8LtLsh4gcu3d2fKkCHue2QLeqvWM",
 				},
 				{
 					vmID:       constants.EVMID,
@@ -505,7 +505,7 @@ func TestAVAXAssetID(t *testing.T) {
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "vc7moAC7SqyrcWt5T2voKkJTfM6oQYGPtvuxwAJmphamLsJSV",
+			expectedID: "gbs1MNJvvs493dvRb6M8E2k3BjJ9FXSYmcc6QWu9PZTeFMatb",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/secp256k1fx/camino_fx_test.go
+++ b/vms/secp256k1fx/camino_fx_test.go
@@ -59,7 +59,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 				Addrs:     []ids.ShortID{addr1, addr2},
 			},
 			msig:          noAliasesMsigGetter,
-			expectedError: errTooFewSigIndices,
+			expectedError: errInputCredentialSignersMismatch,
 		},
 		"Fail: To many signature indices": {
 			in:      &Input{SigIndices: []uint32{0, 1, 2}},
@@ -69,7 +69,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 				Addrs:     []ids.ShortID{addr1, addr2},
 			},
 			msig:          noAliasesMsigGetter,
-			expectedError: errTooManySigIndices,
+			expectedError: errInputCredentialSignersMismatch,
 		},
 		"Fail: To many signers": {
 			in:      &Input{SigIndices: []uint32{0, 1}},
@@ -79,7 +79,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 				Addrs:     []ids.ShortID{addr1, addr2},
 			},
 			msig:          noAliasesMsigGetter,
-			expectedError: errTooManySigners,
+			expectedError: errInputCredentialSignersMismatch,
 		},
 		"Fail: Not enough sigs to reach treshold": {
 			in:      &Input{SigIndices: []uint32{0}},
@@ -131,7 +131,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 		},
 		"OK msig: addr1, alias1{addr2, addr3, thresh: 2}": {
-			in:      &Input{SigIndices: []uint32{0, math.MaxUint32}},
+			in:      &Input{SigIndices: []uint32{0, math.MaxUint32, 2}},
 			signers: []*crypto.PrivateKeySECP256K1R{key1, key2, key3},
 			owners: &OutputOwners{
 				Threshold: 2,
@@ -150,7 +150,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 		},
 		"OK msig: alias1{ alias2{addr1, addr2, thresh: 2}, addr3, thresh: 2 }, addr4": {
-			in:      &Input{SigIndices: []uint32{math.MaxUint32, 1}},
+			in:      &Input{SigIndices: []uint32{0, 1, 2, 3}},
 			signers: []*crypto.PrivateKeySECP256K1R{key1, key2, key3, key4},
 			owners: &OutputOwners{
 				Threshold: 2,
@@ -178,7 +178,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 		},
 		"OK msig: alias1{ alias2{addr1, addr2 (wildcard), thresh: 2}, addr3, thresh: 2 }, addr4": {
-			in:      &Input{SigIndices: []uint32{math.MaxUint32, 1}},
+			in:      &Input{SigIndices: []uint32{0, math.MaxUint32, 2, 3}},
 			signers: []*crypto.PrivateKeySECP256K1R{key1, key2, key3, key4},
 			owners: &OutputOwners{
 				Threshold: 2,
@@ -206,7 +206,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 		},
 		"OK msig: alias1{ alias2{addr1, addr2, thresh: 2}, addr3, thresh: 2 }, addr4, all wildcards": {
-			in:      &Input{SigIndices: []uint32{math.MaxUint32, math.MaxUint32}},
+			in:      &Input{SigIndices: []uint32{math.MaxUint32, math.MaxUint32, math.MaxUint32, math.MaxUint32}},
 			signers: []*crypto.PrivateKeySECP256K1R{key1, key2, key3, key4},
 			owners: &OutputOwners{
 				Threshold: 2,
@@ -234,7 +234,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 		},
 		"Fail msig: alias1{ alias2{addr1, addr2 (bad sig), thresh: 2}, addr3, thresh: 2 }, addr4": {
-			in:      &Input{SigIndices: []uint32{math.MaxUint32, 1}},
+			in:      &Input{SigIndices: []uint32{math.MaxUint32, 1, 2, 3}},
 			signers: []*crypto.PrivateKeySECP256K1R{key1, key4, key3, key4},
 			owners: &OutputOwners{
 				Threshold: 2,

--- a/vms/secp256k1fx/camino_keychain_test.go
+++ b/vms/secp256k1fx/camino_keychain_test.go
@@ -14,7 +14,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSpendMultiSig(t *testing.T) {
+type TestGetter struct {
+	address ids.ShortID
+}
+
+func (t *TestGetter) GetMultisigAlias(addr ids.ShortID) (*multisig.Alias, error) {
+	if addr == msigAddress {
+		return &multisig.Alias{
+			Owners: &OutputOwners{
+				Threshold: 1,
+				Addrs: []ids.ShortID{
+					t.address,
+				},
+			},
+		}, nil
+	}
+	return nil, database.ErrNotFound
+}
+
+func TestSpendMultiSigNoMSig(t *testing.T) {
 	require := require.New(t)
 	kc := NewKeychain()
 
@@ -45,8 +63,48 @@ func TestSpendMultiSig(t *testing.T) {
 	}
 	require.NoError(transfer.Verify())
 
-	_, _, err := kc.SpendMultiSig(&transfer, 54321, nil)
+	_, sigs, err := kc.SpendMultiSig(&transfer, 54321, nil)
 	require.NoError(err)
+
+	require.Equal(len(sigs), 2)
+}
+
+func TestSpendMultiSigMSig(t *testing.T) {
+	require := require.New(t)
+	kc := NewKeychain()
+
+	addresses := make([]ids.ShortID, 0, len(keys))
+
+	for _, keyStr := range keys {
+		skBytes, err := formatting.Decode(formatting.HexNC, keyStr)
+		require.NoError(err)
+
+		skIntf, err := kc.factory.ToPrivateKey(skBytes)
+		require.NoError(err)
+		sk, ok := skIntf.(*crypto.PrivateKeySECP256K1R)
+		require.True(ok, "Factory should have returned secp256k1r private key")
+		kc.Add(sk)
+		addresses = append(addresses, sk.PublicKey().Address())
+	}
+
+	transfer := TransferOutput{
+		Amt: 12345,
+		OutputOwners: OutputOwners{
+			Locktime:  54321,
+			Threshold: 3,
+			Addrs: []ids.ShortID{
+				addresses[1],
+				addresses[2],
+				msigAddress,
+			},
+		},
+	}
+	require.NoError(transfer.Verify())
+
+	_, sigs, err := kc.SpendMultiSig(&transfer, 54321, &TestGetter{addresses[0]})
+	require.NoError(err)
+
+	require.Equal(len(sigs), 3)
 }
 
 func TestSpendMultiSigFakeKeys(t *testing.T) {
@@ -82,22 +140,6 @@ func TestSpendMultiSigFakeKeys(t *testing.T) {
 	require.NoError(err)
 }
 
-type TestGetter struct{}
-
-func (*TestGetter) GetMultisigAlias(addr ids.ShortID) (*multisig.Alias, error) {
-	if addr == msigAddress {
-		return &multisig.Alias{
-			Owners: &OutputOwners{
-				Threshold: 1,
-				Addrs: []ids.ShortID{
-					msigAddress,
-				},
-			},
-		}, nil
-	}
-	return nil, database.ErrNotFound
-}
-
 func TestSpendMultiSigCycle(t *testing.T) {
 	require := require.New(t)
 	kc := NewKeychain()
@@ -129,6 +171,6 @@ func TestSpendMultiSigCycle(t *testing.T) {
 	}
 	require.NoError(transfer.Verify())
 
-	_, _, err := kc.SpendMultiSig(&transfer, 54321, &TestGetter{})
+	_, _, err := kc.SpendMultiSig(&transfer, 54321, &TestGetter{address: msigAddress})
 	require.ErrorIs(err, errCyclicAliases)
 }


### PR DESCRIPTION
## Why this should be merged
PR #199 introduces a simplified logic for sigIndices which make things more complicated as required.
This PR reverts above mentioned one partly (except that Spend will not traverse into nested elements if passed as key)

## How this works
Verify spend again expects 1 signature and 1 sigIndex (absolute counted) per "non-msig" address.
Example: {address1, alias{address2, address3, T2}, T1} and signatures [address1, address3] requires sigIndices [0, 2]

## How this was tested
UnitTests
