### PR TITLE
[Multisig] MultisigCredential / Traverse cleanup

### DIFF
--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -19,11 +19,11 @@ type CaminoFx interface {
 	// should be returned. Multisig aliases supported.
 	VerifyMultisigTransfer(txIntf, inIntf, credIntf, utxoIntf, msigIntf interface{}) error
 
-	// VerifyPermission returns nil if credential [credIntf] proves that [controlGroup] assents to transaction [utx].
+	// VerifyMultisigPermission returns nil if credential [credIntf] proves that [controlGroup] assents to transaction [utx].
 	// Multisig aliases supported.
 	VerifyMultisigPermission(txIntf, inIntf, credIntf, controlGroup, msigIntf interface{}) error
 
-	// VerifyPermission returns nil if credential [credIntf] proves that [controlGroup] assents to transaction [utx].
+	// VerifyMultisigUnorderedPermission returns nil if credential [credIntf] proves [ownerIntf].
 	// Multisig aliases supported. Signatures order and number doesn't matter.
 	VerifyMultisigUnorderedPermission(txIntf, credIntf, ownerIntf, msigIntf interface{}) error
 }

--- a/vms/platformvm/state/camino_multisig_alias.go
+++ b/vms/platformvm/state/camino_multisig_alias.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/database"
@@ -12,11 +11,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/multisig"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
-	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/avalanchego/vms/types"
 )
-
-var errWrongOwnerType = errors.New("wrong owner type")
 
 type msigAlias struct {
 	Memo   types.JSONByteSlice `serialize:"true"`
@@ -85,24 +81,4 @@ func (cs *caminoState) writeMultisigOwners() error {
 		}
 	}
 	return nil
-}
-
-func GetOwner(state Chain, addr ids.ShortID) (*secp256k1fx.OutputOwners, error) {
-	msigOwner, err := state.GetMultisigAlias(addr)
-	if err != nil && err != database.ErrNotFound {
-		return nil, err
-	}
-
-	if msigOwner != nil {
-		owners, ok := msigOwner.Owners.(*secp256k1fx.OutputOwners)
-		if !ok {
-			return nil, errWrongOwnerType
-		}
-		return owners, nil
-	}
-
-	return &secp256k1fx.OutputOwners{
-		Threshold: 1,
-		Addrs:     []ids.ShortID{addr},
-	}, nil
 }

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -148,8 +148,8 @@ func (vm *VM) Initialize(
 	vm.ctx = chainCtx
 	vm.dbManager = dbManager
 
-	vm.codecRegistry = linearcodec.NewDefault()
-	vm.fx = &secp256k1fx.Fx{}
+	vm.codecRegistry = linearcodec.NewCaminoDefault()
+	vm.fx = &secp256k1fx.CaminoFx{}
 	if err := vm.fx.Initialize(vm); err != nil {
 		return err
 	}

--- a/vms/secp256k1fx/camino_credential.go
+++ b/vms/secp256k1fx/camino_credential.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package secp256k1fx
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils"
+	"github.com/ava-labs/avalanchego/utils/crypto"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+)
+
+var errMSigNotUniqueOrSorted = errors.New("multisig aliases not sorted or unique")
+
+type CredentialIntf interface {
+	verify.Verifiable
+	Signatures() [][crypto.SECP256K1RSigLen]byte
+}
+
+type MultisigCredential struct {
+	Credential `serialize:"true"`
+	// Specifies which MultisigAliases should be used during verification
+	// Aliases which are not part of of this list are skipped (non-verified)
+	MultiSigAliases []ids.ShortID `serialize:"true" json:"multisigAliases"`
+}
+
+func (cr *Credential) Signatures() [][crypto.SECP256K1RSigLen]byte {
+	return cr.Sigs
+}
+
+// MarshalJSON marshals [cr] to JSON
+// The string representation of each signature is created using the hex formatter
+func (mcr *MultisigCredential) MarshalJSON() ([]byte, error) {
+	b, err := mcr.Credential.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	jsonFieldMap := make(map[string]interface{}, 0)
+	if err = json.Unmarshal(b, &jsonFieldMap); err != nil {
+		return nil, err
+	}
+	jsonFieldMap["multisigAliases"] = mcr.MultiSigAliases
+	return json.Marshal(jsonFieldMap)
+}
+
+func (mcr *MultisigCredential) Verify() error {
+	switch {
+	case mcr == nil:
+		return errNilCredential
+	case !utils.IsSortedAndUniqueSortable(mcr.MultiSigAliases):
+		return errMSigNotUniqueOrSorted
+	default:
+		return nil
+	}
+}
+
+func (mcr *MultisigCredential) HasMultisig(id ids.ShortID) bool {
+	for _, s := range mcr.MultiSigAliases {
+		switch bytes.Compare(s[:], id[:]) {
+		case 0:
+			return true
+		case 1:
+			return false
+		}
+	}
+	return false
+}

--- a/vms/secp256k1fx/camino_fx_test.go
+++ b/vms/secp256k1fx/camino_fx_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/components/multisig"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -471,7 +472,7 @@ func TestVerifyMultisigUnorderedCredentials(t *testing.T) {
 				copy(cred.Sigs[i][:], sig)
 			}
 
