### PR TITLE
[PVM][MULTISIG] new type to export utxo together with msig

### DIFF
--- a/vms/components/avax/camino_utxo_with_msig.go
+++ b/vms/components/avax/camino_utxo_with_msig.go
@@ -1,0 +1,20 @@
+package avax
+
+import (
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+)
+
+type UTXOWithMSig struct {
+	UTXO    `serialize:"true"`
+	Aliases []verify.State `serialize:"true" json:"aliases"`
+}
+
+func (utxo *UTXOWithMSig) Verify() error {
+	for _, alias := range utxo.Aliases {
+		if err := alias.Verify(); err != nil {
+			return err
+		}
+	}
+
+	return utxo.UTXO.Verify()
+}

--- a/vms/components/multisig/camino_multisig.go
+++ b/vms/components/multisig/camino_multisig.go
@@ -22,6 +22,13 @@ type Alias struct {
 	Owners verify.State        `serialize:"true" json:"owners"`
 }
 
+type AliasWithNonce struct {
+	Alias `serialize:"true" json:"alias"`
+
+	// Nonce reflects how many times the owners of this alias have changed
+	Nonce uint64 `serialize:"true" json:"nonce"`
+}
+
 func (ma *Alias) InitCtx(ctx *snow.Context) {
 	ma.Owners.InitCtx(ctx)
 }

