### PR TITLE
[PVM] Various fixes, improvements, state tests

### DIFF
--- a/vms/components/avax/camino_transferables.go
+++ b/vms/components/avax/camino_transferables.go
@@ -65,7 +65,7 @@ func (utxos *innerSortTransferableTimedUTXOs) Swap(i, j int) {
 	utxos.utxos[j], utxos.utxos[i] = utxos.utxos[i], utxos.utxos[j]
 }
 
-// SortTransferableUTXOs sorts the utxos based on the utxoid
+// SortTransferableTimedUTXOs sorts the utxos based on the utxoid
 func SortTransferableTimedUTXOs(utxos []*TimedUTXO) {
 	sort.Sort(&innerSortTransferableTimedUTXOs{utxos: utxos})
 }

--- a/vms/platformvm/state/camino_claimable_test.go
+++ b/vms/platformvm/state/camino_claimable_test.go
@@ -1,0 +1,348 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/cache"
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClaimable(t *testing.T) {
+	claimableOwnerID := ids.ID{1}
+	claimable := &Claimable{Owner: &secp256k1fx.OutputOwners{Addrs: []ids.ShortID{}}}
+	claimableBytes, err := blocks.GenesisCodec.Marshal(blocks.Version, claimable)
+	require.NoError(t, err)
+	testError := errors.New("test error")
+
+	tests := map[string]struct {
+		caminoState       func(*gomock.Controller) *caminoState
+		claimableOwnerID  ids.ID
+		expectedClaimable *Claimable
+		expectedErr       error
+	}{
+		"Fail: claimable removed": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedClaimables: map[ids.ID]*Claimable{claimableOwnerID: nil},
+					},
+				}
+			},
+			claimableOwnerID: claimableOwnerID,
+			expectedErr:      database.ErrNotFound,
+		},
+		"Fail: claimable in cache, but removed": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				cache := cache.NewMockCacher(c)
+				cache.EXPECT().Get(claimableOwnerID).Return(nil, true)
+				return &caminoState{
+					claimablesCache: cache,
+					caminoDiff:      &caminoDiff{},
+				}
+			},
+			claimableOwnerID: claimableOwnerID,
+			expectedErr:      database.ErrNotFound,
+		},
+		"OK: claimable added/modified": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedClaimables: map[ids.ID]*Claimable{claimableOwnerID: claimable},
+					},
+				}
+			},
+			claimableOwnerID:  claimableOwnerID,
+			expectedClaimable: claimable,
+		},
+		"OK: claimable in cache": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				cache := cache.NewMockCacher(c)
+				cache.EXPECT().Get(claimableOwnerID).Return(claimable, true)
+				return &caminoState{
+					claimablesCache: cache,
+					caminoDiff:      &caminoDiff{},
+				}
+			},
+			claimableOwnerID:  claimableOwnerID,
+			expectedClaimable: claimable,
+		},
+		"OK: claimable in db": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				cache := cache.NewMockCacher(c)
+				cache.EXPECT().Get(claimableOwnerID).Return(nil, false)
+				cache.EXPECT().Put(claimableOwnerID, claimable)
+				db := database.NewMockDatabase(c)
+				db.EXPECT().Get(claimableOwnerID[:]).Return(claimableBytes, nil)
+				return &caminoState{
+					claimablesDB:    db,
+					claimablesCache: cache,
+					caminoDiff:      &caminoDiff{},
+				}
+			},
+			claimableOwnerID:  claimableOwnerID,
+			expectedClaimable: claimable,
+		},
+		"Fail: db error": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				cache := cache.NewMockCacher(c)
+				cache.EXPECT().Get(claimableOwnerID).Return(nil, false)
+				db := database.NewMockDatabase(c)
+				db.EXPECT().Get(claimableOwnerID[:]).Return(nil, testError)
+				return &caminoState{
+					claimablesDB:    db,
+					claimablesCache: cache,
+					caminoDiff:      &caminoDiff{},
+				}
+			},
+			claimableOwnerID: claimableOwnerID,
+			expectedErr:      testError,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			claimable, err := tt.caminoState(ctrl).GetClaimable(tt.claimableOwnerID)
+			require.ErrorIs(t, err, tt.expectedErr)
+			require.Equal(t, tt.expectedClaimable, claimable)
+		})
+	}
+}
+
+func TestSetClaimable(t *testing.T) {
+	ownerID := ids.GenerateTestID()
+	claimable := &Claimable{
+		Owner:           &secp256k1fx.OutputOwners{},
+		ValidatorReward: 1,
+		DepositReward:   1,
+	}
+
+	tests := map[string]struct {
+		caminoState         func(*gomock.Controller) *caminoState
+		claimableOwnerID    ids.ID
+		claimable           *Claimable
+		expectedCaminoState func(cache.Cacher) *caminoState
+	}{
+		"OK": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				cache := cache.NewMockCacher(c)
+				cache.EXPECT().Evict(ownerID)
+				return &caminoState{
+					claimablesCache: cache,
+					caminoDiff:      &caminoDiff{modifiedClaimables: map[ids.ID]*Claimable{}},
+				}
+			},
+			claimableOwnerID: ownerID,
+			claimable:        claimable,
+			expectedCaminoState: func(claimablesCache cache.Cacher) *caminoState {
+				return &caminoState{
+					claimablesCache: claimablesCache,
+					caminoDiff: &caminoDiff{
+						modifiedClaimables: map[ids.ID]*Claimable{ownerID: claimable},
+					},
+				}
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			caminoState := tt.caminoState(ctrl)
+			caminoState.SetClaimable(tt.claimableOwnerID, tt.claimable)
+			require.Equal(t, tt.expectedCaminoState(caminoState.claimablesCache), caminoState)
+		})
+	}
+}
+
+func TestSetNotDistributedValidatorReward(t *testing.T) {
+	tests := map[string]struct {
+		caminoState         *caminoState
+		reward              uint64
+		expectedCaminoState func(uint64) *caminoState
+	}{
+		"OK": {
+			caminoState: &caminoState{
+				caminoDiff: &caminoDiff{},
+			},
+			expectedCaminoState: func(reward uint64) *caminoState {
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedNotDistributedValidatorReward: &reward,
+					},
+				}
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			tt.caminoState.SetNotDistributedValidatorReward(tt.reward)
+			require.Equal(t, tt.expectedCaminoState(tt.reward), tt.caminoState)
+		})
+	}
+}
+
+func TestGetNotDistributedValidatorReward(t *testing.T) {
+	tests := map[string]struct {
+		caminoState                           func(c *gomock.Controller) *caminoState
+		expectedNotDistributedValidatorReward uint64
+	}{
+		"OK": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					notDistributedValidatorReward: 11,
+					caminoDiff:                    &caminoDiff{},
+				}
+			},
+			expectedNotDistributedValidatorReward: 11,
+		},
+		"OK: modified": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				modifiedReward := uint64(15)
+				return &caminoState{
+					notDistributedValidatorReward: 11,
+					caminoDiff: &caminoDiff{
+						modifiedNotDistributedValidatorReward: &modifiedReward,
+					},
+				}
+			},
+			expectedNotDistributedValidatorReward: 15,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			notDistributedValidatorReward, err := tt.caminoState(ctrl).GetNotDistributedValidatorReward()
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedNotDistributedValidatorReward, notDistributedValidatorReward)
+		})
+	}
+}
+
+func TestWriteClaimableAndValidatorRewards(t *testing.T) {
+	testError := errors.New("test error")
+	claimableOwnerID1 := ids.ID{1}
+	claimableOwnerID2 := ids.ID{2}
+	claimable1 := &Claimable{Owner: &secp256k1fx.OutputOwners{}, ValidatorReward: 1, DepositReward: 2}
+	claimableBytes1, err := blocks.GenesisCodec.Marshal(blocks.Version, claimable1)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		caminoState         func(*gomock.Controller) *caminoState
+		expectedCaminoState func(*caminoState) *caminoState
+		expectedErr         error
+	}{
+		"Fail: db errored on modifiedClaimables Put": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				claimablesDB := database.NewMockDatabase(c)
+				claimablesDB.EXPECT().Put(claimableOwnerID1[:], claimableBytes1).Return(testError)
+				return &caminoState{
+					claimablesDB: claimablesDB,
+					caminoDiff: &caminoDiff{
+						modifiedClaimables: map[ids.ID]*Claimable{
+							claimableOwnerID1: claimable1,
+						},
+					},
+				}
+			},
+			expectedCaminoState: func(actualState *caminoState) *caminoState {
+				return &caminoState{
+					claimablesDB: actualState.claimablesDB,
+					caminoDiff: &caminoDiff{
+						modifiedClaimables: map[ids.ID]*Claimable{},
+					},
+				}
+			},
+			expectedErr: testError,
+		},
+		"Fail: db errored on modifiedClaimables Delete": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				claimablesDB := database.NewMockDatabase(c)
+				claimablesDB.EXPECT().Delete(claimableOwnerID1[:]).Return(testError)
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedClaimables: map[ids.ID]*Claimable{
+							claimableOwnerID1: nil,
+						},
+					},
+					claimablesDB: claimablesDB,
+				}
+			},
+			expectedCaminoState: func(actualState *caminoState) *caminoState {
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedClaimables: map[ids.ID]*Claimable{},
+					},
+					claimablesDB: actualState.claimablesDB,
+				}
+			},
+			expectedErr: testError,
+		},
+		"OK: modifiedNotDistributedValidatorReward is nil": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{caminoDiff: &caminoDiff{}}
+			},
+			expectedCaminoState: func(actualState *caminoState) *caminoState {
+				return &caminoState{caminoDiff: &caminoDiff{}}
+			},
+		},
+		"OK": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				notDistributedReward := uint64(11)
+
+				caminoDB := database.NewMockDatabase(c)
+				caminoDB.EXPECT().Put(
+					notDistributedValidatorRewardKey,
+					database.PackUInt64(notDistributedReward),
+				).Return(nil)
+
+				claimablesDB := database.NewMockDatabase(c)
+				claimablesDB.EXPECT().Put(claimableOwnerID1[:], claimableBytes1).Return(nil)
+				claimablesDB.EXPECT().Delete(claimableOwnerID2[:]).Return(nil)
+
+				return &caminoState{
+					caminoDB:     caminoDB,
+					claimablesDB: claimablesDB,
+					caminoDiff: &caminoDiff{
+						modifiedNotDistributedValidatorReward: &notDistributedReward,
+						modifiedClaimables: map[ids.ID]*Claimable{
+							claimableOwnerID1: claimable1,
+							claimableOwnerID2: nil,
+						},
+					},
+				}
+			},
+			expectedCaminoState: func(actualState *caminoState) *caminoState {
+				return &caminoState{
+					caminoDB:                      actualState.caminoDB,
+					claimablesDB:                  actualState.claimablesDB,
+					notDistributedValidatorReward: 11,
+					caminoDiff: &caminoDiff{
+						modifiedClaimables: map[ids.ID]*Claimable{},
+					},
+				}
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			actualCaminoState := tt.caminoState(ctrl)
+			require.ErrorIs(t, actualCaminoState.writeClaimableAndValidatorRewards(), tt.expectedErr)
+			require.Equal(t, tt.expectedCaminoState(actualCaminoState), actualCaminoState)
+		})
+	}
+}

