### PR TITLE
Deposit auto unlock fixes

### DIFF
--- a/vms/platformvm/blocks/builder/camino_builder.go
+++ b/vms/platformvm/blocks/builder/camino_builder.go
@@ -124,7 +124,7 @@ func getNextDepositsToUnlock(
 		return nil, false, errEndOfTime
 	}
 
-	nextDeposits, nextDepositsEndtime, err := preferredState.GetNextToUnlockDepositIDsAndTime()
+	nextDeposits, nextDepositsEndtime, err := preferredState.GetNextToUnlockDepositIDsAndTime(nil)
 	if err == database.ErrNotFound {
 		return nil, false, nil
 	} else if err != nil {

--- a/vms/platformvm/blocks/executor/proposal_block_test.go
+++ b/vms/platformvm/blocks/executor/proposal_block_test.go
@@ -257,8 +257,8 @@ func TestBanffProposalBlockTimeVerification(t *testing.T) {
 	deferredStakersIt.EXPECT().Release().AnyTimes()
 	onParentAccept.EXPECT().GetDeferredStakerIterator().Return(deferredStakersIt, nil).AnyTimes()
 
-	onParentAccept.EXPECT().GetNextToUnlockDepositTime().Return(time.Time{}, database.ErrNotFound).AnyTimes()
-	onParentAccept.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(nil, time.Time{}, database.ErrNotFound).AnyTimes()
+	onParentAccept.EXPECT().GetNextToUnlockDepositTime(nil).Return(time.Time{}, database.ErrNotFound).AnyTimes()
+	onParentAccept.EXPECT().GetNextToUnlockDepositIDsAndTime(nil).Return(nil, time.Time{}, database.ErrNotFound).AnyTimes()
 
 	env.mockedState.EXPECT().GetUptime(gomock.Any(), gomock.Any()).Return(
 		time.Duration(1000), /*upDuration*/

--- a/vms/platformvm/blocks/executor/standard_block_test.go
+++ b/vms/platformvm/blocks/executor/standard_block_test.go
@@ -164,8 +164,8 @@ func TestBanffStandardBlockTimeVerification(t *testing.T) {
 	deferredStakersIt.EXPECT().Release().AnyTimes()
 	onParentAccept.EXPECT().GetDeferredStakerIterator().Return(deferredStakersIt, nil).AnyTimes()
 
-	onParentAccept.EXPECT().GetNextToUnlockDepositTime().Return(time.Time{}, database.ErrNotFound).AnyTimes()
-	onParentAccept.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(nil, time.Time{}, database.ErrNotFound).AnyTimes()
+	onParentAccept.EXPECT().GetNextToUnlockDepositTime(nil).Return(time.Time{}, database.ErrNotFound).AnyTimes()
+	onParentAccept.EXPECT().GetNextToUnlockDepositIDsAndTime(nil).Return(nil, time.Time{}, database.ErrNotFound).AnyTimes()
 
 	onParentAccept.EXPECT().GetTimestamp().Return(chainTime).AnyTimes()
 

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -526,7 +526,7 @@ func TestDepositsAutoUnlock(t *testing.T) {
 	require.Equal(getUnlockedBalance(t, vm.state, depositOwnerAddr), depositOffer.MinAmount)
 	require.Equal(getUnlockedBalance(t, vm.state, treasury.Addr), deposit.TotalReward(depositOffer))
 	require.Equal(deposit.EndTime(), vm.state.GetTimestamp())
-	_, err = vm.state.GetNextToUnlockDepositTime()
+	_, err = vm.state.GetNextToUnlockDepositTime(nil)
 	require.ErrorIs(err, database.ErrNotFound)
 }
 

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -88,8 +88,8 @@ type CaminoDiff interface {
 	// deposit start and duration should never be modified, deposit should never be nil
 	RemoveDeposit(depositTxID ids.ID, deposit *deposit.Deposit)
 	GetDeposit(depositTxID ids.ID) (*deposit.Deposit, error)
-	GetNextToUnlockDepositTime() (time.Time, error)
-	GetNextToUnlockDepositIDsAndTime() ([]ids.ID, time.Time, error)
+	GetNextToUnlockDepositTime(removedDepositIDs set.Set[ids.ID]) (time.Time, error)
+	GetNextToUnlockDepositIDsAndTime(removedDepositIDs set.Set[ids.ID]) ([]ids.ID, time.Time, error)
 
 	// Multisig Owners
 

--- a/vms/platformvm/state/camino_diff_test.go
+++ b/vms/platformvm/state/camino_diff_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -204,39 +206,39 @@ func TestDiffGetNextToUnlockDepositTime(t *testing.T) {
 	parentStateID := ids.GenerateTestID()
 	earlyDepositTxID1 := ids.ID{1}
 	earlyDepositTxID2 := ids.ID{2}
-	midDepositTxID := ids.ID{10}
-	lateDepositTxID1 := ids.ID{100}
-	lateDepositTxID2 := ids.ID{200}
+	midDepositTxID := ids.ID{11}
+	lateDepositTxID1 := ids.ID{101}
+	lateDepositTxID2 := ids.ID{102}
 	earlyDeposit := &deposit.Deposit{Duration: 101}
 	midDeposit := &deposit.Deposit{Duration: 102}
 	lateDeposit := &deposit.Deposit{Duration: 103}
 
 	tests := map[string]struct {
-		diff                   func(*gomock.Controller) *diff
+		diff                   func(*gomock.Controller, set.Set[ids.ID]) *diff
+		removedDepositIDs      set.Set[ids.ID]
 		expectedNextUnlockTime time.Time
 		expectedErr            error
 	}{
 		"Fail: no deposits": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(nil, time.Time{}, database.ErrNotFound)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, database.ErrNotFound)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
 					caminoDiff:    &caminoDiff{},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
+			expectedNextUnlockTime: mockable.MaxTime,
 			expectedErr:            database.ErrNotFound,
 		},
 		"Fail: deposits in parent state only, but all removed": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1, earlyDepositTxID2)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, database.ErrNotFound)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -248,17 +250,15 @@ func TestDiffGetNextToUnlockDepositTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockTime: mockable.MaxTime,
+			expectedErr:            database.ErrNotFound,
 		},
-		"Fail: deposits in parent state only, but one removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in parent state only, but one removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(earlyDeposit.EndTime(), nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -269,87 +269,52 @@ func TestDiffGetNextToUnlockDepositTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
-		"Fail: deposits in added (late) and parent state (early), but all removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in added (late) and parent state (early), but all parent removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
 					caminoDiff: &caminoDiff{
 						modifiedDeposits: map[ids.ID]*depositDiff{
 							lateDepositTxID1:  {Deposit: lateDeposit, added: true},
-							midDepositTxID:    {Deposit: midDeposit, removed: true},
 							earlyDepositTxID1: {Deposit: earlyDeposit, removed: true},
-							earlyDepositTxID2: {Deposit: earlyDeposit, removed: true},
 						},
 					},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockTime: lateDeposit.EndTime(),
 		},
-		"Fail: deposits in added (late) and parent state (early), but one removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in added (late) and parent state (early), but one parent removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(earlyDeposit.EndTime(), nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
 					caminoDiff: &caminoDiff{
 						modifiedDeposits: map[ids.ID]*depositDiff{
 							lateDepositTxID1:  {Deposit: lateDeposit, added: true},
-							midDepositTxID:    {Deposit: midDeposit, removed: true},
 							earlyDepositTxID1: {Deposit: earlyDeposit, removed: true},
 						},
 					},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
-		"Fail: deposits in added (early) and parent state (late), but all removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in added (early) and parent state (late), but all parent removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{lateDepositTxID1, lateDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
-				return &diff{
-					stateVersions: newMockStateVersions(c, parentStateID, parentState),
-					parentID:      parentStateID,
-					caminoDiff: &caminoDiff{
-						modifiedDeposits: map[ids.ID]*depositDiff{
-							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
-							lateDepositTxID1:  {Deposit: lateDeposit, removed: true},
-							lateDepositTxID2:  {Deposit: lateDeposit, removed: true},
-						},
-					},
-				}
-			},
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
-		},
-		"Fail: deposits in added (early) and parent state (late), but one removed": {
-			diff: func(c *gomock.Controller) *diff {
-				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{lateDepositTxID1, lateDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -361,13 +326,32 @@ func TestDiffGetNextToUnlockDepositTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but one removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(lateDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+							lateDepositTxID1:  {Deposit: lateDeposit, removed: true},
+						},
+					},
+				}
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in added only": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(nil, time.Time{}, database.ErrNotFound)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, database.ErrNotFound)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -382,13 +366,10 @@ func TestDiffGetNextToUnlockDepositTime(t *testing.T) {
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in parent state only": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, lateDepositTxID1},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(earlyDeposit.EndTime(), nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -398,13 +379,10 @@ func TestDiffGetNextToUnlockDepositTime(t *testing.T) {
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in added (late) and parent state (early)": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(earlyDeposit.EndTime(), nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -418,13 +396,10 @@ func TestDiffGetNextToUnlockDepositTime(t *testing.T) {
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in added (early, mid) and parent state (late)": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{lateDepositTxID1},
-					lateDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(lateDeposit.EndTime(), nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -438,12 +413,220 @@ func TestDiffGetNextToUnlockDepositTime(t *testing.T) {
 			},
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
+		"Fail: deposits in parent state only, but all removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, database.ErrNotFound)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff:    &caminoDiff{},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockTime: mockable.MaxTime,
+			expectedErr:            database.ErrNotFound,
+		},
+		"Fail: deposits in parent state only, but all removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, database.ErrNotFound)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockTime: mockable.MaxTime,
+			expectedErr:            database.ErrNotFound,
+		},
+		"OK: deposits in added (late) and parent state (early), but all parent removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							lateDepositTxID1:  {Deposit: lateDeposit, added: true},
+							earlyDepositTxID1: {Deposit: earlyDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockTime: lateDeposit.EndTime(),
+		},
+		"OK: deposits in added (late) and parent state (early), but all parent removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							lateDepositTxID1: {Deposit: lateDeposit, added: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockTime: lateDeposit.EndTime(),
+		},
+		"OK: deposits in added (late) and parent state (early), but some parent removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(earlyDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							lateDepositTxID1:  {Deposit: lateDeposit, added: true},
+							earlyDepositTxID1: {Deposit: earlyDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (late) and parent state (early), but some parent removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(earlyDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							lateDepositTxID1: {Deposit: lateDeposit, added: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but all parent removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+							lateDepositTxID1:  {Deposit: lateDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				lateDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but all parent removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(mockable.MaxTime, nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				lateDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but some removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(lateDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+							lateDepositTxID1:  {Deposit: lateDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				lateDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but some removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositTime(removedDepositIDs).
+					Return(lateDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				lateDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			nextUnlockTime, err := tt.diff(ctrl).GetNextToUnlockDepositTime()
+			nextUnlockTime, err := tt.diff(ctrl, tt.removedDepositIDs).GetNextToUnlockDepositTime(tt.removedDepositIDs)
 			require.ErrorIs(t, err, tt.expectedErr)
 			require.Equal(t, tt.expectedNextUnlockTime, nextUnlockTime)
 		})
@@ -454,40 +637,42 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 	parentStateID := ids.GenerateTestID()
 	earlyDepositTxID1 := ids.ID{1}
 	earlyDepositTxID2 := ids.ID{2}
+	earlyDepositTxID3 := ids.ID{3}
 	midDepositTxID := ids.ID{10}
-	lateDepositTxID1 := ids.ID{100}
-	lateDepositTxID2 := ids.ID{200}
+	lateDepositTxID1 := ids.ID{101}
+	lateDepositTxID2 := ids.ID{102}
+	lateDepositTxID3 := ids.ID{103}
 	earlyDeposit := &deposit.Deposit{Duration: 101}
 	midDeposit := &deposit.Deposit{Duration: 102}
 	lateDeposit := &deposit.Deposit{Duration: 103}
 
 	tests := map[string]struct {
-		diff                   func(*gomock.Controller) *diff
+		diff                   func(*gomock.Controller, set.Set[ids.ID]) *diff
+		removedDepositIDs      set.Set[ids.ID]
 		expectedNextUnlockIDs  []ids.ID
 		expectedNextUnlockTime time.Time
 		expectedErr            error
 	}{
 		"Fail: no deposits": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(nil, time.Time{}, database.ErrNotFound)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, database.ErrNotFound)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
 					caminoDiff:    &caminoDiff{},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
+			expectedNextUnlockTime: mockable.MaxTime,
 			expectedErr:            database.ErrNotFound,
 		},
 		"Fail: deposits in parent state only, but all removed": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1, earlyDepositTxID2)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, database.ErrNotFound)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -499,17 +684,15 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockTime: mockable.MaxTime,
+			expectedErr:            database.ErrNotFound,
 		},
-		"Fail: deposits in parent state only, but one removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in parent state only, but one removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{earlyDepositTxID2}, earlyDeposit.EndTime(), nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -520,17 +703,15 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID2},
 		},
-		"Fail: deposits in added (late) and parent state (early), but all removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in added (late) and parent state (early), but all parent removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1, earlyDepositTxID2)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, database.ErrNotFound)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -543,18 +724,15 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockIDs:  nil,
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockIDs:  []ids.ID{lateDepositTxID1},
+			expectedNextUnlockTime: lateDeposit.EndTime(),
 		},