--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -11,8 +11,10 @@ import (
 type CaminoFx interface {
 	// Recovers signers addresses from [verifies] credentials for [utx] transaction
 	RecoverAddresses(utx secp256k1fx.UnsignedTx, verifies []verify.Verifiable) (secp256k1fx.RecoverMap, error)
+
 	// Verifies that Multisig aliases are on inputs are only used in supported hierarchy
 	VerifyMultisigOwner(outIntf, msigIntf interface{}) error
+
 	// VerifyMultisigTransfer verifies that the specified transaction can spend the
 	// provided utxo with no restrictions on the destination. If the transaction
 	// can't spend the output based on the input and credential, a non-nil error
@@ -26,4 +28,7 @@ type CaminoFx interface {
 	// VerifyMultisigUnorderedPermission returns nil if credential [credIntf] proves [ownerIntf].
 	// Multisig aliases supported. Signatures order and number doesn't matter.
 	VerifyMultisigUnorderedPermission(txIntf, credIntf, ownerIntf, msigIntf interface{}) error
+
+	// CollectMultisigAliases returns an array of OutputOwners part of the owner
+	CollectMultisigAliases(ownerIntf, msigIntf interface{}) ([]interface{}, error)
 }

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -67,6 +67,21 @@ func (mr *MockFxMockRecorder) Bootstrapping() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrapping", reflect.TypeOf((*MockFx)(nil).Bootstrapping))
 }
 
+// CollectMultisigAliases mocks base method.
+func (m *MockFx) CollectMultisigAliases(arg0, arg1 interface{}) ([]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CollectMultisigAliases", arg0, arg1)
+	ret0, _ := ret[0].([]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CollectMultisigAliases indicates an expected call of CollectMultisigAliases.
+func (mr *MockFxMockRecorder) CollectMultisigAliases(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CollectMultisigAliases", reflect.TypeOf((*MockFx)(nil).CollectMultisigAliases), arg0, arg1)
+}
+
 // CreateOutput mocks base method.
 func (m *MockFx) CreateOutput(arg0 uint64, arg1 interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
@@ -125,6 +140,20 @@ func (mr *MockFxMockRecorder) VerifyMultisigOwner(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigOwner", reflect.TypeOf((*MockFx)(nil).VerifyMultisigOwner), arg0, arg1)
 }
 
+// VerifyMultisigPermission mocks base method.
+func (m *MockFx) VerifyMultisigPermission(arg0, arg1, arg2, arg3, arg4 interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyMultisigPermission", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyMultisigPermission indicates an expected call of VerifyMultisigPermission.
+func (mr *MockFxMockRecorder) VerifyMultisigPermission(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigPermission", reflect.TypeOf((*MockFx)(nil).VerifyMultisigPermission), arg0, arg1, arg2, arg3, arg4)
+}
+
 // VerifyMultisigTransfer mocks base method.
 func (m *MockFx) VerifyMultisigTransfer(arg0, arg1, arg2, arg3, arg4 interface{}) error {
 	m.ctrl.T.Helper()
@@ -137,6 +166,20 @@ func (m *MockFx) VerifyMultisigTransfer(arg0, arg1, arg2, arg3, arg4 interface{}
 func (mr *MockFxMockRecorder) VerifyMultisigTransfer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigTransfer", reflect.TypeOf((*MockFx)(nil).VerifyMultisigTransfer), arg0, arg1, arg2, arg3, arg4)
+}
+
+// VerifyMultisigUnorderedPermission mocks base method.
+func (m *MockFx) VerifyMultisigUnorderedPermission(arg0, arg1, arg2, arg3 interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyMultisigUnorderedPermission", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyMultisigUnorderedPermission indicates an expected call of VerifyMultisigUnorderedPermission.
+func (mr *MockFxMockRecorder) VerifyMultisigUnorderedPermission(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigUnorderedPermission", reflect.TypeOf((*MockFx)(nil).VerifyMultisigUnorderedPermission), arg0, arg1, arg2, arg3)
 }
 
 // VerifyPermission mocks base method.
@@ -165,34 +208,6 @@ func (m *MockFx) VerifyTransfer(arg0, arg1, arg2, arg3 interface{}) error {
 func (mr *MockFxMockRecorder) VerifyTransfer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyTransfer", reflect.TypeOf((*MockFx)(nil).VerifyTransfer), arg0, arg1, arg2, arg3)
-}
-
-// VerifyMultisigPermission mocks base method.
-func (m *MockFx) VerifyMultisigPermission(arg0, arg1, arg2, arg3, arg4 interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyMultisigPermission", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// VerifyMultisigPermission indicates an expected call of VerifyMultisigPermission.
-func (mr *MockFxMockRecorder) VerifyMultisigPermission(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigPermission", reflect.TypeOf((*MockFx)(nil).VerifyMultisigPermission), arg0, arg1, arg2, arg3, arg4)
-}
-
-// VerifyMultisigUnorderedPermission mocks base method.
-func (m *MockFx) VerifyMultisigUnorderedPermission(arg0, arg1, arg2, arg3 interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyMultisigUnorderedPermission", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// VerifyMultisigUnorderedPermission indicates an expected call of VerifyMultisigUnorderedPermission.
-func (mr *MockFxMockRecorder) VerifyMultisigUnorderedPermission(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigUnorderedPermission", reflect.TypeOf((*MockFx)(nil).VerifyMultisigUnorderedPermission), arg0, arg1, arg2, arg3)
 }
 
 // MockOwner is a mock of Owner interface.

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -94,8 +94,8 @@ type CaminoDiff interface {
 
 	// Multisig Owners
 
-	GetMultisigAlias(ids.ShortID) (*multisig.Alias, error)
-	SetMultisigAlias(*multisig.Alias)
+	GetMultisigAlias(ids.ShortID) (*multisig.AliasWithNonce, error)
+	SetMultisigAlias(*multisig.AliasWithNonce)
 
 	// ShortIDsLink
 
@@ -147,7 +147,7 @@ type caminoDiff struct {
 	modifiedAddressStates                 map[ids.ShortID]uint64
 	modifiedDepositOffers                 map[ids.ID]*deposit.Offer
 	modifiedDeposits                      map[ids.ID]*depositDiff
-	modifiedMultisigOwners                map[ids.ShortID]*multisig.Alias
+	modifiedMultisigOwners                map[ids.ShortID]*multisig.AliasWithNonce
 	modifiedShortLinks                    map[ids.ID]*ids.ShortID
 	modifiedClaimables                    map[ids.ID]*Claimable
 	modifiedNotDistributedValidatorReward *uint64
@@ -200,7 +200,7 @@ func newCaminoDiff() *caminoDiff {
 		modifiedAddressStates:  make(map[ids.ShortID]uint64),
 		modifiedDepositOffers:  make(map[ids.ID]*deposit.Offer),
 		modifiedDeposits:       make(map[ids.ID]*depositDiff),
-		modifiedMultisigOwners: make(map[ids.ShortID]*multisig.Alias),
+		modifiedMultisigOwners: make(map[ids.ShortID]*multisig.AliasWithNonce),
 		modifiedShortLinks:     make(map[ids.ID]*ids.ShortID),
 		modifiedClaimables:     make(map[ids.ID]*Claimable),
 	}
@@ -365,7 +365,7 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 	// adding msig aliases
 
 	for _, multisigAlias := range g.Camino.MultisigAliases {
-		cs.SetMultisigAlias(multisigAlias)
+		cs.SetMultisigAlias(&multisig.AliasWithNonce{Alias: *multisigAlias})
 	}
 
 	// adding blocks (validators and deposits)

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -268,11 +268,11 @@ func (d *diff) GetNextToUnlockDepositIDsAndTime(removedDepositIDs set.Set[ids.ID
 	return nextDepositIDs, nextUnlockTime, nil
 }
 
-func (d *diff) SetMultisigAlias(owner *multisig.Alias) {
+func (d *diff) SetMultisigAlias(owner *multisig.AliasWithNonce) {
 	d.caminoDiff.modifiedMultisigOwners[owner.ID] = owner
 }
 
-func (d *diff) GetMultisigAlias(alias ids.ShortID) (*multisig.Alias, error) {
+func (d *diff) GetMultisigAlias(alias ids.ShortID) (*multisig.AliasWithNonce, error) {
 	if msigOwner, ok := d.caminoDiff.modifiedMultisigOwners[alias]; ok {
 		if msigOwner == nil {
 			return nil, database.ErrNotFound

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -92,11 +92,11 @@ func (s *state) GetNextToUnlockDepositIDsAndTime(removedDepositIDs set.Set[ids.I
 	return s.caminoState.GetNextToUnlockDepositIDsAndTime(removedDepositIDs)
 }
 
-func (s *state) SetMultisigAlias(owner *multisig.Alias) {
+func (s *state) SetMultisigAlias(owner *multisig.AliasWithNonce) {
 	s.caminoState.SetMultisigAlias(owner)
 }
 
-func (s *state) GetMultisigAlias(alias ids.ShortID) (*multisig.Alias, error) {
+func (s *state) GetMultisigAlias(alias ids.ShortID) (*multisig.AliasWithNonce, error) {
 	return s.caminoState.GetMultisigAlias(alias)
 }
 

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -402,10 +402,10 @@ func (mr *MockChainMockRecorder) GetDepositOffer(arg0 interface{}) *gomock.Call 
 }
 
 // GetMultisigAlias mocks base method.
-func (m *MockChain) GetMultisigAlias(arg0 ids.ShortID) (*multisig.Alias, error) {
+func (m *MockChain) GetMultisigAlias(arg0 ids.ShortID) (*multisig.AliasWithNonce, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMultisigAlias", arg0)
-	ret0, _ := ret[0].(*multisig.Alias)
+	ret0, _ := ret[0].(*multisig.AliasWithNonce)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -748,7 +748,7 @@ func (mr *MockChainMockRecorder) SetLastRewardImportTimestamp(arg0 interface{}) 
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockChain) SetMultisigAlias(arg0 *multisig.Alias) {
+func (m *MockChain) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMultisigAlias", arg0)
 }

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -426,10 +426,10 @@ func (mr *MockDiffMockRecorder) GetDepositOffer(arg0 interface{}) *gomock.Call {
 }
 
 // GetMultisigAlias mocks base method.
-func (m *MockDiff) GetMultisigAlias(arg0 ids.ShortID) (*multisig.Alias, error) {
+func (m *MockDiff) GetMultisigAlias(arg0 ids.ShortID) (*multisig.AliasWithNonce, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMultisigAlias", arg0)
-	ret0, _ := ret[0].(*multisig.Alias)
+	ret0, _ := ret[0].(*multisig.AliasWithNonce)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -759,7 +759,7 @@ func (mr *MockDiffMockRecorder) SetCurrentSupply(arg0, arg1 interface{}) *gomock
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockDiff) SetMultisigAlias(arg0 *multisig.Alias) {
+func (m *MockDiff) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMultisigAlias", arg0)
 }

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -487,10 +487,10 @@ func (mr *MockStateMockRecorder) GetLastAccepted() *gomock.Call {
 }
 
 // GetMultisigAlias mocks base method.
-func (m *MockState) GetMultisigAlias(arg0 ids.ShortID) (*multisig.Alias, error) {
+func (m *MockState) GetMultisigAlias(arg0 ids.ShortID) (*multisig.AliasWithNonce, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMultisigAlias", arg0)
-	ret0, _ := ret[0].(*multisig.Alias)
+	ret0, _ := ret[0].(*multisig.AliasWithNonce)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -923,7 +923,7 @@ func (mr *MockStateMockRecorder) SetLastAccepted(arg0 interface{}) *gomock.Call 
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockState) SetMultisigAlias(arg0 *multisig.Alias) {
+func (m *MockState) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetMultisigAlias", arg0)
 }

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/vms/components/multisig"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/signer"
 	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
@@ -118,6 +119,7 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&ClaimTx{}),
 		targetCodec.RegisterCustomType(&RewardsImportTx{}),
 		targetCodec.RegisterCustomType(&secp256k1fx.MultisigCredential{}),
+		targetCodec.RegisterCustomType(&multisig.AliasWithNonce{}),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -624,9 +624,9 @@ func newCaminoEnvironmentWithMocks(
 	return env
 }
 
-func expectVerifyMultisigPermission(s *state.MockDiff, addrs []ids.ShortID, aliases []*multisig.Alias) { //nolint:unparam
+func expectVerifyMultisigPermission(s *state.MockDiff, addrs []ids.ShortID, aliases []*multisig.AliasWithNonce) { //nolint:unparam
 	for i := range addrs {
-		var alias *multisig.Alias
+		var alias *multisig.AliasWithNonce
 		if len(aliases) > i {
 			alias = aliases[i]
 		}

--- a/vms/platformvm/utxo/camino_multisig_test.go
+++ b/vms/platformvm/utxo/camino_multisig_test.go
@@ -1,0 +1,151 @@
+package utxo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/codec/linearcodec"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/hashing"
+	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/components/multisig"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUTXOWithMsigVerify(t *testing.T) {
+	address := ids.ShortID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	utxoWithMSig := avax.UTXOWithMSig{
+		UTXO: avax.UTXO{
+			UTXOID: avax.UTXOID{
+				TxID:        ids.GenerateTestID(),
+				OutputIndex: 0,
+			},
+			Asset: avax.Asset{
+				ID: ids.GenerateTestID(),
+			},
+			Out: &secp256k1fx.TransferOutput{
+				Amt: uint64(1),
+				OutputOwners: secp256k1fx.OutputOwners{
+					Locktime:  0,
+					Threshold: 1,
+					Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
+				},
+			},
+		},
+		Aliases: nil,
+	}
+
+	tests := map[string]struct {
+		aliases []verify.State
+		err     error
+	}{
+		"Successful": {
+			aliases: []verify.State{
+				&multisig.Alias{
+					ID: address,
+					Owners: &secp256k1fx.OutputOwners{
+						Threshold: 1,
+						Addrs:     []ids.ShortID{ids.ShortEmpty},
+					},
+				},
+			},
+			err: nil,
+		},
+		"Threshold exceeds Addrs length": {
+			aliases: []verify.State{
+				&multisig.Alias{
+					ID: address,
+					Owners: &secp256k1fx.OutputOwners{
+						Threshold: 2,
+						Addrs:     []ids.ShortID{ids.ShortEmpty},
+					},
+				},
+			},
+			err: errors.New("output is unspendable"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			utxoWithMSig.Aliases = test.aliases
+			err := utxoWithMSig.Verify()
+			if test.err != nil {
+				require.Error(t, err)
+				require.Equal(t, test.err, err)
+			}
+		})
+	}
+}
+
+func TestUTXOWithMSigSerialized(t *testing.T) {
+	// Create a new codec manager and linear codec instance
+	manager := codec.NewDefaultManager()
+	c := linearcodec.NewDefault()
+
+	// Register all relevant types with the codec
+	errs := wrappers.Errs{}
+	errs.Add(
+		c.RegisterType(&secp256k1fx.MintOutput{}),
+		c.RegisterType(&secp256k1fx.TransferOutput{}),
+		c.RegisterType(&secp256k1fx.Input{}),
+		c.RegisterType(&secp256k1fx.TransferInput{}),
+		c.RegisterType(&secp256k1fx.Credential{}),
+		c.RegisterType(&secp256k1fx.OutputOwners{}),
+		c.RegisterType(&multisig.AliasWithNonce{}),
+
+		manager.RegisterCodec(0, c),
+	)
+
+	require.False(t, errs.Errored(), errs.Err)
+
+	// Create a new UTXO with extended `Out` object
+	utxo := avax.UTXO{
+		UTXOID: avax.UTXOID{
+			TxID:        ids.GenerateTestID(),
+			OutputIndex: 0,
+		},
+		Asset: avax.Asset{
+			ID: ids.GenerateTestID(),
+		},
+		Out: &secp256k1fx.TransferOutput{
+			Amt: uint64(1),
+			OutputOwners: secp256k1fx.OutputOwners{
+				Locktime:  0,
+				Threshold: 1,
+				Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
+			},
+		},
+	}
+	alias := &multisig.AliasWithNonce{
+		Alias: multisig.Alias{
+			Owners: &secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{ids.GenerateTestShortID()},
+			},
+			Memo: make([]byte, avax.MaxMemoSize+1),
+			ID:   hashing.ComputeHash160Array(ids.Empty[:]),
+		},
+	}
+	utxoWithMSig := avax.UTXOWithMSig{
+		UTXO:    utxo,
+		Aliases: []verify.State{alias},
+	}
+
+	// Marshal the UTXOWithMSig object into a byte array using the codec manager
+	mUTXO, err := manager.Marshal(0, &utxoWithMSig)
+	require.NoError(t, err)
+
+	// Create a new UTXOWithMSig object to unmarshal the byte array into
+	var newUTXO avax.UTXOWithMSig
+
+	// Unmarshal the byte array into the new UTXOWithMSig object using the codec manager
+	_, err = manager.Unmarshal(mUTXO, &newUTXO)
+	require.NoError(t, err)
+
+	// Check if the unmarshaled object matches the original object
+	require.Equal(t, utxoWithMSig, newUTXO)
+}

--- a/vms/secp256k1fx/camino_fx.go
+++ b/vms/secp256k1fx/camino_fx.go
@@ -29,7 +29,7 @@ type Owned interface {
 }
 
 type AliasGetter interface {
-	GetMultisigAlias(ids.ShortID) (*multisig.Alias, error)
+	GetMultisigAlias(ids.ShortID) (*multisig.AliasWithNonce, error)
 }
 
 type (
@@ -214,6 +214,19 @@ func (fx *Fx) VerifyMultisigUnorderedPermission(txIntf, credIntf, ownerIntf, msi
 	return fx.verifyMultisigUnorderedCredentials(tx, cred, owners, msig)
 }
 
+func (*Fx) CollectMultisigAliases(ownerIntf, msigIntf interface{}) ([]interface{}, error) {
+	owners, ok := ownerIntf.(*OutputOwners)
+	if !ok {
+		return nil, errWrongUTXOType
+	}
+	msig, ok := msigIntf.(AliasGetter)
+	if !ok {
+		return nil, errNotAliasGetter
+	}
+
+	return collectMultisigAliases(owners, msig)
+}
+
 func (fx *Fx) verifyMultisigCredentials(tx UnsignedTx, in *Input, cred CredentialIntf, owners *OutputOwners, msig AliasGetter) error {
 	sigIdxs := cred.SignatureIndices()
 	if sigIdxs == nil {
@@ -276,6 +289,19 @@ func (fx *Fx) verifyMultisigUnorderedCredentials(tx UnsignedTx, creds []verify.V
 	}
 
 	return nil
+}
+
+func collectMultisigAliases(owners *OutputOwners, msig AliasGetter) ([]interface{}, error) {
+	result := make([]interface{}, 0, len(owners.Addrs))
+
+	tf := func(alias *multisig.AliasWithNonce) {
+		result = append(result, alias)
+	}
+
+	if err := TraverseAliases(owners, msig, tf); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // ExtractFromAndSigners splits an array of PrivateKeys into `from` and `signers`

--- a/vms/secp256k1fx/camino_fx_test.go
+++ b/vms/secp256k1fx/camino_fx_test.go
@@ -121,13 +121,13 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{{Alias: multisig.Alias{
 					ID: aliasAddr1,
 					Owners: &OutputOwners{
 						Threshold: 1,
 						Addrs:     []ids.ShortID{addr2, addr3},
 					},
-				}})
+				}}})
 				return msig
 			},
 		},
@@ -140,13 +140,13 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{{Alias: multisig.Alias{
 					ID: aliasAddr1,
 					Owners: &OutputOwners{
 						Threshold: 2,
 						Addrs:     []ids.ShortID{addr2, addr3},
 					},
-				}})
+				}}})
 				return msig
 			},
 		},
@@ -159,21 +159,21 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{
-					{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{
+					{Alias: multisig.Alias{
 						ID: aliasAddr1,
 						Owners: &OutputOwners{
 							Threshold: 2,
 							Addrs:     []ids.ShortID{aliasAddr2, addr3},
 						},
-					},
-					{
+					}},
+					{Alias: multisig.Alias{
 						ID: aliasAddr2,
 						Owners: &OutputOwners{
 							Threshold: 2,
 							Addrs:     []ids.ShortID{addr1, addr2},
 						},
-					},
+					}},
 				})
 				return msig
 			},
@@ -187,21 +187,21 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{
-					{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{
+					{Alias: multisig.Alias{
 						ID: aliasAddr1,
 						Owners: &OutputOwners{
 							Threshold: 2,
 							Addrs:     []ids.ShortID{aliasAddr2, addr3},
 						},
-					},
-					{
+					}},
+					{Alias: multisig.Alias{
 						ID: aliasAddr2,
 						Owners: &OutputOwners{
 							Threshold: 2,
 							Addrs:     []ids.ShortID{addr1, addr2},
 						},
-					},
+					}},
 				})
 				return msig
 			},
@@ -292,13 +292,13 @@ func TestVerifyMultisigUnorderedCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{{Alias: multisig.Alias{
 					ID: aliasAddr1,
 					Owners: &OutputOwners{
 						Threshold: 1,
 						Addrs:     []ids.ShortID{addr2, addr3},
 					},
-				}})
+				}}})
 				return msig
 			},
 		},
@@ -310,13 +310,13 @@ func TestVerifyMultisigUnorderedCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{{Alias: multisig.Alias{
 					ID: aliasAddr1,
 					Owners: &OutputOwners{
 						Threshold: 2,
 						Addrs:     []ids.ShortID{addr2, addr3},
 					},
-				}})
+				}}})
 				return msig
 			},
 		},
