### PR TITLE
Treasury rewards rework

### DIFF
--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -507,7 +507,11 @@ func (s *CaminoService) Claim(_ *http.Request, args *ClaimArgs, reply *api.JSONT
 
 	claimableOwnerIDs := make([]ids.ID, len(args.ClaimableOwners))
 	for i := range args.ClaimableOwners {
-		ownerID, err := txs.GetOwnerID(args.ClaimableOwners[i])
+		claimableOwner, err := s.getOutputOwner(&args.ClaimableOwners[i])
+		if err != nil {
+			return fmt.Errorf("failed to parse api owner to secp owner: %w", err)
+		}
+		ownerID, err := txs.GetOwnerID(claimableOwner)
 		if err != nil {
 			return fmt.Errorf("failed to calculate ownerID from owner: %w", err)
 		}

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -524,7 +524,6 @@ func TestDepositsAutoUnlock(t *testing.T) {
 		DepositReward: deposit.TotalReward(depositOffer),
 	}, claimable)
 	require.Equal(getUnlockedBalance(t, vm.state, depositOwnerAddr), depositOffer.MinAmount)
-	require.Equal(getUnlockedBalance(t, vm.state, treasury.Addr), deposit.TotalReward(depositOffer))
 	require.Equal(deposit.EndTime(), vm.state.GetTimestamp())
 	_, err = vm.state.GetNextToUnlockDepositTime(nil)
 	require.ErrorIs(err, database.ErrNotFound)

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -545,7 +545,7 @@ func generateKeyAndOwner() (*crypto.PrivateKeySECP256K1R, ids.ShortID, secp256k1
 	}
 }
 
