### PR TITLE
[PVM] add claimType to claimTx

### DIFF
--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -482,6 +482,7 @@ type ClaimArgs struct {
 	DepositTxIDs    []ids.ID            `json:"depositTxIDs"`
 	ClaimableOwners []platformapi.Owner `json:"claimableOwners"`
 	AmountToClaim   []uint64            `json:"amountToClaim"`
+	ClaimType       txs.ClaimType       `json:"claimType"`
 	ClaimTo         platformapi.Owner   `json:"claimTo"`
 	Change          platformapi.Owner   `json:"change"`
 }
@@ -523,6 +524,7 @@ func (s *CaminoService) Claim(_ *http.Request, args *ClaimArgs, reply *api.JSONT
 		args.DepositTxIDs,
 		claimableOwnerIDs,
 		args.AmountToClaim,
+		args.ClaimType,
 		claimTo,
 		privKeys,
 		change,
@@ -602,7 +604,7 @@ func (s *CaminoService) GetClaimables(_ *http.Request, args *GetClaimablesArgs, 
 	}
 
 	response.ValidatorRewards = claimable.ValidatorReward
-	response.ExpiredDepositRewards = claimable.DepositReward
+	response.ExpiredDepositRewards = claimable.ExpiredDepositReward
 
 	return nil
 }

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -520,8 +520,8 @@ func TestDepositsAutoUnlock(t *testing.T) {
 	claimable, err := vm.state.GetClaimable(ownerID)
 	require.NoError(err)
 	require.Equal(&state.Claimable{
-		Owner:         &depositOwner,
-		DepositReward: deposit.TotalReward(depositOffer),
+		Owner:                &depositOwner,
+		ExpiredDepositReward: deposit.TotalReward(depositOffer),
 	}, claimable)
 	require.Equal(getUnlockedBalance(t, vm.state, depositOwnerAddr), depositOffer.MinAmount)
 	require.Equal(deposit.EndTime(), vm.state.GetTimestamp())

--- a/vms/platformvm/state/camino_claimable.go
+++ b/vms/platformvm/state/camino_claimable.go
@@ -13,9 +13,9 @@ import (
 )
 
 type Claimable struct {
-	Owner           *secp256k1fx.OutputOwners `serialize:"true"`
-	ValidatorReward uint64                    `serialize:"true"`
-	DepositReward   uint64                    `serialize:"true"`
+	Owner                *secp256k1fx.OutputOwners `serialize:"true"`
+	ValidatorReward      uint64                    `serialize:"true"`
+	ExpiredDepositReward uint64                    `serialize:"true"`
 }
 
 func (cs *caminoState) SetClaimable(ownerID ids.ID, claimable *Claimable) {

--- a/vms/platformvm/state/camino_claimable_test.go
+++ b/vms/platformvm/state/camino_claimable_test.go
@@ -121,9 +121,9 @@ func TestGetClaimable(t *testing.T) {
 func TestSetClaimable(t *testing.T) {
 	ownerID := ids.GenerateTestID()
 	claimable := &Claimable{
-		Owner:           &secp256k1fx.OutputOwners{},
-		ValidatorReward: 1,
-		DepositReward:   1,
+		Owner:                &secp256k1fx.OutputOwners{},
+		ValidatorReward:      1,
+		ExpiredDepositReward: 1,
 	}
 
 	tests := map[string]struct {
@@ -235,7 +235,7 @@ func TestWriteClaimableAndValidatorRewards(t *testing.T) {
 	testError := errors.New("test error")
 	claimableOwnerID1 := ids.ID{1}
 	claimableOwnerID2 := ids.ID{2}
-	claimable1 := &Claimable{Owner: &secp256k1fx.OutputOwners{}, ValidatorReward: 1, DepositReward: 2}
+	claimable1 := &Claimable{Owner: &secp256k1fx.OutputOwners{}, ValidatorReward: 1, ExpiredDepositReward: 2}
 	claimableBytes1, err := blocks.GenesisCodec.Marshal(blocks.Version, claimable1)
 	require.NoError(t, err)
 

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -74,6 +74,7 @@ type CaminoTxBuilder interface {
 		depositTxIDs []ids.ID,
 		claimableOwnerIDs []ids.ID,
 		amountToClaim []uint64,
+		claimType txs.ClaimType,
 		claimTo *secp256k1fx.OutputOwners,
 		keys []*crypto.PrivateKeySECP256K1R,
 		change *secp256k1fx.OutputOwners,
@@ -389,6 +390,7 @@ func (b *caminoBuilder) NewClaimTx(
 	depositTxIDs []ids.ID,
 	claimableOwnerIDs []ids.ID,
 	amountToClaim []uint64,
+	claimType txs.ClaimType,
 	claimTo *secp256k1fx.OutputOwners,
 	keys []*crypto.PrivateKeySECP256K1R,
 	change *secp256k1fx.OutputOwners,
@@ -451,6 +453,7 @@ func (b *caminoBuilder) NewClaimTx(
 		DepositTxIDs:      depositTxIDs,
 		ClaimableOwnerIDs: claimableOwnerIDs,
 		ClaimedAmounts:    amountToClaim,
+		ClaimType:         claimType,
 		ClaimTo:           claimTo,
 	}
 

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -307,6 +307,7 @@ func TestNewClaimTx(t *testing.T) {
 		depositTxIDs      []ids.ID
 		claimableOwnerIDs []ids.ID
 		amountToClaim     []uint64
+		claimType         txs.ClaimType
 		claimTo           *secp256k1fx.OutputOwners
 		keys              []*crypto.PrivateKeySECP256K1R
 		change            *secp256k1fx.OutputOwners
@@ -429,13 +430,14 @@ func TestNewClaimTx(t *testing.T) {
 				// fee
 				expectLock(s, map[ids.ShortID][]*avax.UTXO{feeAddr: {feeUTXO}, rewardOwner1Addr: {}})
 				// claimables
-				claimable := &state.Claimable{Owner: &rewardOwner1, DepositReward: 10, ValidatorReward: 100}
+				claimable := &state.Claimable{Owner: &rewardOwner1, ExpiredDepositReward: 10, ValidatorReward: 100}
 				s.EXPECT().GetClaimable(claimableOwnerID).Return(claimable, nil)
 				return s
 			},
 			args: args{
 				claimableOwnerIDs: []ids.ID{claimableOwnerID},
 				amountToClaim:     []uint64{60},
+				claimType:         txs.ClaimTypeAll,
 				claimTo:           &rewardOwner1,
 				keys: []*crypto.PrivateKeySECP256K1R{
 					feeKey,
@@ -447,6 +449,7 @@ func TestNewClaimTx(t *testing.T) {
 					BaseTx:            baseTx,
 					ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
 					ClaimedAmounts:    []uint64{60},
+					ClaimType:         txs.ClaimTypeAll,
 					ClaimTo:           &rewardOwner1,
 				}, txs.Codec, [][]*crypto.PrivateKeySECP256K1R{{feeKey}, {rewardOwner1Key}})
 				require.NoError(t, err)
@@ -469,7 +472,7 @@ func TestNewClaimTx(t *testing.T) {
 				}}
 				s.EXPECT().GetTx(depositTxID1).Return(depositTx1, status.Committed, nil)
 				// claimables
-				claimable := &state.Claimable{Owner: &rewardOwner1, DepositReward: 10, ValidatorReward: 100}
+				claimable := &state.Claimable{Owner: &rewardOwner1, ExpiredDepositReward: 10, ValidatorReward: 100}
 				s.EXPECT().GetClaimable(claimableOwnerID).Return(claimable, nil)
 				return s
 			},
@@ -477,6 +480,7 @@ func TestNewClaimTx(t *testing.T) {
 				depositTxIDs:      []ids.ID{depositTxID1},
 				claimableOwnerIDs: []ids.ID{claimableOwnerID},
 				amountToClaim:     []uint64{60},
+				claimType:         txs.ClaimTypeAll,
 				claimTo:           &rewardOwner1,
 				keys: []*crypto.PrivateKeySECP256K1R{
 					feeKey,
@@ -490,6 +494,7 @@ func TestNewClaimTx(t *testing.T) {
 					DepositTxIDs:      []ids.ID{depositTxID1},
 					ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
 					ClaimedAmounts:    []uint64{60},
+					ClaimType:         txs.ClaimTypeAll,
 					ClaimTo:           &rewardOwner1,
 				}, txs.Codec, [][]*crypto.PrivateKeySECP256K1R{{feeKey}, {rewardOwner1Key, rewardOwner2Key}})
 				require.NoError(t, err)
@@ -646,6 +651,7 @@ func TestNewClaimTx(t *testing.T) {
 				tt.args.depositTxIDs,
 				tt.args.claimableOwnerIDs,
 				tt.args.amountToClaim,
+				tt.args.claimType,
 				tt.args.claimTo,
 				tt.args.keys,
 				tt.args.change,

--- a/vms/platformvm/txs/camino_claim_tx_test.go
+++ b/vms/platformvm/txs/camino_claim_tx_test.go
@@ -58,11 +58,22 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 			},
 			expectedErr: errNonUniqueDepositTxID,
 		},
+		"Wrong claim type": {
+			tx: &ClaimTx{
+				BaseTx:            baseTx,
+				ClaimTo:           &owner1,
+				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
+				ClaimedAmounts:    []uint64{1},
+				ClaimType:         ClaimTypeAll + 1,
+			},
+			expectedErr: errWrongClaimType,
+		},
 		"Not unique ownerIDs": {
 			tx: &ClaimTx{
 				BaseTx:            baseTx,
 				ClaimableOwnerIDs: []ids.ID{claimableOwnerID, claimableOwnerID},
 				ClaimedAmounts:    []uint64{1, 1},
+				ClaimType:         ClaimTypeAll,
 			},
 			expectedErr: errNonUniqueOwnerID,
 		},
@@ -101,12 +112,31 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 				ClaimTo:      &owner1,
 			},
 		},
-		"OK with claimables": {
+		"OK with claimables (all)": {
 			tx: &ClaimTx{
 				BaseTx:            baseTx,
 				ClaimTo:           &owner1,
 				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
 				ClaimedAmounts:    []uint64{20},
+				ClaimType:         ClaimTypeAll,
+			},
+		},
+		"OK with claimables (expired deposit reward)": {
+			tx: &ClaimTx{
+				BaseTx:            baseTx,
+				ClaimTo:           &owner1,
+				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
+				ClaimedAmounts:    []uint64{20},
+				ClaimType:         ClaimTypeExpiredDepositReward,
+			},
+		},
+		"OK with claimables (validator reward)": {
+			tx: &ClaimTx{
+				BaseTx:            baseTx,
+				ClaimTo:           &owner1,
+				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
+				ClaimedAmounts:    []uint64{20},
+				ClaimType:         ClaimTypeValidatorReward,
 			},
 		},
 		"OK with claimables and deposits": {
@@ -116,6 +146,7 @@ func TestClaimTxSyntacticVerify(t *testing.T) {
 				ClaimTo:           &owner1,
 				ClaimableOwnerIDs: []ids.ID{claimableOwnerID},
 				ClaimedAmounts:    []uint64{20},
+				ClaimType:         ClaimTypeAll,
 			},
 		},
 	}


### PR DESCRIPTION
This PRs makes possible to claim either expired deposit reward, validator reward or both.
Its done by adding claimType bitfield to claimTx transaction. This field controls which parts of claimable will be claimed.
Unit tests are extended in order to test this change.