-		"Fail: deposits in added (late) and parent state (early), but one removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in added (late) and parent state (early), but one parent removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{earlyDepositTxID2}, earlyDeposit.EndTime(), nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -566,18 +744,15 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockIDs:  nil,
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID2},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
-		"Fail: deposits in added (early) and parent state (late), but all removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in added (early) and parent state (late), but all parent removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1, lateDepositTxID2)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{lateDepositTxID1, lateDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -590,18 +765,15 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockIDs:  nil,
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID1},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
-		"Fail: deposits in added (early) and parent state (late), but one removed": {
-			diff: func(c *gomock.Controller) *diff {
+		"OK: deposits in added (early) and parent state (late), but one parent removed": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1)
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
-					[]ids.ID{lateDepositTxID1, lateDepositTxID2},
-					earlyDeposit.EndTime(),
-					nil,
-				)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{lateDepositTxID2}, lateDeposit.EndTime(), nil)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -613,14 +785,13 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 					},
 				}
 			},
-			expectedNextUnlockIDs:  nil,
-			expectedNextUnlockTime: time.Time{},
-			expectedErr:            errInvalidatedNextToUnlockTime,
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID1},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in added only (early, late)": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(nil, time.Time{}, database.ErrNotFound)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).Return(nil, mockable.MaxTime, database.ErrNotFound)
 				return &diff{
 					stateVersions: newMockStateVersions(c, parentStateID, parentState),
 					parentID:      parentStateID,
@@ -636,9 +807,9 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in parent state only": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).Return(
 					[]ids.ID{earlyDepositTxID1, earlyDepositTxID2},
 					earlyDeposit.EndTime(),
 					nil,
@@ -653,9 +824,9 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in added (late) and parent state (early)": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).Return(
 					[]ids.ID{earlyDepositTxID1},
 					earlyDeposit.EndTime(),
 					nil,
@@ -674,9 +845,9 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in added (early, mid) and parent state (late)": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).Return(
 					[]ids.ID{lateDepositTxID1},
 					lateDeposit.EndTime(),
 					nil,
@@ -696,9 +867,9 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
 		"OK: deposits in added (early1, late) and parent state (early2)": {
-			diff: func(c *gomock.Controller) *diff {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
 				parentState := NewMockChain(c)
-				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime().Return(
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).Return(
 					[]ids.ID{earlyDepositTxID2},
 					earlyDeposit.EndTime(),
 					nil,
@@ -717,12 +888,267 @@ func TestDiffGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID1, earlyDepositTxID2},
 			expectedNextUnlockTime: earlyDeposit.EndTime(),
 		},
+		"Fail: deposits in parent state only, but all removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, database.ErrNotFound)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff:    &caminoDiff{},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockTime: mockable.MaxTime,
+			expectedErr:            database.ErrNotFound,
+		},
+		"OK: deposits in parent state only, but one removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{earlyDepositTxID2}, earlyDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff:    &caminoDiff{},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID2},
+		},
+		"OK: deposits in added (late) and parent state (early), but all parent removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, database.ErrNotFound)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							lateDepositTxID1: {Deposit: lateDeposit, added: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockIDs:  []ids.ID{lateDepositTxID1},
+			expectedNextUnlockTime: lateDeposit.EndTime(),
+		},
+		"OK: deposits in added (late) and parent state (early), but one parent removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{earlyDepositTxID2}, earlyDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							lateDepositTxID1: {Deposit: lateDeposit, added: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID2},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but all parent removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				lateDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID1},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but one parent removed in arg": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{lateDepositTxID2}, lateDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				lateDepositTxID1: struct{}{},
+			},
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID1},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+
+		"Fail: deposits in parent state only, but all removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, database.ErrNotFound)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockTime: mockable.MaxTime,
+			expectedErr:            database.ErrNotFound,
+		},
+		"OK: deposits in parent state only, but some removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{earlyDepositTxID3}, earlyDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID3},
+		},
+		"OK: deposits in added (late) and parent state (early), but all parent removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, database.ErrNotFound)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							lateDepositTxID1:  {Deposit: lateDeposit, added: true},
+							earlyDepositTxID1: {Deposit: lateDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockIDs:  []ids.ID{lateDepositTxID1},
+			expectedNextUnlockTime: lateDeposit.EndTime(),
+		},
+		"OK: deposits in added (late) and parent state (early), but some parent removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(earlyDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{earlyDepositTxID3}, earlyDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							lateDepositTxID1:  {Deposit: lateDeposit, added: true},
+							earlyDepositTxID1: {Deposit: lateDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				earlyDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID3},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but all parent removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return(nil, mockable.MaxTime, nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+							lateDepositTxID1:  {Deposit: lateDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				lateDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID1},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
+		"OK: deposits in added (early) and parent state (late), but some parent removed (one in arg, one in diff)": {
+			diff: func(c *gomock.Controller, removedDepositIDs set.Set[ids.ID]) *diff {
+				removedDepositIDs.Add(lateDepositTxID1)
+				parentState := NewMockChain(c)
+				parentState.EXPECT().GetNextToUnlockDepositIDsAndTime(removedDepositIDs).
+					Return([]ids.ID{lateDepositTxID3}, lateDeposit.EndTime(), nil)
+				return &diff{
+					stateVersions: newMockStateVersions(c, parentStateID, parentState),
+					parentID:      parentStateID,
+					caminoDiff: &caminoDiff{
+						modifiedDeposits: map[ids.ID]*depositDiff{
+							earlyDepositTxID1: {Deposit: earlyDeposit, added: true},
+							lateDepositTxID1:  {Deposit: lateDeposit, removed: true},
+						},
+					},
+				}
+			},
+			removedDepositIDs: set.Set[ids.ID]{
+				lateDepositTxID2: struct{}{},
+			},
+			expectedNextUnlockIDs:  []ids.ID{earlyDepositTxID1},
+			expectedNextUnlockTime: earlyDeposit.EndTime(),
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			nextUnlockIDs, nextUnlockTime, err := tt.diff(ctrl).GetNextToUnlockDepositIDsAndTime()
+			nextUnlockIDs, nextUnlockTime, err := tt.diff(ctrl, tt.removedDepositIDs).GetNextToUnlockDepositIDsAndTime(tt.removedDepositIDs)
 			require.ErrorIs(t, err, tt.expectedErr)
 			require.Equal(t, tt.expectedNextUnlockTime, nextUnlockTime)
 			require.Equal(t, tt.expectedNextUnlockIDs, nextUnlockIDs)

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -84,12 +84,12 @@ func (s *state) GetDeposit(depositTxID ids.ID) (*deposit.Deposit, error) {
 	return s.caminoState.GetDeposit(depositTxID)
 }
 
-func (s *state) GetNextToUnlockDepositTime() (time.Time, error) {
-	return s.caminoState.GetNextToUnlockDepositTime()
+func (s *state) GetNextToUnlockDepositTime(removedDepositIDs set.Set[ids.ID]) (time.Time, error) {
+	return s.caminoState.GetNextToUnlockDepositTime(removedDepositIDs)
 }
 
-func (s *state) GetNextToUnlockDepositIDsAndTime() ([]ids.ID, time.Time, error) {
-	return s.caminoState.GetNextToUnlockDepositIDsAndTime()
+func (s *state) GetNextToUnlockDepositIDsAndTime(removedDepositIDs set.Set[ids.ID]) ([]ids.ID, time.Time, error) {
+	return s.caminoState.GetNextToUnlockDepositIDsAndTime(removedDepositIDs)
 }
 
 func (s *state) SetMultisigAlias(owner *multisig.Alias) {

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -356,24 +356,24 @@ func (mr *MockChainMockRecorder) GetDeposit(arg0 interface{}) *gomock.Call {
 }
 
 // GetNextToUnlockDepositTime mocks base method.
-func (m *MockChain) GetNextToUnlockDepositTime() (time.Time, error) {
+func (m *MockChain) GetNextToUnlockDepositTime(arg0 set.Set[ids.ID]) (time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNextToUnlockDepositTime")
+	ret := m.ctrl.Call(m, "GetNextToUnlockDepositTime", arg0)
 	ret0, _ := ret[0].(time.Time)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNextToUnlockDepositTime indicates an expected call of GetNextToUnlockDepositTime.
-func (mr *MockChainMockRecorder) GetNextToUnlockDepositTime() *gomock.Call {
+func (mr *MockChainMockRecorder) GetNextToUnlockDepositTime(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositTime", reflect.TypeOf((*MockChain)(nil).GetNextToUnlockDepositTime))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositTime", reflect.TypeOf((*MockChain)(nil).GetNextToUnlockDepositTime), arg0)
 }
 
 // GetNextToUnlockDepositIDsAndTime mocks base method.
-func (m *MockChain) GetNextToUnlockDepositIDsAndTime() ([]ids.ID, time.Time, error) {
+func (m *MockChain) GetNextToUnlockDepositIDsAndTime(arg0 set.Set[ids.ID]) ([]ids.ID, time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNextToUnlockDepositIDsAndTime")
+	ret := m.ctrl.Call(m, "GetNextToUnlockDepositIDsAndTime", arg0)
 	ret0, _ := ret[0].([]ids.ID)
 	ret1, _ := ret[1].(time.Time)
 	ret2, _ := ret[2].(error)
@@ -381,9 +381,9 @@ func (m *MockChain) GetNextToUnlockDepositIDsAndTime() ([]ids.ID, time.Time, err
 }
 
 // GetNextToUnlockDepositIDsAndTime indicates an expected call of GetNextToUnlockDepositIDsAndTime.
-func (mr *MockChainMockRecorder) GetNextToUnlockDepositIDsAndTime() *gomock.Call {
+func (mr *MockChainMockRecorder) GetNextToUnlockDepositIDsAndTime(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositIDsAndTime", reflect.TypeOf((*MockChain)(nil).GetNextToUnlockDepositIDsAndTime))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositIDsAndTime", reflect.TypeOf((*MockChain)(nil).GetNextToUnlockDepositIDsAndTime), arg0)
 }
 
 // GetDepositOffer mocks base method.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -380,24 +380,24 @@ func (mr *MockDiffMockRecorder) GetDeposit(arg0 interface{}) *gomock.Call {
 }
 
 // GetNextToUnlockDepositTime mocks base method.
-func (m *MockDiff) GetNextToUnlockDepositTime() (time.Time, error) {
+func (m *MockDiff) GetNextToUnlockDepositTime(arg0 set.Set[ids.ID]) (time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNextToUnlockDepositTime")
+	ret := m.ctrl.Call(m, "GetNextToUnlockDepositTime", arg0)
 	ret0, _ := ret[0].(time.Time)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNextToUnlockDepositTime indicates an expected call of GetNextToUnlockDepositTime.
-func (mr *MockDiffMockRecorder) GetNextToUnlockDepositTime() *gomock.Call {
+func (mr *MockDiffMockRecorder) GetNextToUnlockDepositTime(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositTime", reflect.TypeOf((*MockDiff)(nil).GetNextToUnlockDepositTime))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositTime", reflect.TypeOf((*MockDiff)(nil).GetNextToUnlockDepositTime), arg0)
 }
 
 // GetNextToUnlockDepositIDsAndTime mocks base method.
-func (m *MockDiff) GetNextToUnlockDepositIDsAndTime() ([]ids.ID, time.Time, error) {
+func (m *MockDiff) GetNextToUnlockDepositIDsAndTime(arg0 set.Set[ids.ID]) ([]ids.ID, time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNextToUnlockDepositIDsAndTime")
+	ret := m.ctrl.Call(m, "GetNextToUnlockDepositIDsAndTime", arg0)
 	ret0, _ := ret[0].([]ids.ID)
 	ret1, _ := ret[1].(time.Time)
 	ret2, _ := ret[2].(error)
@@ -405,9 +405,9 @@ func (m *MockDiff) GetNextToUnlockDepositIDsAndTime() ([]ids.ID, time.Time, erro
 }
 
 // GetNextToUnlockDepositIDsAndTime indicates an expected call of GetNextToUnlockDepositIDsAndTime.
-func (mr *MockDiffMockRecorder) GetNextToUnlockDepositIDsAndTime() *gomock.Call {
+func (mr *MockDiffMockRecorder) GetNextToUnlockDepositIDsAndTime(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositIDsAndTime", reflect.TypeOf((*MockDiff)(nil).GetNextToUnlockDepositIDsAndTime))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositIDsAndTime", reflect.TypeOf((*MockDiff)(nil).GetNextToUnlockDepositIDsAndTime), arg0)
 }
 
 // GetDepositOffer mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -427,24 +427,24 @@ func (mr *MockStateMockRecorder) GetDeposit(arg0 interface{}) *gomock.Call {
 }
 
 // GetNextToUnlockDepositTime mocks base method.
-func (m *MockState) GetNextToUnlockDepositTime() (time.Time, error) {
+func (m *MockState) GetNextToUnlockDepositTime(arg0 set.Set[ids.ID]) (time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNextToUnlockDepositTime")
+	ret := m.ctrl.Call(m, "GetNextToUnlockDepositTime", arg0)
 	ret0, _ := ret[0].(time.Time)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNextToUnlockDepositTime indicates an expected call of GetNextToUnlockDepositTime.
-func (mr *MockStateMockRecorder) GetNextToUnlockDepositTime() *gomock.Call {
+func (mr *MockStateMockRecorder) GetNextToUnlockDepositTime(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositTime", reflect.TypeOf((*MockState)(nil).GetNextToUnlockDepositTime))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositTime", reflect.TypeOf((*MockState)(nil).GetNextToUnlockDepositTime), arg0)
 }
 
 // GetNextToUnlockDepositIDsAndTime mocks base method.
-func (m *MockState) GetNextToUnlockDepositIDsAndTime() ([]ids.ID, time.Time, error) {
+func (m *MockState) GetNextToUnlockDepositIDsAndTime(arg0 set.Set[ids.ID]) ([]ids.ID, time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNextToUnlockDepositIDsAndTime")
+	ret := m.ctrl.Call(m, "GetNextToUnlockDepositIDsAndTime", arg0)
 	ret0, _ := ret[0].([]ids.ID)
 	ret1, _ := ret[1].(time.Time)
 	ret2, _ := ret[2].(error)
@@ -452,9 +452,9 @@ func (m *MockState) GetNextToUnlockDepositIDsAndTime() ([]ids.ID, time.Time, err
 }
 
 // GetNextToUnlockDepositIDsAndTime indicates an expected call of GetNextToUnlockDepositIDsAndTime.
-func (mr *MockStateMockRecorder) GetNextToUnlockDepositIDsAndTime() *gomock.Call {
+func (mr *MockStateMockRecorder) GetNextToUnlockDepositIDsAndTime(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositIDsAndTime", reflect.TypeOf((*MockState)(nil).GetNextToUnlockDepositIDsAndTime))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextToUnlockDepositIDsAndTime", reflect.TypeOf((*MockState)(nil).GetNextToUnlockDepositIDsAndTime), arg0)
 }
 
 // GetDepositOffer mocks base method.

--- a/vms/platformvm/txs/executor/camino_chain_event.go
+++ b/vms/platformvm/txs/executor/camino_chain_event.go
@@ -23,7 +23,7 @@ func GetNextChainEventTime(state state.Chain, stakerChangeTime time.Time) (time.
 		earliestTime = nextDeferredStakerEndTime
 	}
 
-	depositUnlockTime, err := state.GetNextToUnlockDepositTime()
+	depositUnlockTime, err := state.GetNextToUnlockDepositTime(nil)
 	if err != nil && err != database.ErrNotFound {
 		return time.Time{}, err
 	}


### PR DESCRIPTION
This PR changes internal logic of `GetNextToUnlockDepositIDsAndTime` and `GetNextToUnlockDepositTime` methods. It also adds correct behavior for cases, when state contains removed deposits.