### PR TITLE
Deposit offers limit

### DIFF
--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,15 +370,15 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2FWy6wbtsNuU57dApwj1874by5FokQfCyLDjstTUM3jXMAq2wD",
+			expectedID: "23SLkqz8fHUhV963jPKVTw5v4yoWi9WAaBkAwmgVKVpnPKeiDs",
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "2Qkk3HFATS1A2w89oBaEArNrrcfmAG2AZYUMKRveZ3sZ5suWB2",
+			expectedID: "2Uvo2S395UaCi7yLYVCwWiVpCwoHjNpULT4MpGCoXMbFdRBexv",
 		},
 		{
 			networkID:  constants.KopernikusID,
-			expectedID: "2ZeMvHVJZVUsXJwAj4fNJsHbdrLCQ2NpVH28WLkqTppKD3Y4UN",
+			expectedID: "2ZzQb7uQzm5M7Ty59i7L9HHP2hDXVtX4Tp5UWMzsfx4TUqMAK3",
 		},
 		{
 			networkID:  constants.LocalID,

--- a/vms/platformvm/camino_service_test.go
+++ b/vms/platformvm/camino_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm
@@ -247,15 +247,15 @@ func TestCaminoService_GetAllDepositOffers(t *testing.T) {
 				},
 			},
 			prepare: func(service CaminoService) {
-				service.vm.state.AddDepositOffer(&deposit.Offer{
+				service.vm.state.SetDepositOffer(&deposit.Offer{
 					ID:    ids.ID{0},
 					Flags: 0,
 				})
-				service.vm.state.AddDepositOffer(&deposit.Offer{
+				service.vm.state.SetDepositOffer(&deposit.Offer{
 					ID:    ids.ID{1},
 					Flags: 0,
 				})
-				service.vm.state.AddDepositOffer(&deposit.Offer{
+				service.vm.state.SetDepositOffer(&deposit.Offer{
 					ID:    ids.ID{2},
 					Flags: 1,
 				})
@@ -284,15 +284,15 @@ func TestCaminoService_GetAllDepositOffers(t *testing.T) {
 				},
 			},
 			prepare: func(service CaminoService) {
-				service.vm.state.AddDepositOffer(&deposit.Offer{
+				service.vm.state.SetDepositOffer(&deposit.Offer{
 					ID:    ids.ID{0},
 					Flags: 0,
 				})
-				service.vm.state.AddDepositOffer(&deposit.Offer{
+				service.vm.state.SetDepositOffer(&deposit.Offer{
 					ID:    ids.ID{1},
 					Flags: 0,
 				})
-				service.vm.state.AddDepositOffer(&deposit.Offer{
+				service.vm.state.SetDepositOffer(&deposit.Offer{
 					ID:    ids.ID{2},
 					Flags: 1,
 				})

--- a/vms/platformvm/deposit/camino_deposit.go
+++ b/vms/platformvm/deposit/camino_deposit.go
@@ -33,6 +33,8 @@ type Offer struct {
 	Start                   uint64              `serialize:"true" json:"start"`
 	End                     uint64              `serialize:"true" json:"end"`
 	MinAmount               uint64              `serialize:"true" json:"minAmount"`
+	TotalMaxAmount          uint64              `serialize:"true" json:"totalMaxAmount"`
+	DepositedAmount         uint64              `serialize:"true" json:"depositedAmount"`
 	MinDuration             uint32              `serialize:"true" json:"minDuration"`
 	MaxDuration             uint32              `serialize:"true" json:"maxDuration"`
 	UnlockPeriodDuration    uint32              `serialize:"true" json:"unlockPeriodDuration"`
@@ -59,6 +61,10 @@ func (o *Offer) StartTime() time.Time {
 // Time when this offer becomes inactive
 func (o *Offer) EndTime() time.Time {
 	return time.Unix(int64(o.End), 0)
+}
+
+func (o *Offer) RemainingAmount() uint64 {
+	return o.TotalMaxAmount - o.DepositedAmount
 }
 
 func (o *Offer) InterestRateFloat64() float64 {

--- a/vms/platformvm/deposit/camino_deposit_test.go
+++ b/vms/platformvm/deposit/camino_deposit_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 package deposit
 
 import (
@@ -39,12 +41,10 @@ func TestTotalReward(t *testing.T) {
 				Duration: uint32(tt.DepositDuration),
 			}
 
-			depOffer := Offer{
+			require.EqualValues(expectedRewardAmount, dep.TotalReward(&Offer{
 				InterestRateNominator:   tt.InterestRateNominator,
 				NoRewardsPeriodDuration: tt.NoRewardsPeriodDuration,
-			}
-
-			require.EqualValues(expectedRewardAmount, dep.TotalReward(&depOffer))
+			}))
 		})
 	}
 }

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -75,7 +75,7 @@ type CaminoDiff interface {
 	// Deposit offers
 
 	// precondition: offer.SetID() must be called and return no error
-	AddDepositOffer(offer *deposit.Offer)
+	SetDepositOffer(offer *deposit.Offer)
 	GetDepositOffer(offerID ids.ID) (*deposit.Offer, error)
 	GetAllDepositOffers() ([]*deposit.Offer, error)
 
@@ -348,7 +348,7 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 	depositOffers := make(map[ids.ID]*deposit.Offer, len(g.Camino.DepositOffers))
 	for _, offer := range g.Camino.DepositOffers {
 		depositOffers[offer.ID] = offer
-		cs.AddDepositOffer(offer)
+		cs.SetDepositOffer(offer)
 	}
 
 	// adding msig aliases

--- a/vms/platformvm/state/camino_deposit_offer.go
+++ b/vms/platformvm/state/camino_deposit_offer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 )
 
-func (cs *caminoState) AddDepositOffer(offer *deposit.Offer) {
+func (cs *caminoState) SetDepositOffer(offer *deposit.Offer) {
 	cs.modifiedDepositOffers[offer.ID] = offer
 }
 
@@ -61,9 +61,7 @@ func (cs *caminoState) loadDepositOffers() error {
 		}
 
 		depositOfferBytes := depositOffersIt.Value()
-		depositOffer := &deposit.Offer{
-			ID: depositOfferID,
-		}
+		depositOffer := &deposit.Offer{ID: depositOfferID}
 		if _, err := blocks.GenesisCodec.Unmarshal(depositOfferBytes, depositOffer); err != nil {
 			return err
 		}

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -110,7 +110,7 @@ func (d *diff) GetAddressStates(address ids.ShortID) (uint64, error) {
 	return parentState.GetAddressStates(address)
 }
 
-func (d *diff) AddDepositOffer(offer *deposit.Offer) {
+func (d *diff) SetDepositOffer(offer *deposit.Offer) {
 	d.caminoDiff.modifiedDepositOffers[offer.ID] = offer
 }
 
@@ -397,7 +397,7 @@ func (d *diff) ApplyCaminoState(baseState State) {
 	}
 
 	for _, depositOffer := range d.caminoDiff.modifiedDepositOffers {
-		baseState.AddDepositOffer(depositOffer)
+		baseState.SetDepositOffer(depositOffer)
 	}
 
 	for depositTxID, depositDiff := range d.caminoDiff.modifiedDeposits {

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -56,8 +56,8 @@ func (s *state) GetAddressStates(address ids.ShortID) (uint64, error) {
 	return s.caminoState.GetAddressStates(address)
 }
 
-func (s *state) AddDepositOffer(offer *deposit.Offer) {
-	s.caminoState.AddDepositOffer(offer)
+func (s *state) SetDepositOffer(offer *deposit.Offer) {
+	s.caminoState.SetDepositOffer(offer)
 }
 
 func (s *state) GetDepositOffer(offerID ids.ID) (*deposit.Offer, error) {

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -58,16 +58,16 @@ func (mr *MockChainMockRecorder) AddChain(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddChain", reflect.TypeOf((*MockChain)(nil).AddChain), arg0)
 }
 
-// AddDepositOffer mocks base method.
-func (m *MockChain) AddDepositOffer(arg0 *deposit.Offer) {
+// SetDepositOffer mocks base method.
+func (m *MockChain) SetDepositOffer(arg0 *deposit.Offer) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddDepositOffer", arg0)
+	m.ctrl.Call(m, "SetDepositOffer", arg0)
 }
 
-// AddDepositOffer indicates an expected call of AddDepositOffer.
-func (mr *MockChainMockRecorder) AddDepositOffer(arg0 interface{}) *gomock.Call {
+// SetDepositOffer indicates an expected call of SetDepositOffer.
+func (mr *MockChainMockRecorder) SetDepositOffer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDepositOffer", reflect.TypeOf((*MockChain)(nil).AddDepositOffer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDepositOffer", reflect.TypeOf((*MockChain)(nil).SetDepositOffer), arg0)
 }
 
 // AddRewardUTXO mocks base method.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -58,16 +58,16 @@ func (mr *MockDiffMockRecorder) AddChain(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddChain", reflect.TypeOf((*MockDiff)(nil).AddChain), arg0)
 }
 
-// AddDepositOffer mocks base method.
-func (m *MockDiff) AddDepositOffer(arg0 *deposit.Offer) {
+// SetDepositOffer mocks base method.
+func (m *MockDiff) SetDepositOffer(arg0 *deposit.Offer) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddDepositOffer", arg0)
+	m.ctrl.Call(m, "SetDepositOffer", arg0)
 }
 
-// AddDepositOffer indicates an expected call of AddDepositOffer.
-func (mr *MockDiffMockRecorder) AddDepositOffer(arg0 interface{}) *gomock.Call {
+// SetDepositOffer indicates an expected call of SetDepositOffer.
+func (mr *MockDiffMockRecorder) SetDepositOffer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDepositOffer", reflect.TypeOf((*MockDiff)(nil).AddDepositOffer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDepositOffer", reflect.TypeOf((*MockDiff)(nil).SetDepositOffer), arg0)
 }
 
 // AddRewardUTXO mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -74,16 +74,16 @@ func (mr *MockStateMockRecorder) AddChain(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddChain", reflect.TypeOf((*MockState)(nil).AddChain), arg0)
 }
 
-// AddDepositOffer mocks base method.
-func (m *MockState) AddDepositOffer(arg0 *deposit.Offer) {
+// SetDepositOffer mocks base method.
+func (m *MockState) SetDepositOffer(arg0 *deposit.Offer) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddDepositOffer", arg0)
+	m.ctrl.Call(m, "SetDepositOffer", arg0)
 }
 
-// AddDepositOffer indicates an expected call of AddDepositOffer.
-func (mr *MockStateMockRecorder) AddDepositOffer(arg0 interface{}) *gomock.Call {
+// SetDepositOffer indicates an expected call of SetDepositOffer.
+func (mr *MockStateMockRecorder) SetDepositOffer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDepositOffer", reflect.TypeOf((*MockState)(nil).AddDepositOffer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDepositOffer", reflect.TypeOf((*MockState)(nil).SetDepositOffer), arg0)
 }
 
 // AddRewardUTXO mocks base method.


### PR DESCRIPTION
- Adds two new field to deposit offer: `TotalMaxAmount` and `DepositedAmount`. First field defines how much tokens could be deposited with this offer in total, second field defines how much tokens was already deposited with this offer. `DepositedAmount` should be 0 for new offers.
- Updates DepositTx, so it will respect new offer fields.