--- a/vms/platformvm/state/camino_deposit.go
+++ b/vms/platformvm/state/camino_deposit.go
@@ -46,11 +46,17 @@ func (cs *caminoState) GetDeposit(depositTxID ids.ID) (*deposit.Deposit, error) 
 	}
 
 	if depositIntf, ok := cs.depositsCache.Get(depositTxID); ok {
+		if depositIntf == nil {
+			return nil, database.ErrNotFound
+		}
 		return depositIntf.(*deposit.Deposit), nil
 	}
 
 	depositBytes, err := cs.depositsDB.Get(depositTxID[:])
-	if err != nil {
+	if err == database.ErrNotFound {
+		cs.depositsCache.Put(depositTxID, nil)
+		return nil, err
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/vms/platformvm/state/camino_deposit_offer_test.go
+++ b/vms/platformvm/state/camino_deposit_offer_test.go
@@ -1,0 +1,470 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/database"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDepositOffer(t *testing.T) {
+	depositOffer1 := &deposit.Offer{ID: ids.ID{1}}
+	depositOffer2 := &deposit.Offer{ID: ids.ID{2}}
+
+	tests := map[string]struct {
+		caminoState          func(*gomock.Controller) *caminoState
+		depositOfferID       ids.ID
+		expectedCaminoState  func(*caminoState) *caminoState
+		expectedDepositOffer *deposit.Offer
+		expectedErr          error
+	}{
+		"Fail: offer removed": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer1.ID: nil,
+						},
+					},
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer1.ID: nil,
+						},
+					},
+				}
+			},
+			depositOfferID: depositOffer1.ID,
+			expectedErr:    database.ErrNotFound,
+		},
+		"Fail: offer doesn't exist": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer2.ID: depositOffer2,
+					},
+					caminoDiff: &caminoDiff{},
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer2.ID: depositOffer2,
+					},
+					caminoDiff: &caminoDiff{},
+				}
+			},
+			depositOfferID: depositOffer1.ID,
+			expectedErr:    database.ErrNotFound,
+		},
+		"OK: offer added": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer2.ID: depositOffer2,
+						},
+					},
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer2.ID: depositOffer2,
+						},
+					},
+				}
+			},
+			depositOfferID:       depositOffer2.ID,
+			expectedDepositOffer: depositOffer2,
+		},
+		"OK: offer modified": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer2.ID: {ID: depositOffer2.ID, MinAmount: 1},
+						},
+					},
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer2.ID: {ID: depositOffer2.ID, MinAmount: 1},
+						},
+					},
+				}
+			},
+			depositOfferID:       depositOffer2.ID,
+			expectedDepositOffer: &deposit.Offer{ID: depositOffer2.ID, MinAmount: 1},
+		},
+		"OK": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+					},
+					caminoDiff: &caminoDiff{},
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+					},
+					caminoDiff: &caminoDiff{},
+				}
+			},
+			depositOfferID:       depositOffer1.ID,
+			expectedDepositOffer: depositOffer1,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			caminoState := tt.caminoState(ctrl)
+			actualDepositOffer, err := caminoState.GetDepositOffer(tt.depositOfferID)
+			require.ErrorIs(t, err, tt.expectedErr)
+			require.Equal(t, tt.expectedDepositOffer, actualDepositOffer)
+			require.Equal(t, tt.expectedCaminoState(caminoState), caminoState)
+		})
+	}
+}
+
+func TestSetDepositOffer(t *testing.T) {
+	depositOffer1 := &deposit.Offer{ID: ids.ID{1}}
+	depositOffer2 := &deposit.Offer{ID: ids.ID{2}}
+	depositOffer3 := &deposit.Offer{ID: ids.ID{3}}
+
+	tests := map[string]struct {
+		caminoState         *caminoState
+		depositOffer        *deposit.Offer
+		expectedCaminoState *caminoState
+	}{
+		"OK": {
+			caminoState: &caminoState{
+				depositOffers: map[ids.ID]*deposit.Offer{
+					depositOffer1.ID: depositOffer1,
+				},
+				caminoDiff: &caminoDiff{
+					modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer2.ID: depositOffer2,
+					},
+				},
+			},
+			depositOffer: depositOffer3,
+			expectedCaminoState: &caminoState{
+				depositOffers: map[ids.ID]*deposit.Offer{
+					depositOffer1.ID: depositOffer1,
+				},
+				caminoDiff: &caminoDiff{
+					modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer2.ID: depositOffer2,
+						depositOffer3.ID: depositOffer3,
+					},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tt.caminoState.SetDepositOffer(tt.depositOffer)
+			require.Equal(t, tt.expectedCaminoState, tt.caminoState)
+		})
+	}
+}
+
+func TestGetAllDepositOffers(t *testing.T) {
+	depositOffer1 := &deposit.Offer{ID: ids.ID{1}}
+	depositOffer2 := &deposit.Offer{ID: ids.ID{2}}
+	depositOffer3 := &deposit.Offer{ID: ids.ID{3}}
+	depositOffer4 := &deposit.Offer{ID: ids.ID{4}}
+
+	tests := map[string]struct {
+		caminoState           func(c *gomock.Controller) *caminoState
+		expectedCaminoState   func(*caminoState) *caminoState
+		expectedDepositOffers []*deposit.Offer
+		expectedErr           error
+	}{
+		"OK": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+						depositOffer4.ID: depositOffer4,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer2.ID: {ID: depositOffer2.ID, MinAmount: 1},
+							depositOffer3.ID: depositOffer3,
+							depositOffer4.ID: nil,
+						},
+					},
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+						depositOffer4.ID: depositOffer4,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer2.ID: {ID: depositOffer2.ID, MinAmount: 1},
+							depositOffer3.ID: depositOffer3,
+							depositOffer4.ID: nil,
+						},
+					},
+				}
+			},
+			expectedDepositOffers: []*deposit.Offer{
+				depositOffer1,
+				{ID: depositOffer2.ID, MinAmount: 1},
+				depositOffer3,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			caminoState := tt.caminoState(ctrl)
+			depositOffers, err := caminoState.GetAllDepositOffers()
+			require.ErrorIs(t, err, tt.expectedErr)
+			require.ElementsMatch(t, tt.expectedDepositOffers, depositOffers)
+			require.Equal(t, tt.expectedCaminoState(caminoState), caminoState)
+		})
+	}
+}
+
+func TestWriteDepositOffers(t *testing.T) {
+	depositOffer1 := &deposit.Offer{ID: ids.ID{1}}
+	depositOffer2 := &deposit.Offer{ID: ids.ID{2}}
+	depositOffer2modified := &deposit.Offer{ID: ids.ID{2}, MinAmount: 1}
+	depositOffer3 := &deposit.Offer{ID: ids.ID{3}}
+	depositOffer4 := &deposit.Offer{ID: ids.ID{4}}
+	depositOffer2modifiedBytes, err := blocks.GenesisCodec.Marshal(blocks.Version, depositOffer2modified)
+	require.NoError(t, err)
+	depositOffer2Bytes, err := blocks.GenesisCodec.Marshal(blocks.Version, depositOffer2)
+	require.NoError(t, err)
+	depositOffer3Bytes, err := blocks.GenesisCodec.Marshal(blocks.Version, depositOffer3)
+	require.NoError(t, err)
+	testError := errors.New("test error")
+
+	tests := map[string]struct {
+		caminoState         func(*gomock.Controller) *caminoState
+		expectedCaminoState func(*caminoState) *caminoState
+		expectedErr         error
+	}{
+		"Fail: db errored on Put": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				depositOffersDB := database.NewMockDatabase(c)
+				depositOffersDB.EXPECT().Put(depositOffer2.ID[:], depositOffer2Bytes).Return(testError)
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer2.ID: depositOffer2,
+						},
+					},
+					depositOffersDB: depositOffersDB,
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{},
+					},
+					depositOffersDB: actualCaminoState.depositOffersDB,
+				}
+			},
+			expectedErr: testError,
+		},
+		"Fail: db errored on Delete": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				depositOffersDB := database.NewMockDatabase(c)
+				depositOffersDB.EXPECT().Delete(depositOffer1.ID[:]).Return(testError)
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer1.ID: nil,
+						},
+					},
+					depositOffersDB: depositOffersDB,
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{},
+					},
+					depositOffersDB: actualCaminoState.depositOffersDB,
+				}
+			},
+			expectedErr: testError,
+		},
+		"OK": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				depositOffersDB := database.NewMockDatabase(c)
+				depositOffersDB.EXPECT().Put(depositOffer2.ID[:], depositOffer2modifiedBytes).Return(nil)
+				depositOffersDB.EXPECT().Put(depositOffer3.ID[:], depositOffer3Bytes).Return(nil)
+				depositOffersDB.EXPECT().Delete(depositOffer4.ID[:]).Return(nil)
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+						depositOffer4.ID: depositOffer4,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{
+							depositOffer2.ID: depositOffer2modified,
+							depositOffer3.ID: depositOffer3,
+							depositOffer4.ID: nil,
+						},
+					},
+					depositOffersDB: depositOffersDB,
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2modified,
+						depositOffer3.ID: depositOffer3,
+					},
+					caminoDiff: &caminoDiff{
+						modifiedDepositOffers: map[ids.ID]*deposit.Offer{},
+					},
+					depositOffersDB: actualCaminoState.depositOffersDB,
+				}
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			actualCaminoState := tt.caminoState(ctrl)
+			require.ErrorIs(t, actualCaminoState.writeDepositOffers(), tt.expectedErr)
+			require.Equal(t, tt.expectedCaminoState(actualCaminoState), actualCaminoState)
+		})
+	}
+}
+
+func TestLoadDepositOffers(t *testing.T) {
+	depositOffer1 := &deposit.Offer{ID: ids.ID{1}, Memo: []byte("1")}
+	depositOffer2 := &deposit.Offer{ID: ids.ID{2}, Memo: []byte("2")}
+	depositOffer3 := &deposit.Offer{ID: ids.ID{3}, Memo: []byte("3")}
+	depositOffer1Bytes, err := blocks.GenesisCodec.Marshal(blocks.Version, depositOffer1)
+	require.NoError(t, err)
+	depositOffer2Bytes, err := blocks.GenesisCodec.Marshal(blocks.Version, depositOffer2)
+	require.NoError(t, err)
+	depositOffer3Bytes, err := blocks.GenesisCodec.Marshal(blocks.Version, depositOffer3)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		caminoState         func(*gomock.Controller) *caminoState
+		expectedCaminoState func(*caminoState) *caminoState
+		expectedErr         error
+	}{
+		"OK": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				offersIterator := database.NewMockIterator(c)
+				offersIterator.EXPECT().Next().Return(true).Times(3)
+				offersIterator.EXPECT().Key().Return(depositOffer1.ID[:])
+				offersIterator.EXPECT().Value().Return(depositOffer1Bytes)
+				offersIterator.EXPECT().Key().Return(depositOffer2.ID[:])
+				offersIterator.EXPECT().Value().Return(depositOffer2Bytes)
+				offersIterator.EXPECT().Key().Return(depositOffer3.ID[:])
+				offersIterator.EXPECT().Value().Return(depositOffer3Bytes)
+				offersIterator.EXPECT().Error().Return(nil)
+				offersIterator.EXPECT().Next().Return(false)
+				offersIterator.EXPECT().Release()
+
+				depositOffersDB := database.NewMockDatabase(c)
+				depositOffersDB.EXPECT().NewIterator().Return(offersIterator)
+				return &caminoState{
+					depositOffers:   map[ids.ID]*deposit.Offer{},
+					depositOffersDB: depositOffersDB,
+				}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffersDB: actualCaminoState.depositOffersDB,
+					depositOffers: map[ids.ID]*deposit.Offer{
+						depositOffer1.ID: depositOffer1,
+						depositOffer2.ID: depositOffer2,
+						depositOffer3.ID: depositOffer3,
+					},
+				}
+			},
+		},
+		"OK: no deposits": {
+			caminoState: func(c *gomock.Controller) *caminoState {
+				offersIterator := database.NewMockIterator(c)
+				offersIterator.EXPECT().Next().Return(false)
+				offersIterator.EXPECT().Error().Return(nil)
+				offersIterator.EXPECT().Release()
+
+				depositOffersDB := database.NewMockDatabase(c)
+				depositOffersDB.EXPECT().NewIterator().Return(offersIterator)
+				return &caminoState{depositOffersDB: depositOffersDB}
+			},
+			expectedCaminoState: func(actualCaminoState *caminoState) *caminoState {
+				return &caminoState{
+					depositOffersDB: actualCaminoState.depositOffersDB,
+				}
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			actualCaminoState := tt.caminoState(ctrl)
+			require.ErrorIs(t, actualCaminoState.loadDepositOffers(), tt.expectedErr)
+			require.Equal(t, tt.expectedCaminoState(actualCaminoState), actualCaminoState)
+		})
+	}
+}