-func generateTestInFromUTXO(utxo *avax.UTXO, sigIndices []uint32) *avax.TransferableInput {
+func generateTestInFromUTXO(utxo *avax.UTXO, sigIndices []uint32, init bool) *avax.TransferableInput {
 	var in avax.TransferableIn
 	switch out := utxo.Out.(type) {
 	case *secp256k1fx.TransferOutput:
@@ -565,33 +565,17 @@ func generateTestInFromUTXO(utxo *avax.UTXO, sigIndices []uint32) *avax.Transfer
 		panic("unknown utxo.Out type")
 	}
 
-	// to be sure that utxoid.id is set in both entities
-	utxo.InputID()
-	return &avax.TransferableInput{
-		UTXOID: utxo.UTXOID,
+	input := &avax.TransferableInput{
+		UTXOID: avax.UTXOID{TxID: utxo.UTXOID.TxID, OutputIndex: utxo.UTXOID.OutputIndex},
 		Asset:  utxo.Asset,
 		In:     in,
 	}
-}
 
-func generateTestOut(assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.TransferableOutput {
-	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
-		Amt:          amount,
-		OutputOwners: outputOwners,
+	if init {
+		input.InputID()
 	}
-	if depositTxID != ids.Empty || bondTxID != ids.Empty {
-		out = &locked.Out{
-			IDs: locked.IDs{
-				DepositTxID: depositTxID,
-				BondTxID:    bondTxID,
-			},
-			TransferableOut: out,
-		}
-	}
-	return &avax.TransferableOutput{
-		Asset: avax.Asset{ID: assetID},
-		Out:   out,
-	}
+
+	return input
 }
 
 func newCaminoBuilderWithMocks(postBanff bool, state state.State, sharedMemory atomic.SharedMemory) (*caminoBuilder, *versiondb.Database) {

--- a/vms/platformvm/txs/camino_claim_tx.go
+++ b/vms/platformvm/txs/camino_claim_tx.go
@@ -9,25 +9,18 @@ import (
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/utils"
-	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/set"
-	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
-	"github.com/ava-labs/avalanchego/vms/platformvm/treasury"
-	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
 var (
 	_ UnsignedTx = (*ClaimTx)(nil)
 
-	errNoDepositsOrClaimables     = errors.New("no deposit txs with rewards or claimables to claim")
-	errNonUniqueDepositTxID       = errors.New("non-unique deposit tx id")
-	errNonUniqueOwnerID           = errors.New("non-unique owner id")
-	errWrongClaimedAmount         = errors.New("zero claimed amount or amounts len doesn't match ownerIDs len")
-	errMultipleTreasuryOuts       = errors.New("multiple treasury outputs")
-	errWrongProducedClaimedAmount = errors.New("claimed amount not equal to produced claimed amount")
+	errNoDepositsOrClaimables = errors.New("no deposit txs with rewards or claimables to claim")
+	errNonUniqueDepositTxID   = errors.New("non-unique deposit tx id")
+	errNonUniqueOwnerID       = errors.New("non-unique owner id")
+	errWrongClaimedAmount     = errors.New("zero claimed amount or amounts len doesn't match ownerIDs len")
 )
 
 // ClaimTx is an unsigned ClaimTx
@@ -35,19 +28,16 @@ type ClaimTx struct {
 	// Metadata, inputs and outputs
 	BaseTx `serialize:"true"`
 	// IDs of deposit txs which will be used to claim rewards
-	DepositTxs []ids.ID `serialize:"true" json:"depositTxs"`
+	DepositTxIDs []ids.ID `serialize:"true" json:"depositTxIDs"`
 	// Owner ids of claimables owners (validator rewards, expired deposit unclaimed rewards).
 	// ID is hash256 of owners structure (secp256k1fx.OutputOwners, for example)
 	ClaimableOwnerIDs []ids.ID `serialize:"true" json:"claimableOwnerIDs"`
 	// How much tokens will be claimed for corresponding claimableOwnerIDs
-	ClaimedAmount []uint64 `serialize:"true" json:"claimedAmount"`
-	// Inputs that will consume treasury utxos
-	ClaimableIns []*avax.TransferableInput `serialize:"true" json:"claimableIns"`
-	// Outputs produced from treasury utxos containing both treasury change (if any) and claimed tokens
-	ClaimableOuts []*avax.TransferableOutput `serialize:"true" json:"claimableOuts"`
-	// Deposit rewards outputs will be minted to this owner, unless all of its fields has zero-values.
-	// If it is empty, deposit rewards will be minted for depositTx.RewardsOwner.
-	DepositRewardsOwner fx.Owner `serialize:"true" json:"depositRewardsOwner"`
+	ClaimedAmounts []uint64 `serialize:"true" json:"claimedAmounts"`
+	// Reward and claimables outputs will be minted to this owner, unless all of its fields has zero-values.
+	// If it is empty, deposit rewards will be minted for depositTx.RewardsOwner
+	// and claimables will be minted for claimable owners.
+	ClaimTo fx.Owner `serialize:"true" json:"claimTo"`
 }
 
 // InitCtx sets the FxID fields in the inputs and outputs of this
@@ -55,29 +45,7 @@ type ClaimTx struct {
 // the addresses can be json marshalled into human readable format
 func (tx *ClaimTx) InitCtx(ctx *snow.Context) {
 	tx.BaseTx.InitCtx(ctx)
-	tx.DepositRewardsOwner.InitCtx(ctx)
-	for _, in := range tx.ClaimableIns {
-		in.FxID = secp256k1fx.ID
-	}
-	for _, out := range tx.ClaimableOuts {
-		out.FxID = secp256k1fx.ID
-		out.InitCtx(ctx)
-	}
-}
-
-func (tx *ClaimTx) InputIDs() set.Set[ids.ID] {
-	inputIDs := set.NewSet[ids.ID](len(tx.Ins) + len(tx.ClaimableIns))
-	for _, in := range tx.Ins {
-		inputIDs.Add(in.InputID())
-	}
-	for _, in := range tx.ClaimableIns {
-		inputIDs.Add(in.InputID())
-	}
-	return inputIDs
-}
-
-func (tx *ClaimTx) Outputs() []*avax.TransferableOutput {
-	return append(tx.Outs, tx.ClaimableOuts...)
+	tx.ClaimTo.InitCtx(ctx)
 }
 
 // SyntacticVerify returns nil if [tx] is valid
@@ -87,28 +55,14 @@ func (tx *ClaimTx) SyntacticVerify(ctx *snow.Context) error {
 		return ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
-	case len(tx.DepositTxs) == 0 && len(tx.ClaimableOwnerIDs) == 0:
+	case len(tx.DepositTxIDs) == 0 && len(tx.ClaimableOwnerIDs) == 0:
 		return errNoDepositsOrClaimables
-	case len(tx.ClaimableOwnerIDs) != len(tx.ClaimedAmount):
-		return errWrongClaimedAmount
-	case len(tx.ClaimableOwnerIDs) == 0 && len(tx.ClaimableIns) != 0:
+	case len(tx.ClaimableOwnerIDs) != len(tx.ClaimedAmounts):
 		return errWrongClaimedAmount
 	}
 
-	claimedAmount := uint64(0)
-	for _, amt := range tx.ClaimedAmount {
-		if amt == 0 {
-			return errWrongClaimedAmount
-		}
-		newClaimedAmount, err := math.Add64(claimedAmount, amt)
-		if err != nil {
-			return err
-		}
-		claimedAmount = newClaimedAmount
-	}
-
-	uniqueIDs := set.NewSet[ids.ID](len(tx.DepositTxs))
-	for _, depositTxID := range tx.DepositTxs {
+	uniqueIDs := set.NewSet[ids.ID](len(tx.DepositTxIDs))
+	for _, depositTxID := range tx.DepositTxIDs {
 		if _, ok := uniqueIDs[depositTxID]; ok {
 			return errNonUniqueDepositTxID
 		}
@@ -126,87 +80,12 @@ func (tx *ClaimTx) SyntacticVerify(ctx *snow.Context) error {
 	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {
 		return fmt.Errorf("failed to verify BaseTx: %w", err)
 	}
-	if err := tx.DepositRewardsOwner.Verify(); err != nil {
+	if err := tx.ClaimTo.Verify(); err != nil {
 		return fmt.Errorf("failed to verify DepositRewardsOwner: %w", err)
 	}
 
 	if err := locked.VerifyNoLocks(tx.Ins, tx.Outs); err != nil {
 		return err
-	}
-
-	consumedTreasury := uint64(0)
-	for i, in := range tx.ClaimableIns {
-		if err := in.Verify(); err != nil {
-			return fmt.Errorf("failed to verify tx.ClaimableIns[%d]: %w", i, err)
-		}
-		if inputAssetID := in.AssetID(); inputAssetID != ctx.AVAXAssetID {
-			return fmt.Errorf("input %d has asset ID %s but expect %s: %w",
-				i, inputAssetID, ctx.AVAXAssetID, errNotAVAXAsset)
-		}
-
-		if _, ok := in.In.(*secp256k1fx.TransferInput); !ok {
-			return locked.ErrWrongInType
-		}
-
-		newConsumedTreasury, err := math.Add64(consumedTreasury, in.In.Amount())
-		if err != nil {
-			return err
-		}
-		consumedTreasury = newConsumedTreasury
-	}
-
-	producedClaimed := uint64(0)
-	producedTreasury := uint64(0)
-	for i, out := range tx.ClaimableOuts {
-		if err := out.Verify(); err != nil {
-			return fmt.Errorf("failed to verify tx.ClaimableOuts[%d]: %w", i, err)
-		}
-		if outputAssetID := out.AssetID(); outputAssetID != ctx.AVAXAssetID {
-			return fmt.Errorf("output %d has asset ID %s but expect %s: %w",
-				i, outputAssetID, ctx.AVAXAssetID, errNotAVAXAsset)
-		}
-
-		secpOut, ok := out.Out.(*secp256k1fx.TransferOutput)
-		if !ok {
-			return locked.ErrWrongOutType
-		}
-
-		if secpOut.OutputOwners.Equals(treasury.Owner) {
-			if producedTreasury != 0 {
-				return errMultipleTreasuryOuts
-			}
-			newProducedTreasury, err := math.Add64(producedTreasury, out.Out.Amount())
-			if err != nil {
-				return err
-			}
-			producedTreasury = newProducedTreasury
-		} else {
-			newProducedClaimed, err := math.Add64(producedClaimed, out.Out.Amount())
-			if err != nil {
-				return err
-			}
-			producedClaimed = newProducedClaimed
-		}
-	}
-
-	if producedClaimed != claimedAmount {
-		return errWrongProducedClaimedAmount
-	}
-
-	producedFromTreasury, err := math.Add64(producedTreasury, producedClaimed)
-	if err != nil {
-		return err
-	}
-	// consumedTreasury-producedTreasury != producedClaimed
-	if consumedTreasury != producedFromTreasury {
-		return errProducedNotEqualConsumed
-	}
-
-	switch {
-	case !avax.IsSortedTransferableOutputs(tx.ClaimableOuts, Codec):
-		return errOutputsNotSorted
-	case !utils.IsSortedAndUniqueSortable(tx.ClaimableIns):
-		return errInputsNotSortedUnique
 	}
 
 	// cache that this is valid

--- a/vms/platformvm/txs/camino_claim_tx_test.go
+++ b/vms/platformvm/txs/camino_claim_tx_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
-	"github.com/ava-labs/avalanchego/vms/platformvm/treasury"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/stretchr/testify/require"
 )
@@ -19,10 +18,6 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 	ctx := snow.DefaultContextTest()
 	ctx.AVAXAssetID = ids.GenerateTestID()
 	owner1 := secp256k1fx.OutputOwners{
-		Threshold: 1,
-		Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
-	}
-	owner2 := secp256k1fx.OutputOwners{
 		Threshold: 1,
 		Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
 	}
@@ -36,10 +31,8 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 	}}
 
 	tests := map[string]struct {
-		tx                    *ClaimTx
-		dontSortClaimableIns  bool
-		dontSortClaimableOuts bool
-		expectedErr           error
+		tx          *ClaimTx
+		expectedErr error
 	}{
 		"Nil tx": {
 			expectedErr: ErrNilTx,
@@ -54,32 +47,14 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 			tx: &ClaimTx{
 				BaseTx:            baseTx,
 				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
-				ClaimedAmount:     []uint64{1, 2},
-			},
-			expectedErr: errWrongClaimedAmount,
-		},
-		"Claimed amount is 0": {
-			tx: &ClaimTx{
-				BaseTx:            baseTx,
-				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
-				ClaimedAmount:     []uint64{0},
-			},
-			expectedErr: errWrongClaimedAmount,
-		},
-		"No claimble owner ids, but have claimable inputs": {
-			tx: &ClaimTx{
-				BaseTx:     baseTx,
-				DepositTxs: []ids.ID{depositTxID},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-				},
+				ClaimedAmounts:    []uint64{1, 2},
 			},
 			expectedErr: errWrongClaimedAmount,
 		},
 		"Not unique depositTxs": {
 			tx: &ClaimTx{
-				BaseTx:     baseTx,
-				DepositTxs: []ids.ID{depositTxID, depositTxID},
+				BaseTx:       baseTx,
+				DepositTxIDs: []ids.ID{depositTxID, depositTxID},
 			},
 			expectedErr: errNonUniqueDepositTxID,
 		},
@@ -87,7 +62,7 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 			tx: &ClaimTx{
 				BaseTx:            baseTx,
 				ClaimableOwnerIDs: []ids.ID{claimableOwnerID, claimableOwnerID},
-				ClaimedAmount:     []uint64{1, 1},
+				ClaimedAmounts:    []uint64{1, 1},
 			},
 			expectedErr: errNonUniqueOwnerID,
 		},
@@ -100,8 +75,8 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 						generateTestIn(ctx.AVAXAssetID, 1, ids.GenerateTestID(), ids.Empty, []uint32{0}),
 					},
 				}},
-				DepositTxs:          []ids.ID{depositTxID},
-				DepositRewardsOwner: &owner1,
+				DepositTxIDs: []ids.ID{depositTxID},
+				ClaimTo:      &owner1,
 			},
 			expectedErr: locked.ErrWrongInType,
 		},
@@ -114,289 +89,38 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 						generateTestOut(ctx.AVAXAssetID, 1, owner1, ids.GenerateTestID(), ids.Empty),
 					},
 				}},
