### PR TITLE
[PVM] Implementation of camino client

### DIFF
--- a/genesis/genesis_kopernikus.json
+++ b/genesis/genesis_kopernikus.json
@@ -195,14 +195,16 @@
     ],
     "initialMultisigAddresses": [
       {
-        "alias": "X-kopernikus1fq0jc8svlyazhygkj0s36qnl6s0km0h3uuc99w",
+        "memo": "111",
+        "alias": "X-kopernikus1z5tv4tg04kf4l9ghclw6ssek8zugs7yd65prpl",
         "addresses": [
           "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
         ],
         "threshold": 1
       },
       {
-        "alias": "X-kopernikus1k4przmfu79ypp4u7y98glmdpzwk0u3sc7saazy",
+        "memo": "222",
+        "alias": "X-kopernikus1t5qgr9hcmf2vxj7k0hz77kawf9yr389cxte5j0",
         "addresses": [
           "X-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68",
           "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -378,7 +378,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "gUWFhrL2KNj7bhAz1GWspJCVFQqGSYuMDYRoD3HasUcW2fC52",
+			expectedID: "ADaZfEQJLY2khWAPVZxceHGA6EUn6SuafRFzm4DC5trzRNtUE",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/camino_client.go
+++ b/vms/platformvm/camino_client.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package platformvm
+
+import (
+	"context"
+
+	"github.com/ava-labs/avalanchego/api"
+	"github.com/ava-labs/avalanchego/utils/rpc"
+)
+
+type CaminoClient interface {
+	// GetConfiguration returns genesis information of the primary network
+	GetConfiguration(ctx context.Context, options ...rpc.Option) (*GetConfigurationReply, error)
+
+	// GetMultisigAlias returns the alias definition of the given multisig address
+	GetMultisigAlias(ctx context.Context, multisigAddress string, options ...rpc.Option) (*GetMultisigAliasReply, error)
+}
+
+func (c *client) GetConfiguration(ctx context.Context, options ...rpc.Option) (*GetConfigurationReply, error) {
+	res := &GetConfigurationReply{}
+	err := c.requester.SendRequest(ctx, "platform.getConfiguration", struct{}{}, res, options...)
+	return res, err
+}
+
+func (c *client) GetMultisigAlias(ctx context.Context, multisigAddress string, options ...rpc.Option) (*GetMultisigAliasReply, error) {
+	res := &GetMultisigAliasReply{}
+	err := c.requester.SendRequest(ctx, "platform.getMultisigAlias", &api.JSONAddress{
+		Address: multisigAddress,
+	}, res, options...)
+	return res, err
+}

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.
@@ -34,6 +34,7 @@ var _ Client = (*client)(nil)
 
 // Client interface for interacting with the P Chain endpoint
 type Client interface {
+	CaminoClient
 	// GetHeight returns the current block height of the P Chain
 	GetHeight(ctx context.Context, options ...rpc.Option) (uint64, error)
 	// ExportKey returns the private key corresponding to [address] from [user]'s account
@@ -215,8 +216,6 @@ type Client interface {
 	GetValidatorsAt(ctx context.Context, subnetID ids.ID, height uint64, options ...rpc.Option) (map[ids.NodeID]uint64, error)
 	// GetBlock returns the block with the given id.
 	GetBlock(ctx context.Context, blockID ids.ID, options ...rpc.Option) ([]byte, error)
-	// GetConfiguration returns genesis information of the primary network
-	GetConfiguration(ctx context.Context, options ...rpc.Option) (*GetConfigurationReply, error)
 }
 
 // Client implementation for interacting with the P Chain endpoint
@@ -819,10 +818,4 @@ func (c *client) GetBlock(ctx context.Context, blockID ids.ID, options ...rpc.Op
 	}
 
 	return formatting.Decode(response.Encoding, response.Block)
-}
-
-func (c *client) GetConfiguration(ctx context.Context, options ...rpc.Option) (*GetConfigurationReply, error) {
-	res := &GetConfigurationReply{}
-	err := c.requester.SendRequest(ctx, "getConfiguration", struct{}{}, res, options...)
-	return res, err
 }


### PR DESCRIPTION
## Description ##

This PR introduces the `camino_client`. Its an extension of the already existing `client` and is used in order to use camino related API calls from outside.

## Changes ##

- Transferred the `GetConfiguration` function from `client` to `camino_client`
- Added the `GetMultisigAlias` function to `camino_client`
- Added the `memo` field on multisig definitions on kopernikus genesis in order to be able to be used for testing