@@ -328,21 +328,21 @@ func TestVerifyMultisigUnorderedCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{
-					{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{
+					{Alias: multisig.Alias{
 						ID: aliasAddr1,
 						Owners: &OutputOwners{
 							Threshold: 2,
 							Addrs:     []ids.ShortID{aliasAddr2, addr3},
 						},
-					},
-					{
+					}},
+					{Alias: multisig.Alias{
 						ID: aliasAddr2,
 						Owners: &OutputOwners{
 							Threshold: 2,
 							Addrs:     []ids.ShortID{addr1, addr2},
 						},
-					},
+					}},
 				})
 				return msig
 			},
@@ -355,21 +355,21 @@ func TestVerifyMultisigUnorderedCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{
-					{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{
+					{Alias: multisig.Alias{
 						ID: aliasAddr1,
 						Owners: &OutputOwners{
 							Threshold: 1,
 							Addrs:     []ids.ShortID{aliasAddr2, addr3},
 						},
-					},
-					{
+					}},
+					{Alias: multisig.Alias{
 						ID: aliasAddr2,
 						Owners: &OutputOwners{
 							Threshold: 1,
 							Addrs:     []ids.ShortID{addr1, addr2},
 						},
-					},
+					}},
 				})
 				return msig
 			},
@@ -382,21 +382,21 @@ func TestVerifyMultisigUnorderedCredentials(t *testing.T) {
 			},
 			msig: func(c *gomock.Controller) AliasGetter {
 				msig := NewMockAliasGetter(c)
-				expectGetMultisigAliases(msig, []*multisig.Alias{
-					{
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{
+					{Alias: multisig.Alias{
 						ID: aliasAddr1,
 						Owners: &OutputOwners{
 							Threshold: 2,
 							Addrs:     []ids.ShortID{aliasAddr2, addr3},
 						},
-					},
-					{
+					}},
+					{Alias: multisig.Alias{
 						ID: aliasAddr2,
 						Owners: &OutputOwners{
 							Threshold: 2,
 							Addrs:     []ids.ShortID{addr1, addr2},
 						},
-					},
+					}},
 				})
 				return msig
 			},
@@ -454,6 +454,62 @@ func TestExtractFromAndSigners(t *testing.T) {
 	}
 }
 