-				DepositTxs:          []ids.ID{depositTxID},
-				DepositRewardsOwner: &owner1,
-			},
-			expectedErr: locked.ErrWrongOutType,
-		},
-		"Claimable input has wrong asset": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ids.GenerateTestID(), 1, ids.Empty, ids.Empty, []uint32{}),
-				},
-			},
-			expectedErr: errNotAVAXAsset,
-		},
-		"Claimable output has wrong asset": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ids.GenerateTestID(), 1, owner1, ids.Empty, ids.Empty),
-				},
-			},
-			expectedErr: errNotAVAXAsset,
-		},
-		"Multiple treasury outs": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 2, ids.Empty, ids.Empty, []uint32{}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-				},
-			},
-			expectedErr: errMultipleTreasuryOuts,
-		},
-		"Claimed amount is less than produced claimed amount": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 3, ids.Empty, ids.Empty, []uint32{}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-					generateTestOut(ctx.AVAXAssetID, 2, owner1, ids.Empty, ids.Empty),
-				},
-			},
-			expectedErr: errWrongProducedClaimedAmount,
-		},
-		"Claimed amount is greater than produced claimed amount": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{3},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 2, ids.Empty, ids.Empty, []uint32{}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-					generateTestOut(ctx.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
-				},
-			},
-			expectedErr: errWrongProducedClaimedAmount,
-		},
-		"Consumed from treasury less than produced": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 2, *treasury.Owner, ids.Empty, ids.Empty),
-					generateTestOut(ctx.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
-				},
-			},
-			expectedErr: errProducedNotEqualConsumed,
-		},
-		"Consumed from treasury more than produced": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
-				},
-			},
-			expectedErr: errProducedNotEqualConsumed,
-		},
-		"Claimable inputs not sorted": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					{
-						UTXOID: avax.UTXOID{TxID: ids.ID{2}},
-						Asset:  avax.Asset{ID: ctx.AVAXAssetID},
-						In: &secp256k1fx.TransferInput{
-							Amt:   1,
-							Input: secp256k1fx.Input{SigIndices: []uint32{}},
-						},
-					},
-					{
-						UTXOID: avax.UTXOID{TxID: ids.ID{1}},
-						Asset:  avax.Asset{ID: ctx.AVAXAssetID},
-						In: &secp256k1fx.TransferInput{
-							Amt:   1,
-							Input: secp256k1fx.Input{SigIndices: []uint32{}},
-						},
-					},
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-					generateTestOut(ctx.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
-				},
-			},
-			dontSortClaimableIns: true,
-			expectedErr:          errInputsNotSortedUnique,
-		},
-		"Claimable inputs not unique": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					{
-						UTXOID: avax.UTXOID{TxID: ids.ID{1}},
-						Asset:  avax.Asset{ID: ctx.AVAXAssetID},
-						In: &secp256k1fx.TransferInput{
-							Amt:   1,
-							Input: secp256k1fx.Input{SigIndices: []uint32{}},
-						},
-					},
-					{
-						UTXOID: avax.UTXOID{TxID: ids.ID{1}},
-						Asset:  avax.Asset{ID: ctx.AVAXAssetID},
-						In: &secp256k1fx.TransferInput{
-							Amt:   1,
-							Input: secp256k1fx.Input{SigIndices: []uint32{}},
-						},
-					},
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-					generateTestOut(ctx.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
-				},
-			},
-			expectedErr: errInputsNotSortedUnique,
-		},
-		"Claimable outputs not sorted": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 3, ids.Empty, ids.Empty, []uint32{0}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					{
-						Asset: avax.Asset{ID: ctx.AVAXAssetID},
-						Out: &secp256k1fx.TransferOutput{
-							Amt:          2,
-							OutputOwners: *treasury.Owner,
-						},
-					},
-					{
-						Asset: avax.Asset{ID: ctx.AVAXAssetID},
-						Out: &secp256k1fx.TransferOutput{
-							Amt:          1,
-							OutputOwners: owner1,
-						},
-					},
-				},
-			},
-			dontSortClaimableOuts: true,
-			expectedErr:           errOutputsNotSorted,
-		},
-		"Locked claimable input": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.GenerateTestID(), ids.Empty, []uint32{0}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
-				},
-			},
-			expectedErr: locked.ErrWrongInType,
-		},
-		"Locked claimable output": {
-			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{1},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{0}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, owner1, ids.GenerateTestID(), ids.Empty),
-				},
+				DepositTxIDs: []ids.ID{depositTxID},
+				ClaimTo:      &owner1,
 			},
 			expectedErr: locked.ErrWrongOutType,
 		},
 		"OK with deposits": {
 			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositTxs:          []ids.ID{depositTxID},
-				DepositRewardsOwner: &owner1,
+				BaseTx:       baseTx,
+				DepositTxIDs: []ids.ID{depositTxID},
+				ClaimTo:      &owner1,
 			},
 		},
 		"OK with claimables": {
 			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{20},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 10, ids.Empty, ids.Empty, []uint32{}),