--- a/vms/platformvm/state/camino_helpers_test.go
+++ b/vms/platformvm/state/camino_helpers_test.go
@@ -81,3 +81,35 @@ func newMockStateVersions(c *gomock.Controller, parentStateID ids.ID, parentStat
 	stateVersions.EXPECT().GetState(parentStateID).Return(parentState, true)
 	return stateVersions
 }
+
+func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.UTXO { //nolint:unparam
+	return generateTestUTXOWithIndex(txID, 0, assetID, amount, outputOwners, depositTxID, bondTxID, true)
+}
+
+func generateTestUTXOWithIndex(txID ids.ID, outIndex uint32, assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID, init bool) *avax.UTXO {
+	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
+		Amt:          amount,
+		OutputOwners: outputOwners,
+	}
+	if depositTxID != ids.Empty || bondTxID != ids.Empty {
+		out = &locked.Out{
+			IDs: locked.IDs{
+				DepositTxID: depositTxID,
+				BondTxID:    bondTxID,
+			},
+			TransferableOut: out,
+		}
+	}
+	testUTXO := &avax.UTXO{
+		UTXOID: avax.UTXOID{
+			TxID:        txID,
+			OutputIndex: outIndex,
+		},
+		Asset: avax.Asset{ID: assetID},
+		Out:   out,
+	}
+	if init {
+		testUTXO.InputID()
+	}
+	return testUTXO
+}

