### PR TITLE
[PVM] unlockUTXOs return error instead of skip, deposits iterator process db error

### DIFF
--- a/vms/platformvm/state/camino_deposit.go
+++ b/vms/platformvm/state/camino_deposit.go
@@ -225,6 +225,10 @@ func (cs caminoState) getNextToUnlockDepositIDsAndTimeFromDB(removedDepositIDs s
 		nextDeposits = append(nextDeposits, depositID)
 	}
 
+	if err := depositIterator.Error(); err != nil {
+		return nil, time.Time{}, err
+	}
+
 	if len(nextDeposits) == 0 {
 		return nil, mockable.MaxTime, database.ErrNotFound
 	}

--- a/vms/platformvm/state/camino_deposit_test.go
+++ b/vms/platformvm/state/camino_deposit_test.go
@@ -281,6 +281,7 @@ func TestGetNextToUnlockDepositTime(t *testing.T) {
 			caminoState: func(c *gomock.Controller) *caminoState {
 				it := database.NewMockIterator(c)
 				it.EXPECT().Next().Return(false)
+				it.EXPECT().Error().Return(nil)
 				it.EXPECT().Release()
 
 				db := database.NewMockDatabase(c)
@@ -313,6 +314,7 @@ func TestGetNextToUnlockDepositTime(t *testing.T) {
 				it.EXPECT().Key().Return(depositToKey(depositTxID31[:], deposit31))
 				it.EXPECT().Key().Return(depositToKey(depositTxID32[:], deposit32))
 				it.EXPECT().Next().Return(false)
+				it.EXPECT().Error().Return(nil)
 				it.EXPECT().Release()
 
 				db := database.NewMockDatabase(c)
@@ -382,6 +384,7 @@ func TestGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 			caminoState: func(c *gomock.Controller) *caminoState {
 				it := database.NewMockIterator(c)
 				it.EXPECT().Next().Return(false)
+				it.EXPECT().Error().Return(nil)
 				it.EXPECT().Release()
 
 				db := database.NewMockDatabase(c)
@@ -415,6 +418,7 @@ func TestGetNextToUnlockDepositIDsAndTime(t *testing.T) {
 				it.EXPECT().Key().Return(depositToKey(depositTxID31[:], deposit31))
 				it.EXPECT().Key().Return(depositToKey(depositTxID32[:], deposit32))
 				it.EXPECT().Next().Return(false)
+				it.EXPECT().Error().Return(nil)
 				it.EXPECT().Release()
 
 				db := database.NewMockDatabase(c)
@@ -594,6 +598,7 @@ func TestWriteDeposits(t *testing.T) {
 				depositsIterator.EXPECT().Next().Return(true)
 				depositsIterator.EXPECT().Key().Return(depositToKey(depositTxID1[:], deposit1))
 				depositsIterator.EXPECT().Next().Return(false)
+				depositsIterator.EXPECT().Error().Return(nil)
 				depositsIterator.EXPECT().Release()
 
 				depositIDsByEndtimeDB := database.NewMockDatabase(c)
@@ -662,6 +667,7 @@ func TestLoadDeposits(t *testing.T) {
 				depositsIterator.EXPECT().Key().Return(depositToKey(depositTxID1[:], deposit1))
 				depositsIterator.EXPECT().Key().Return(depositToKey(depositTxID2[:], deposit2))
 				depositsIterator.EXPECT().Key().Return(depositToKey(depositTxID3[:], deposit3))
+				depositsIterator.EXPECT().Error().Return(nil)
 				depositsIterator.EXPECT().Release()
 				depositIDsByEndtimeDB := database.NewMockDatabase(c)
 				depositIDsByEndtimeDB.EXPECT().NewIterator().Return(depositsIterator)
@@ -680,6 +686,7 @@ func TestLoadDeposits(t *testing.T) {
 			caminoState: func(c *gomock.Controller) *caminoState {
 				depositsIterator := database.NewMockIterator(c)
 				depositsIterator.EXPECT().Next().Return(false)
+				depositsIterator.EXPECT().Error().Return(nil)
 				depositsIterator.EXPECT().Release()
 				depositIDsByEndtimeDB := database.NewMockDatabase(c)
 				depositIDsByEndtimeDB.EXPECT().NewIterator().Return(depositsIterator)

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -95,10 +95,11 @@ func TestUnlockUTXOs(t *testing.T) {
 			},
 			generateWant: func(utxos []*avax.UTXO) want {
 				return want{
-					ins:  []*avax.TransferableInput{},
-					outs: []*avax.TransferableOutput{},
+					ins:  nil,
+					outs: nil,
 				}
 			},
+			expectedError: errNotLockedUTXO,
 		},
 		"Undeposit bonded UTXOs": {
 			lockState: locked.StateDeposited,
@@ -107,10 +108,11 @@ func TestUnlockUTXOs(t *testing.T) {
 			},
 			generateWant: func(utxos []*avax.UTXO) want {
 				return want{
-					ins:  []*avax.TransferableInput{},
-					outs: []*avax.TransferableOutput{},
+					ins:  nil,
+					outs: nil,
 				}
 			},
+			expectedError: errNotLockedUTXO,
 		},
 		"Unlock unlocked UTXOs": {
 			lockState: locked.StateBonded,
@@ -119,10 +121,11 @@ func TestUnlockUTXOs(t *testing.T) {
 			},
 			generateWant: func(utxos []*avax.UTXO) want {
 				return want{
-					ins:  []*avax.TransferableInput{},
-					outs: []*avax.TransferableOutput{},
+					ins:  nil,
+					outs: nil,
 				}
 			},
+			expectedError: errNotLockedUTXO,
 		},
 		"Wrong state, lockStateUnlocked": {
 			lockState: locked.StateUnlocked,


### PR DESCRIPTION
- Currently, utxo handler unlockUTXOs method just skips utxos that it can't unlock, thought this method should unlock all utxos (for example, unbonding). This PR changes this behavior, so this method will error if it can't unlock any given utxo.
- Method, that gets depositIDs by endtime from iterator that is iterating over deposits-by-endtime db, isn't processing db errors. This PR solves that.