### PR TITLE
[SECP256K1] CrossTransferOutput with (Import) recipient field

### DIFF
--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -120,6 +120,7 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&RewardsImportTx{}),
 		targetCodec.RegisterCustomType(&secp256k1fx.MultisigCredential{}),
 		targetCodec.RegisterCustomType(&multisig.AliasWithNonce{}),
+		targetCodec.RegisterCustomType(&secp256k1fx.CrossTransferOutput{}),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -393,6 +393,20 @@ func generateTestOut(assetID ids.ID, amount uint64, outputOwners secp256k1fx.Out
 	}
 }
 
+func generateCrossOut(assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, recipient ids.ShortID) *avax.TransferableOutput {
+	var out avax.TransferableOut = &secp256k1fx.CrossTransferOutput{
+		TransferOutput: secp256k1fx.TransferOutput{
+			Amt:          amount,
+			OutputOwners: outputOwners,
+		},
+		Recipient: recipient,
+	}
+	return &avax.TransferableOutput{
+		Asset: avax.Asset{ID: assetID},
+		Out:   out,
+	}
+}
+
 func generateTestIn(assetID ids.ID, amount uint64, depositTxID, bondTxID ids.ID, sigIndices []uint32) *avax.TransferableInput {
 	var in avax.TransferableIn = &secp256k1fx.TransferInput{
 		Amt: amount,

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -371,12 +371,12 @@ func (e *CaminoStandardTxExecutor) wrapAtomicElementsForMultisig(tx *txs.ExportT
 	}
 
 	for i, output := range tx.ExportedOutputs {
-		out, ok := output.Out.(*secp256k1fx.TransferOutput)
+		owned, ok := output.Out.(secp256k1fx.Owned)
 		if !ok {
 			return locked.ErrWrongOutType
 		}
 
-		aliasInfs, err := e.Fx.CollectMultisigAliases(&out.OutputOwners, e.State)
+		aliasInfs, err := e.Fx.CollectMultisigAliases(owned.Owners(), e.State)
 		if err != nil {
 			return err
 		}

--- a/vms/secp256k1fx/camino_transfer_output.go
+++ b/vms/secp256k1fx/camino_transfer_output.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package secp256k1fx
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+)
+
+var (
+	_ verify.State       = (*CrossTransferOutput)(nil)
+	_ TransferOutputIntf = (*TransferOutput)(nil)
+
+	ErrEmptyRecipient = errors.New("receipient cannot be empty")
+)
+
+type TransferOutputIntf interface {
+	verify.Verifiable
+	Amount() uint64
+	Owners() interface{}
+}
+
+// Used in a cross transfer, this output can be used to specify
+// the recipient on the target chain at export time
+type CrossTransferOutput struct {
+	TransferOutput `serialize:"true"`
+
+	// The recipient address
+	Recipient ids.ShortID `serialize:"true" json:"recipient"`
+}
+
+func (out *CrossTransferOutput) MarshalJSON() ([]byte, error) {
+	result, err := out.OutputOwners.Fields()
+	if err != nil {
+		return nil, err
+	}
+
+	result["amount"] = out.Amt
+	result["recipient"] = out.Recipient
+	return json.Marshal(result)
+}
+
+func (out *CrossTransferOutput) Verify() error {
+	if err := out.TransferOutput.Verify(); err != nil {
+		return err
+	}
+
+	if out.Recipient == ids.ShortEmpty {
+		return ErrEmptyRecipient
+	}
+
+	return nil
+}

--- a/vms/secp256k1fx/camino_transfer_output_test.go
+++ b/vms/secp256k1fx/camino_transfer_output_test.go
@@ -1,0 +1,111 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package secp256k1fx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/codec/linearcodec"
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+var validAddress = ids.ShortID{0x00, 0x01, 0x02, 0x03, 0x04}
+
+func TestCrossOutputVerify(t *testing.T) {
+	require := require.New(t)
+	out := CrossTransferOutput{
+		TransferOutput: TransferOutput{
+			Amt: 1,
+			OutputOwners: OutputOwners{
+				Locktime:  1,
+				Threshold: 1,
+				Addrs: []ids.ShortID{
+					ids.ShortEmpty,
+				},
+			},
+		},
+		Recipient: validAddress,
+	}
+	require.NoError(out.Verify())
+}
+
+func TestCrossOutputVerifyEmpty(t *testing.T) {
+	require := require.New(t)
+	out := CrossTransferOutput{
+		TransferOutput: TransferOutput{
+			Amt: 1,
+			OutputOwners: OutputOwners{
+				Locktime:  1,
+				Threshold: 1,
+				Addrs: []ids.ShortID{
+					ids.ShortEmpty,
+				},
+			},
+		},
+		Recipient: ids.ShortEmpty,
+	}
+	require.ErrorIs(out.Verify(), ErrEmptyRecipient)
+}
+
+func TestCrossOutputSerialize(t *testing.T) {
+	require := require.New(t)
+	c := linearcodec.NewDefault()
+	m := codec.NewDefaultManager()
+	require.NoError(m.RegisterCodec(0, c))
+
+	expected := []byte{
+		// Codec version
+		0x00, 0x00,
+		// amount:
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39,
+		// locktime:
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xd4, 0x31,
+		// threshold:
+		0x00, 0x00, 0x00, 0x01,
+		// number of addresses:
+		0x00, 0x00, 0x00, 0x02,
+		// addrs[0]:
+		0x51, 0x02, 0x5c, 0x61, 0xfb, 0xcf, 0xc0, 0x78,
+		0xf6, 0x93, 0x34, 0xf8, 0x34, 0xbe, 0x6d, 0xd2,
+		0x6d, 0x55, 0xa9, 0x55,
+		// addrs[1]:
+		0xc3, 0x34, 0x41, 0x28, 0xe0, 0x60, 0x12, 0x8e,
+		0xde, 0x35, 0x23, 0xa2, 0x4a, 0x46, 0x1c, 0x89,
+		0x43, 0xab, 0x08, 0x59,
+		// Recipient:
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+	out := CrossTransferOutput{
+		TransferOutput: TransferOutput{
+			Amt: 12345,
+			OutputOwners: OutputOwners{
+				Locktime:  54321,
+				Threshold: 1,
+				Addrs: []ids.ShortID{
+					{
+						0x51, 0x02, 0x5c, 0x61, 0xfb, 0xcf, 0xc0, 0x78,
+						0xf6, 0x93, 0x34, 0xf8, 0x34, 0xbe, 0x6d, 0xd2,
+						0x6d, 0x55, 0xa9, 0x55,
+					},
+					{
+						0xc3, 0x34, 0x41, 0x28, 0xe0, 0x60, 0x12, 0x8e,
+						0xde, 0x35, 0x23, 0xa2, 0x4a, 0x46, 0x1c, 0x89,
+						0x43, 0xab, 0x08, 0x59,
+					},
+				},
+			},
+		},
+		Recipient: validAddress,
+	}
+	require.NoError(out.Verify())
+
+	result, err := m.Marshal(0, &out)
+	require.NoError(err)
+	require.Equal(expected, result)
+}


### PR DESCRIPTION
## Why this should be merged
On CrossChain TX (e.g. P -> C) the EVM recipient address is specified at ImportTx time.
This is suboptimal for MultiSig transactions where the initiator of a tx flow wants to specify it.

There is no way to directly (multisig) sign import and export tx together, because UTXO(-ID)s in sharedmem require the signed TransactionID of the export.

## How this works
The new SECP256k1fx CrossTransferOutput contains an Recipient (ids.ShortID) member which must not be empty.
If an ImportTx processes this new OutputType, the funds will be credited to this Recipient address

## How this was tested
Unit Tests / ExportTx flow tests