--- a/vms/platformvm/state/camino_state_test.go
+++ b/vms/platformvm/state/camino_state_test.go
@@ -1,0 +1,223 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockedUTXOs(t *testing.T) {
+	bondTxID1 := ids.ID{0, 1}
+	bondTxID2 := ids.ID{0, 2}
+	depositTxID1 := ids.ID{0, 3}
+	depositTxID2 := ids.ID{0, 4}
+	owner1 := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{{1}}}
+	owner2 := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{{2}}}
+	assetID := ids.ID{}
+
+	// addr1, bond1
+	utxoAddr1Bond1_1 := generateTestUTXO(
+		ids.ID{1}, assetID, 1, owner1, ids.Empty, bondTxID1)
+	utxoAddr1Bond1_2 := generateTestUTXO(
+		ids.ID{2}, assetID, 1, owner1, ids.Empty, bondTxID1)
+	// addr2, bond1
+	utxoAddr2Bond1_1 := generateTestUTXO(
+		ids.ID{3}, assetID, 1, owner2, ids.Empty, bondTxID1)
+	utxoAddr2Bond1_2 := generateTestUTXO(
+		ids.ID{4}, assetID, 1, owner2, ids.Empty, bondTxID1)
+	// addr1, bond2
+	utxoAddr1Bond2_1 := generateTestUTXO(
+		ids.ID{5}, assetID, 1, owner1, ids.Empty, bondTxID2)
+	utxoAddr1Bond2_2 := generateTestUTXO(
+		ids.ID{6}, assetID, 1, owner1, ids.Empty, bondTxID2)
+	// addr2, bond2
+	utxoAddr2Bond2_1 := generateTestUTXO(
+		ids.ID{7}, assetID, 1, owner2, ids.Empty, bondTxID2)
+	utxoAddr2Bond2_2 := generateTestUTXO(
+		ids.ID{8}, assetID, 1, owner2, ids.Empty, bondTxID2)
+	// addr1, deposit1
+	utxoAddr1Deposit1_1 := generateTestUTXO(
+		ids.ID{9}, assetID, 1, owner1, depositTxID1, ids.Empty)
+	utxoAddr1Deposit1_2 := generateTestUTXO(
+		ids.ID{10}, assetID, 1, owner1, depositTxID1, ids.Empty)
+	// addr2, deposit1
+	utxoAddr2Deposit1_1 := generateTestUTXO(
+		ids.ID{11}, assetID, 1, owner2, depositTxID1, ids.Empty)
+	utxoAddr2Deposit1_2 := generateTestUTXO(
+		ids.ID{12}, assetID, 1, owner2, depositTxID1, ids.Empty)
+	// addr1, deposit2
+	utxoAddr1Deposit2_1 := generateTestUTXO(
+		ids.ID{13}, assetID, 1, owner1, depositTxID2, ids.Empty)
+	utxoAddr1Deposit2_2 := generateTestUTXO(
+		ids.ID{14}, assetID, 1, owner1, depositTxID2, ids.Empty)
+	// addr2, deposit2
+	utxoAddr2Deposit2_1 := generateTestUTXO(
+		ids.ID{15}, assetID, 1, owner2, depositTxID2, ids.Empty)
+	utxoAddr2Deposit2_2 := generateTestUTXO(
+		ids.ID{16}, assetID, 1, owner2, depositTxID2, ids.Empty)
+	// addr1, deposit1, bond1
+	utxoAddr1Deposit1Bond1_1 := generateTestUTXO(
+		ids.ID{17}, assetID, 1, owner1, depositTxID1, bondTxID1)
+	utxoAddr1Deposit1Bond1_2 := generateTestUTXO(
+		ids.ID{18}, assetID, 1, owner1, depositTxID1, bondTxID1)
+	// addr2, deposit1, bond1
+	utxoAddr2Deposit1Bond1_1 := generateTestUTXO(
+		ids.ID{19}, assetID, 1, owner2, depositTxID1, bondTxID1)
+	utxoAddr2Deposit1Bond1_2 := generateTestUTXO(
+		ids.ID{20}, assetID, 1, owner2, depositTxID1, bondTxID1)
+	// addr1, deposit2, bond1
+	utxoAddr1Deposit2Bond1_1 := generateTestUTXO(
+		ids.ID{21}, assetID, 1, owner1, depositTxID2, bondTxID1)
+	utxoAddr1Deposit2Bond1_2 := generateTestUTXO(
+		ids.ID{22}, assetID, 1, owner1, depositTxID2, bondTxID1)
+	// addr2, deposit2, bond1
+	utxoAddr2Deposit2Bond1_1 := generateTestUTXO(
+		ids.ID{23}, assetID, 1, owner2, depositTxID2, bondTxID1)
+	utxoAddr2Deposit2Bond1_2 := generateTestUTXO(
+		ids.ID{24}, assetID, 1, owner2, depositTxID2, bondTxID1)
+
+	allUTXOs := []*avax.UTXO{
+		utxoAddr1Bond1_1, utxoAddr1Bond1_2,
+		utxoAddr2Bond1_1, utxoAddr2Bond1_2,
+		utxoAddr1Bond2_1, utxoAddr1Bond2_2,
+		utxoAddr2Bond2_1, utxoAddr2Bond2_2,
+		utxoAddr1Deposit1_1, utxoAddr1Deposit1_2,
+		utxoAddr2Deposit1_1, utxoAddr2Deposit1_2,
+		utxoAddr1Deposit2_1, utxoAddr1Deposit2_2,
+		utxoAddr2Deposit2_1, utxoAddr2Deposit2_2,
+		utxoAddr1Deposit1Bond1_1, utxoAddr1Deposit1Bond1_2,
+		utxoAddr2Deposit1Bond1_1, utxoAddr2Deposit1Bond1_2,
+		utxoAddr1Deposit2Bond1_1, utxoAddr1Deposit2Bond1_2,
+		utxoAddr2Deposit2Bond1_1, utxoAddr2Deposit2Bond1_2,
+	}
+
+	tests := map[string]struct {
+		state         func(*testing.T) *state
+		lockTxIDs     []ids.ID
+		addresses     []ids.ShortID
+		lockState     locked.State
+		expectedUTXOs []*avax.UTXO
+		expectedErr   error
+	}{
+		"OK: addr1, bond1": {
+			state: func(t *testing.T) *state {
+				state := newEmptyState(t)
+				for _, utxo := range allUTXOs {
+					state.AddUTXO(utxo)
+				}
+				require.NoError(t, state.Commit())
+				return state
+			},
+			lockTxIDs: []ids.ID{bondTxID1},
+			addresses: []ids.ShortID{owner1.Addrs[0]},
+			lockState: locked.StateBonded,
+			expectedUTXOs: []*avax.UTXO{
+				utxoAddr1Bond1_1, utxoAddr1Bond1_2,
+				utxoAddr1Deposit1Bond1_1, utxoAddr1Deposit1Bond1_2,
+				utxoAddr1Deposit2Bond1_1, utxoAddr1Deposit2Bond1_2,
+			},
+		},
+		"OK: addr2, bond1, bond2": {
+			state: func(t *testing.T) *state {
+				state := newEmptyState(t)
+				for _, utxo := range allUTXOs {
+					state.AddUTXO(utxo)
+				}
+				require.NoError(t, state.Commit())
+				return state
+			},
+			lockTxIDs: []ids.ID{bondTxID1, bondTxID2},
+			addresses: []ids.ShortID{owner2.Addrs[0]},
+			lockState: locked.StateBonded,
+			expectedUTXOs: []*avax.UTXO{
+				utxoAddr2Bond1_1, utxoAddr2Bond1_2,
+				utxoAddr2Bond2_1, utxoAddr2Bond2_2,
+				utxoAddr2Deposit1Bond1_1, utxoAddr2Deposit1Bond1_2,
+				utxoAddr2Deposit2Bond1_1, utxoAddr2Deposit2Bond1_2,
+			},
+		},
+		"OK: addr1, deposit1": {
+			state: func(t *testing.T) *state {
+				state := newEmptyState(t)
+				for _, utxo := range allUTXOs {
+					state.AddUTXO(utxo)
+				}
+				require.NoError(t, state.Commit())
+				return state
+			},
+			lockTxIDs: []ids.ID{depositTxID1},
+			addresses: []ids.ShortID{owner1.Addrs[0]},
+			lockState: locked.StateDeposited,
+			expectedUTXOs: []*avax.UTXO{
+				utxoAddr1Deposit1_1, utxoAddr1Deposit1_2,
+				utxoAddr1Deposit1Bond1_1, utxoAddr1Deposit1Bond1_2,
+			},
+		},
+		"OK: addr1, deposit1, deposit2": {
+			state: func(t *testing.T) *state {
+				state := newEmptyState(t)
+				for _, utxo := range allUTXOs {
+					state.AddUTXO(utxo)
+				}
+				require.NoError(t, state.Commit())
+				return state
+			},
+			lockTxIDs: []ids.ID{depositTxID1, depositTxID2},
+			addresses: []ids.ShortID{owner1.Addrs[0]},
+			lockState: locked.StateDeposited,
+			expectedUTXOs: []*avax.UTXO{
+				utxoAddr1Deposit1_1, utxoAddr1Deposit1_2,
+				utxoAddr1Deposit2_1, utxoAddr1Deposit2_2,
+				utxoAddr1Deposit1Bond1_1, utxoAddr1Deposit1Bond1_2,
+				utxoAddr1Deposit2Bond1_1, utxoAddr1Deposit2Bond1_2,
+			},
+		},
+		"OK: addr1, addr2, deposit1": {
+			state: func(t *testing.T) *state {
+				state := newEmptyState(t)
+				for _, utxo := range allUTXOs {
+					state.AddUTXO(utxo)
+				}
+				require.NoError(t, state.Commit())
+				return state
+			},
+			lockTxIDs: []ids.ID{depositTxID1},
+			addresses: []ids.ShortID{owner1.Addrs[0], owner2.Addrs[0]},
+			lockState: locked.StateDeposited,
+			expectedUTXOs: []*avax.UTXO{
+				utxoAddr1Deposit1_1, utxoAddr1Deposit1_2,
+				utxoAddr2Deposit1_1, utxoAddr2Deposit1_2,
+				utxoAddr1Deposit1Bond1_1, utxoAddr1Deposit1Bond1_2,
+				utxoAddr2Deposit1Bond1_1, utxoAddr2Deposit1Bond1_2,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			lockTxIDs := set.Set[ids.ID]{}
+			addresses := set.Set[ids.ShortID]{}
+			for _, lockTxID := range tt.lockTxIDs {
+				lockTxIDs.Add(lockTxID)
+			}
+			for _, addr := range tt.addresses {
+				addresses.Add(addr)
+			}
+
+			utxos, err := tt.state(t).LockedUTXOs(lockTxIDs, addresses, tt.lockState)
+			require.ErrorIs(t, err, tt.expectedErr)
+			require.ElementsMatch(t, tt.expectedUTXOs, utxos)
+		})
+	}
+}

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -896,13 +896,14 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 		}
 	}
 
-	// Checking claimables sigs and claimable amounts, updating claimables in state // todo@ comment
+	// Checking claimables sigs and claimable amounts,
+	// updating claimables in state, minting reward utxos and adding them to state
 
 	for i, ownerID := range tx.ClaimableOwnerIDs {
 		claimable, err := e.State.GetClaimable(ownerID)
 		if err == database.ErrNotFound {
 			// tx.ClaimedAmount[i] > 0, so we'r trying to claim more, than available
-			return errWrongClaimedAmount
+			return fmt.Errorf("no claimable found for the ownerID (%s): %w", ownerID, errWrongClaimedAmount)
 		} else if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Various small non-critical improvements like added caching for claimables, cached non distributed reward and so on
- Tests for state functions for deposits, offers, claimables
- Changes deposit offers db from linkeddb to simple leveldb, fix short links db prefix from obsolete "consortium nodes"