-					generateTestIn(ctx.AVAXAssetID, 10, ids.Empty, ids.Empty, []uint32{}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 12, owner1, ids.Empty, ids.Empty),
-					generateTestOut(ctx.AVAXAssetID, 8, owner2, ids.Empty, ids.Empty),
-				},
+				BaseTx:            baseTx,
+				ClaimTo:           &owner1,
+				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
+				ClaimedAmounts:    []uint64{20},
 			},
 		},
 		"OK with claimables and deposits": {
 			tx: &ClaimTx{
-				BaseTx:              baseTx,
-				DepositTxs:          []ids.ID{depositTxID},
-				DepositRewardsOwner: &owner1,
-				ClaimableOwnerIDs:   []ids.ID{claimableOwnerID},
-				ClaimedAmount:       []uint64{20},
-				ClaimableIns: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 10, ids.Empty, ids.Empty, []uint32{}),
-					generateTestIn(ctx.AVAXAssetID, 10, ids.Empty, ids.Empty, []uint32{}),
-				},
-				ClaimableOuts: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 12, owner1, ids.Empty, ids.Empty),
-					generateTestOut(ctx.AVAXAssetID, 8, owner2, ids.Empty, ids.Empty),
-				},
+				BaseTx:            baseTx,
+				DepositTxIDs:      []ids.ID{depositTxID},
+				ClaimTo:           &owner1,
+				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
+				ClaimedAmounts:    []uint64{20},
 			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if tt.tx != nil {
-				if !tt.dontSortClaimableIns {
-					avax.SortTransferableInputs(tt.tx.ClaimableIns)
-				}
-				if !tt.dontSortClaimableOuts {
-					avax.SortTransferableOutputs(tt.tx.ClaimableOuts, Codec)
-				}
-			}
 			require.ErrorIs(t, tt.tx.SyntacticVerify(ctx), tt.expectedErr)
 		})
 	}