+func TestCollectMultisigAliases(t *testing.T) {
+	_, addr1 := generateKey(t)
+	_, addr2 := generateKey(t)
+	_, addr3 := generateKey(t)
+	_, aliasAddr1 := generateKey(t)
+
+	noAliasesMsigGetter := func(c *gomock.Controller) AliasGetter {
+		msig := NewMockAliasGetter(c)
+		msig.EXPECT().GetMultisigAlias(gomock.Any()).Return(nil, database.ErrNotFound).AnyTimes()
+		return msig
+	}
+
+	tests := map[string]struct {
+		owners          *OutputOwners
+		msig            func(c *gomock.Controller) AliasGetter
+		expectedAliases int
+		expectedError   error
+	}{
+		"OK: 2 addrs, no msig alias": {
+			owners: &OutputOwners{
+				Threshold: 2,
+				Addrs:     []ids.ShortID{addr1, addr2},
+			},
+			msig: noAliasesMsigGetter,
+		},
+		"OK 1 msig alias": {
+			owners: &OutputOwners{
+				Threshold: 2,
+				Addrs:     []ids.ShortID{addr1, aliasAddr1},
+			},
+			msig: func(c *gomock.Controller) AliasGetter {
+				msig := NewMockAliasGetter(c)
+				expectGetMultisigAliases(msig, []*multisig.AliasWithNonce{{Alias: multisig.Alias{
+					ID: aliasAddr1,
+					Owners: &OutputOwners{
+						Threshold: 1,
+						Addrs:     []ids.ShortID{addr2, addr3},
+					},
+				}}})
+				return msig
+			},
+			expectedAliases: 1,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			aliases, err := collectMultisigAliases(tt.owners, tt.msig(ctrl))
+			require.ErrorIs(t, err, tt.expectedError)
+			require.Equal(t, len(aliases), tt.expectedAliases)
+		})
+	}
+}
+
 func defaultFx(t *testing.T) *Fx {
 	require := require.New(t)
 	vm := TestVM{
@@ -481,7 +537,7 @@ func generateKey(t *testing.T) (*crypto.PrivateKeySECP256K1R, ids.ShortID) {
 	return secpKey, secpKey.Address()
 }
 
-func expectGetMultisigAliases(msig *MockAliasGetter, aliases []*multisig.Alias) {
+func expectGetMultisigAliases(msig *MockAliasGetter, aliases []*multisig.AliasWithNonce) {
 	aliasesMatchers := []gomock.Matcher{}
 	for _, alias := range aliases {
 		aliasesMatchers = append(aliasesMatchers, gomock.Eq(alias.ID))

--- a/vms/secp256k1fx/camino_keychain_test.go
+++ b/vms/secp256k1fx/camino_keychain_test.go
@@ -20,12 +20,14 @@ type TestGetter struct {
 	threshold uint32
 }
 
-func (t *TestGetter) GetMultisigAlias(addr ids.ShortID) (*multisig.Alias, error) {
+func (t *TestGetter) GetMultisigAlias(addr ids.ShortID) (*multisig.AliasWithNonce, error) {
 	if addr == t.msig {
-		return &multisig.Alias{
-			Owners: &OutputOwners{
-				Threshold: t.threshold,
-				Addrs:     t.addresses,
+		return &multisig.AliasWithNonce{
+			Alias: multisig.Alias{
+				Owners: &OutputOwners{
+					Threshold: t.threshold,
+					Addrs:     t.addresses,
+				},
 			},
 		}, nil
 	}

--- a/vms/secp256k1fx/mock_alias_getter.go
+++ b/vms/secp256k1fx/mock_alias_getter.go
@@ -39,10 +39,10 @@ func (m *MockAliasGetter) EXPECT() *MockAliasGetterMockRecorder {
 }
 
 // GetMultisigAlias mocks base method.
-func (m *MockAliasGetter) GetMultisigAlias(arg0 ids.ShortID) (*multisig.Alias, error) {
+func (m *MockAliasGetter) GetMultisigAlias(arg0 ids.ShortID) (*multisig.AliasWithNonce, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMultisigAlias", arg0)
-	ret0, _ := ret[0].(*multisig.Alias)
+	ret0, _ := ret[0].(*multisig.AliasWithNonce)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
This PR allows to export funds owned by multisig wallet out of P-chain.

Added new wrapped UTXO type `UTXOWithMSig`
This type is used only in the marshalled `atomic.Element` from `ExportTx`.
When exported UTXO is owned by multisig wallet we wrap it with `multisig.Alias`