-			err := fx.verifyMultisigUnorderedCredentials(tx, cred, tt.owners, tt.msig(ctrl))
+			err := fx.verifyMultisigUnorderedCredentials(tx, []verify.Verifiable{cred}, tt.owners, tt.msig(ctrl))
 			require.ErrorIs(t, err, tt.expectedError)
 		})
 	}

--- a/vms/secp256k1fx/camino_keychain_test.go
+++ b/vms/secp256k1fx/camino_keychain_test.go
@@ -15,17 +15,17 @@ import (
 )
 
 type TestGetter struct {
-	address ids.ShortID
+	msig      ids.ShortID
+	addresses []ids.ShortID
+	threshold uint32
 }
 
 func (t *TestGetter) GetMultisigAlias(addr ids.ShortID) (*multisig.Alias, error) {
-	if addr == msigAddress {
+	if addr == t.msig {
 		return &multisig.Alias{
 			Owners: &OutputOwners{
-				Threshold: 1,
-				Addrs: []ids.ShortID{
-					t.address,
-				},
+				Threshold: t.threshold,
+				Addrs:     t.addresses,
 			},
 		}, nil
 	}
@@ -101,7 +101,7 @@ func TestSpendMultiSigMSig(t *testing.T) {
 	}
 	require.NoError(transfer.Verify())
 
-	_, sigs, err := kc.SpendMultiSig(&transfer, 54321, &TestGetter{addresses[0]})
+	_, sigs, err := kc.SpendMultiSig(&transfer, 54321, &TestGetter{msig: msigAddress, addresses: []ids.ShortID{addresses[0]}, threshold: 1})
 	require.NoError(err)
 
 	require.Equal(len(sigs), 3)
@@ -171,6 +171,52 @@ func TestSpendMultiSigCycle(t *testing.T) {
 	}
 	require.NoError(transfer.Verify())
 
-	_, _, err := kc.SpendMultiSig(&transfer, 54321, &TestGetter{address: msigAddress})
+	_, _, err := kc.SpendMultiSig(&transfer, 54321, &TestGetter{msig: msigAddress, addresses: []ids.ShortID{msigAddress}, threshold: 1})
 	require.ErrorIs(err, errCyclicAliases)
+}
+
+// Verify that visited / verified items in nested ownergroups which don't
+// reach threshold are recovered correctly to it's initial state.
+// This test has an {M{A0, A1, T2}, A1, T1} setup, and only A1 signing.
+// We first visit A1 inside M which adds a signature. Because M's threshold of 2
+// M is not verified, and we continue with A1 at root level. This must become
+// SigIndex 0 because it is the first signature added
+func TestUnverifiedNestedOwner(t *testing.T) {
+	require := require.New(t)
+	kc := NewKeychain()
+
+	addresses := make([]ids.ShortID, 0, len(keys))
+
+	for i, keyStr := range keys {
+		skBytes, err := formatting.Decode(formatting.HexNC, keyStr)
+		require.NoError(err)
+
+		skIntf, err := kc.factory.ToPrivateKey(skBytes)
+		require.NoError(err)
+		sk, ok := skIntf.(*crypto.PrivateKeySECP256K1R)
+		require.True(ok, "Factory should have returned secp256k1r private key")
+		// Only one signer for this test
+		if i == 1 {
+			kc.Add(sk)
+		}
+		addresses = append(addresses, sk.PublicKey().Address())
+	}
+
+	transfer := TransferOutput{
+		Amt: 12345,
+		OutputOwners: OutputOwners{
+			Locktime:  54321,
+			Threshold: 1,
+			Addrs: []ids.ShortID{
+				msigAddressLow,
+				addresses[1],
+			},
+		},
+	}
+	require.NoError(transfer.Verify())
+
+	ti, sigs, err := kc.SpendMultiSig(&transfer, 54321, &TestGetter{msig: msigAddressLow, addresses: []ids.ShortID{addresses[0], addresses[1]}, threshold: 2})
+	require.NoError(err)
+	require.Equal(len(sigs), 1)
+	require.Equal(ti.(*TransferInput).SigIndices[0], uint32(0))
 }

--- a/vms/secp256k1fx/keychain_test.go
+++ b/vms/secp256k1fx/keychain_test.go
@@ -24,7 +24,8 @@ var (
 		"P5wdRuZeaDt28eHMP5S3w9ZdoBfo7wuzF",
 		"Q4MzFZZDPHRPAHFeDs3NiyyaZDvxHKivf",
 	}
-	msigAddress = ids.ShortID{255, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	msigAddress    = ids.ShortID{255, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	msigAddressLow = ids.ShortID{0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
 )
 
 func TestNewKeychain(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged
- RegisterNode SubnetAuth not multisig capable (fixed)
- Introduce MultisigCredential to be able to contol if a Multisig alias should be traversed or not.
- Make return values in Traverse more descriptive by replacing bool with 4-state enum

## How this works
- RegisterNode used non-msig capable Permission verification -> Use Msig version
- Signatures passed in Credentials don't include any information about MultisigAlias.
Assume you have a CG with A1, A2, M, A3 and your signatures should verify the 3 A's, something must be provided to tell the logic that M should be skipped. This is what SigIndices are normally meant for, but again, there are no sigIndices for Multisig Alias.

## How this was tested
- Existing unit tests