--- a/vms/platformvm/txs/camino_rewards_import_tx.go
+++ b/vms/platformvm/txs/camino_rewards_import_tx.go
@@ -10,22 +10,18 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
-	"github.com/ava-labs/avalanchego/vms/platformvm/treasury"
-	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
 
 var (
 	_ UnsignedTx = (*RewardsImportTx)(nil)
 
-	errNotTreasuryOwner         = errors.New("not treasury owner")
-	errProducedNotEqualConsumed = errors.New("produced amount not equal to consumed amount")
-	errNotAVAXAsset             = errors.New("transferable assetID isn't avax assetID")
-	errWrongOutsNumber          = errors.New("wrong number of outputs")
+	errNotAVAXAsset    = errors.New("transferable assetID isn't avax assetID")
+	errWrongOutsNumber = errors.New("wrong number of outputs")
 )
 
 // RewardsImportTx is an unsigned rewardsImportTx
 type RewardsImportTx struct {
-	// Metadata, imported inputs and resulting output
+	// Metadata, imported inputs
 	BaseTx `serialize:"true"`
 }
 
@@ -35,28 +31,12 @@ func (tx *RewardsImportTx) SyntacticVerify(ctx *snow.Context) error {
 		return ErrNilTx
 	case tx.SyntacticallyVerified: // already passed syntactic verification
 		return nil
-	case len(tx.Outs) != 1:
-		return fmt.Errorf("expect 1 output, but got %d: %w", len(tx.Outs), errWrongOutsNumber)
+	case len(tx.Outs) != 0:
+		return fmt.Errorf("expect 0 outputs, but got %d: %w", len(tx.Outs), errWrongOutsNumber)
 	}
 
 	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {
 		return fmt.Errorf("failed to verify BaseTx: %w", err)
-	}
-
-	out := tx.Outs[0]
-
-	if outAssetID := out.AssetID(); outAssetID != ctx.AVAXAssetID {
-		return fmt.Errorf("output 0 has asset ID %s but expect %s: %w",
-			outAssetID, ctx.AVAXAssetID, errNotAVAXAsset)
-	}
-
-	secpOut, ok := out.Out.(*secp256k1fx.TransferOutput)
-	if !ok {
-		return locked.ErrWrongOutType
-	}
-
-	if !secpOut.OutputOwners.Equals(treasury.Owner) {
-		return errNotTreasuryOwner
 	}
 
 	importedAmount := uint64(0)
@@ -71,10 +51,6 @@ func (tx *RewardsImportTx) SyntacticVerify(ctx *snow.Context) error {
 			return err
 		}
 		importedAmount = newImportedAmount
-	}
-
-	if out.Out.Amount() != importedAmount {
-		return errProducedNotEqualConsumed
 	}
 
 	if err := locked.VerifyNoLocks(tx.Ins, nil); err != nil {

--- a/vms/platformvm/txs/camino_rewards_import_tx_test.go
+++ b/vms/platformvm/txs/camino_rewards_import_tx_test.go
@@ -10,18 +10,12 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
-	"github.com/ava-labs/avalanchego/vms/platformvm/treasury"
-	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRewardsImportTxSyntacticVerify(t *testing.T) {
 	ctx := snow.DefaultContextTest()
 	ctx.AVAXAssetID = ids.GenerateTestID()
-	otherOwner := secp256k1fx.OutputOwners{
-		Threshold: 1,
-		Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
-	}
 
 	tests := map[string]struct {
 		tx          *RewardsImportTx
@@ -33,56 +27,16 @@ func TestRewardsImportTxSyntacticVerify(t *testing.T) {
 					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
 					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
 				},
-				Outs: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 2, *treasury.Owner, ids.Empty, ids.Empty),
-				},
 			}}},
 		},
 		"Nil tx": {
 			expectedErr: ErrNilTx,
-		},
-		"Zero outs": {
-			tx:          &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{}}},
-			expectedErr: errWrongOutsNumber,
-		},
-		"More than one out": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
-				Outs: make([]*avax.TransferableOutput, 2),
-			}}},
-			expectedErr: errWrongOutsNumber,
-		},
-		"Out has wrong asset": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
-				Outs: []*avax.TransferableOutput{
-					generateTestOut(ids.GenerateTestID(), 1, *treasury.Owner, ids.Empty, ids.Empty),
-				},
-			}}},
-			expectedErr: errNotAVAXAsset,
-		},
-		"Not secp output": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
-				Outs: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.GenerateTestID(), ids.Empty),
-				},
-			}}},
-			expectedErr: locked.ErrWrongOutType,
-		},
-		"Output owner isn't treasury owner": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
-				Outs: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, otherOwner, ids.Empty, ids.Empty),
-				},
-			}}},
-			expectedErr: errNotTreasuryOwner,
 		},
 		"Input has wrong asset": {
 			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
 				Ins: []*avax.TransferableInput{
 					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
 					generateTestIn(ids.GenerateTestID(), 1, ids.Empty, ids.Empty, []uint32{}),
-				},
-				Outs: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 2, *treasury.Owner, ids.Empty, ids.Empty),
 				},
 			}}},
 			expectedErr: errNotAVAXAsset,
@@ -92,35 +46,8 @@ func TestRewardsImportTxSyntacticVerify(t *testing.T) {
 				Ins: []*avax.TransferableInput{
 					generateTestIn(ctx.AVAXAssetID, 1, ids.GenerateTestID(), ids.Empty, []uint32{}),
 				},
-				Outs: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-				},
 			}}},
 			expectedErr: locked.ErrWrongInType,
-		},
-		"Produced less than consumed": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
-				Ins: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-				},
-				Outs: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 1, *treasury.Owner, ids.Empty, ids.Empty),
-				},
-			}}},
-			expectedErr: errProducedNotEqualConsumed,
-		},
-		"Produced more than consumed": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
-				Ins: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-				},
-				Outs: []*avax.TransferableOutput{
-					generateTestOut(ctx.AVAXAssetID, 3, *treasury.Owner, ids.Empty, ids.Empty),
-				},
-			}}},
-			expectedErr: errProducedNotEqualConsumed,
 		},
 	}
 	for name, tt := range tests {

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -654,7 +654,7 @@ func expectConsumeUTXOs(s *state.MockDiff, ins []*avax.TransferableInput) {
 	}
 }
 
-func expectProduceUTXOs(s *state.MockDiff, outs []*avax.TransferableOutput, txID ids.ID, baseOutIndex int) {
+func expectProduceUTXOs(s *state.MockDiff, outs []*avax.TransferableOutput, txID ids.ID, baseOutIndex int) { //nolint:unparam
 	for i := range outs {
 		s.EXPECT().AddUTXO(&avax.UTXO{
 			UTXOID: avax.UTXOID{

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
@@ -57,14 +58,13 @@ var (
 	errNodeAlreadyRegistered        = errors.New("node is already registered")
 	errDepositCredentialMissmatch   = errors.New("deposit credential isn't matching")
 	errClaimableCredentialMissmatch = errors.New("claimable credential isn't matching")
-	errDepositNotFound              = errors.New("deposit tx not found")
+	errDepositNotFound              = errors.New("deposit not found")
 	errNotSECPOwner                 = errors.New("owner is not *secp256k1fx.OutputOwners")
 	errWrongCredentialsNumber       = errors.New("unexpected number of credentials")
 	errWrongOwnerType               = errors.New("wrong owner type")
 	errImportedUTXOMissmatch        = errors.New("imported input doesn't match expected utxo")
 	errInputAmountMissmatch         = errors.New("utxo amount doesn't match input amount")
 	errInputsUTXOSMismatch          = errors.New("number of inputs is different from number of utxos")
-	errClaimingNonTreasuryUTXO      = errors.New("claiming utxo owned by other owner, than treasury owner")
 	errWrongClaimedAmount           = errors.New("claiming more than was available to claim")
 	errMsigAlias                    = errors.New("can't use msig alias here")
 )
@@ -680,7 +680,6 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 	}
 
 	txID := e.Tx.ID()
-	depositRewardOutIndex := 0
 
 	for depositTxID, newUnlockedAmount := range newUnlockedAmounts {
 		deposit, err := e.State.GetDeposit(depositTxID)
@@ -714,15 +713,6 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 					return err
 				}
 
-				outIntf, err := e.Fx.CreateOutput(remainingReward, treasury.Owner)
-				if err != nil {
-					return fmt.Errorf("failed to create output: %w", err)
-				}
-				out, ok := outIntf.(verify.State)
-				if !ok {
-					return errInvalidState
-				}
-
 				claimable, err := e.State.GetClaimable(claimableOwnerID)
 				if err == database.ErrNotFound {
 					scepOwner, ok := depositTx.RewardsOwner.(*secp256k1fx.OutputOwners)
@@ -746,18 +736,6 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 					return err
 				}
 
-				utxo := &avax.UTXO{
-					UTXOID: avax.UTXOID{
-						TxID:        txID,
-						OutputIndex: uint32(len(tx.Outs) + depositRewardOutIndex),
-					},
-					Asset: avax.Asset{ID: e.Ctx.AVAXAssetID},
-					Out:   out,
-				}
-				depositRewardOutIndex++
-
-				e.State.AddRewardUTXO(txID, utxo)
-				e.State.AddUTXO(utxo)
 				e.State.SetClaimable(claimableOwnerID, newClaimable)
 			}
 			e.State.RemoveDeposit(depositTxID, deposit)
@@ -816,9 +794,18 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 	claimableCredential := []verify.Verifiable{e.Tx.Creds[len(e.Tx.Creds)-1]}
 	txID := e.Tx.ID()
 
+	newClaimTo := false
+	if secpOwner, ok := tx.ClaimTo.(*secp256k1fx.OutputOwners); !ok {
+		return errNotSECPOwner
+	} else if len(secpOwner.Addrs) != 0 {
+		newClaimTo = true
+	}
+
 	// Checking deposits sigs and creating reward outputs
 
-	for i, depositTxID := range tx.DepositTxs {
+	mintedOutsCount := 0
+
+	for _, depositTxID := range tx.DepositTxIDs {
 		// getting deposit tx
 
 		signedDepositTx, txStatus, err := e.State.GetTx(depositTxID)
@@ -853,7 +840,7 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 
 		deposit, err := e.State.GetDeposit(depositTxID)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w: %s", errDepositNotFound, err)
 		}
 
 		depositOffer, err := e.State.GetDepositOffer(deposit.DepositOfferID)
@@ -863,16 +850,12 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 
 		claimableReward := deposit.ClaimableReward(depositOffer, currentTimestamp)
 		if claimableReward > 0 {
-			rewardsOwner := tx.DepositRewardsOwner
-			secpOwners, ok := rewardsOwner.(*secp256k1fx.OutputOwners)
-			if !ok {
-				return errNotSECPOwner
-			}
-			if len(secpOwners.Addrs) == 0 {
-				rewardsOwner = depositTx.RewardsOwner
+			claimTo := depositTx.RewardsOwner
+			if newClaimTo {
+				claimTo = tx.ClaimTo
 			}
 
-			outIntf, err := e.Fx.CreateOutput(claimableReward, rewardsOwner)
+			outIntf, err := e.Fx.CreateOutput(claimableReward, claimTo)
 			if err != nil {
 				return fmt.Errorf("failed to create output: %w", err)
 			}
@@ -884,11 +867,12 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 			utxo := &avax.UTXO{
 				UTXOID: avax.UTXOID{
 					TxID:        txID,
-					OutputIndex: uint32(len(tx.Outs) + len(tx.ClaimableOuts) + i),
+					OutputIndex: uint32(len(tx.Outs) + mintedOutsCount),
 				},
 				Asset: avax.Asset{ID: e.Ctx.AVAXAssetID},
 				Out:   out,
 			}
+			mintedOutsCount++
 
 			e.State.AddUTXO(utxo)
 			e.State.AddRewardUTXO(depositTxID, utxo)
@@ -903,7 +887,7 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 		}
 	}
 
-	// Checking claimables sigs and claimable amounts, updating claimables in state
+	// Checking claimables sigs and claimable amounts, updating claimables in state // todo@ comment
 
 	for i, ownerID := range tx.ClaimableOwnerIDs {
 		claimable, err := e.State.GetClaimable(ownerID)
@@ -923,7 +907,7 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 			return fmt.Errorf("%w: %s", errClaimableCredentialMissmatch, err)
 		}
 
-		amountToClaim := tx.ClaimedAmount[i]
+		amountToClaim := tx.ClaimedAmounts[i]
 
 		newClaimableValidatorReward := claimable.ValidatorReward
 		if amountToClaim > newClaimableValidatorReward {
@@ -947,6 +931,33 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 			return errWrongClaimedAmount
 		}
 
+		var claimTo fx.Owner = claimable.Owner
+		if newClaimTo {
+			claimTo = tx.ClaimTo
+		}
+
+		outIntf, err := e.Fx.CreateOutput(tx.ClaimedAmounts[i], claimTo)
+		if err != nil {
+			return fmt.Errorf("failed to create output: %w", err)
+		}
+		out, ok := outIntf.(verify.State)
+		if !ok {
+			return errInvalidState
+		}
+
+		utxo := &avax.UTXO{
+			UTXOID: avax.UTXOID{
+				TxID:        txID,
+				OutputIndex: uint32(len(tx.Outs) + mintedOutsCount),
+			},
+			Asset: avax.Asset{ID: e.Ctx.AVAXAssetID},
+			Out:   out,
+		}
+		mintedOutsCount++
+
+		e.State.AddUTXO(utxo)
+		e.State.AddRewardUTXO(txID, utxo)
+
 		var newClaimabe *state.Claimable
 		if newClaimableDepositReward != 0 || newClaimableValidatorReward != 0 {
 			newClaimabe = &state.Claimable{
@@ -956,41 +967,6 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 			}
 		}
 		e.State.SetClaimable(ownerID, newClaimabe)
-	}
-
-	// Checking treasury consume
-
-	for _, in := range tx.ClaimableIns {
-		treasuryUTXO, err := e.State.GetUTXO(in.InputID())
-		if err != nil {
-			return err
-		}
-		treasuryOut, ok := treasuryUTXO.Out.(*secp256k1fx.TransferOutput)
-		if !ok {
-			return locked.ErrWrongOutType
-		}
-
-		if !treasuryOut.OutputOwners.Equals(treasury.Owner) {
-			return errClaimingNonTreasuryUTXO
-		}
-
-		if treasuryOut.Amt != in.In.Amount() {
-			return fmt.Errorf("utxo.Amt %d, input.Amt %d: %w", treasuryOut.Amt, in.In.Amount(), errInputAmountMissmatch)
-		}
-	}
-
-	// Consuming / producing treasury and claimed utxos
-
-	utxo.Consume(e.State, tx.ClaimableIns)
-	for i, output := range tx.ClaimableOuts {
-		e.State.AddUTXO(&avax.UTXO{
-			UTXOID: avax.UTXOID{
-				TxID:        txID,
-				OutputIndex: uint32(len(tx.Outs) + i),
-			},
-			Asset: avax.Asset{ID: e.Ctx.AVAXAssetID},
-			Out:   output.Out,
-		})
 	}
 
 	// Consuming / producing fee utxos
@@ -1138,8 +1114,6 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 		return errWrongLockMode
 	}
 
-	outs := tx.Outputs()
-
 	if err := e.Tx.SyntacticVerify(e.Ctx); err != nil {
 		return err
 	}
@@ -1228,7 +1202,15 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 		return err
 	}
 
-	amountToDistribute, err := math.Add64(tx.Outs[0].Out.Amount(), notDistributedAmount)
+	importedAmount := uint64(0)
+	for _, in := range tx.Ins {
+		importedAmount, err = math.Add64(importedAmount, in.In.Amount())
+		if err != nil {
+			return err
+		}
+	}
+
+	amountToDistribute, err := math.Add64(importedAmount, notDistributedAmount)
 	if err != nil {
 		return err
 	}
@@ -1276,9 +1258,7 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 		}
 	}
 
-	// Produce UTXOs and atomic request
-
-	utxo.Produce(e.State, e.Tx.ID(), outs)
+	// Atomic request
 
 	utxoIDs := make([][]byte, len(tx.Ins))
 	e.Inputs = set.NewSet[ids.ID](len(tx.Ins))


### PR DESCRIPTION
Before this PR, validator and expired deposits rewards were stored as treasury utxos. Then claimTx transaction would spend this utxos to produce outs owned by claimer.

But that could lead to issue, when at least two users will create claimTx in one block - those txs will most likely try to spend the same treasury utxos, so only one tx will be valid.

This PR removes treasury utxos - they now burned on import and minted on claim.