### PR TITLE
[PVM] add execution for baseTx - simple transfer

### DIFF
--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -18,7 +18,8 @@ type caminoTxMetrics struct {
 	numUnlockDepositTxs,
 	numClaimTxs,
 	numRegisterNodeTxs,
-	numRewardsImportTxs prometheus.Counter
+	numRewardsImportTxs,
+	numBaseTxs prometheus.Counter
 }
 
 func newCaminoTxMetrics(
@@ -40,6 +41,7 @@ func newCaminoTxMetrics(
 		numClaimTxs:         newTxMetric(namespace, "claim", registerer, &errs),
 		numRegisterNodeTxs:  newTxMetric(namespace, "register_node", registerer, &errs),
 		numRewardsImportTxs: newTxMetric(namespace, "rewards_import", registerer, &errs),
+		numBaseTxs:          newTxMetric(namespace, "base", registerer, &errs),
 	}
 	return m, errs.Err
 }
@@ -67,6 +69,10 @@ func (*txMetrics) RegisterNodeTx(*txs.RegisterNodeTx) error {
 }
 
 func (*txMetrics) RewardsImportTx(*txs.RewardsImportTx) error {
+	return nil
+}
+
+func (*txMetrics) BaseTx(*txs.BaseTx) error {
 	return nil
 }
 
@@ -99,5 +105,10 @@ func (m *caminoTxMetrics) RegisterNodeTx(*txs.RegisterNodeTx) error {
 
 func (m *caminoTxMetrics) RewardsImportTx(*txs.RewardsImportTx) error {
 	m.numRegisterNodeTxs.Inc()
+	return nil
+}
+
+func (m *caminoTxMetrics) BaseTx(*txs.BaseTx) error {
+	m.numBaseTxs.Inc()
 	return nil
 }

--- a/vms/platformvm/txs/camino_base_tx.go
+++ b/vms/platformvm/txs/camino_base_tx.go
@@ -1,12 +1,8 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs
 
-import "errors"
-
-var errNonExecutableTx = errors.New("this tx type can't be executed, its genesis-only")
-
-func (*BaseTx) Visit(Visitor) error {
-	return errNonExecutableTx
+func (tx *BaseTx) Visit(visitor Visitor) error {
+	return visitor.BaseTx(tx)
 }

--- a/vms/platformvm/txs/camino_multisig_alias_tx.go
+++ b/vms/platformvm/txs/camino_multisig_alias_tx.go
@@ -4,6 +4,7 @@
 package txs
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/snow"
@@ -11,7 +12,11 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/verify"
 )
 
-var _ UnsignedTx = (*MultisigAliasTx)(nil)
+var (
+	errNonExecutableTx = errors.New("this tx type can't be executed, its genesis-only")
+
+	_ UnsignedTx = (*MultisigAliasTx)(nil)
+)
 
 // MultisigAliasTx is an unsigned multisig alias tx
 type MultisigAliasTx struct {

--- a/vms/platformvm/txs/camino_visitor.go
+++ b/vms/platformvm/txs/camino_visitor.go
@@ -10,4 +10,5 @@ type CaminoVisitor interface {
 	ClaimTx(*ClaimTx) error
 	RegisterNodeTx(*RegisterNodeTx) error
 	RewardsImportTx(*RewardsImportTx) error
+	BaseTx(*BaseTx) error
 }

--- a/vms/platformvm/txs/executor/camino_visitor.go
+++ b/vms/platformvm/txs/executor/camino_visitor.go
@@ -33,6 +33,10 @@ func (*StandardTxExecutor) RewardsImportTx(*txs.RewardsImportTx) error {
 	return errWrongTxType
 }
 
+func (*StandardTxExecutor) BaseTx(*txs.BaseTx) error {
+	return errWrongTxType
+}
+
 // Proposal
 
 func (*ProposalTxExecutor) AddressStateTx(*txs.AddressStateTx) error {
@@ -56,6 +60,10 @@ func (*ProposalTxExecutor) RegisterNodeTx(*txs.RegisterNodeTx) error {
 }
 
 func (*ProposalTxExecutor) RewardsImportTx(*txs.RewardsImportTx) error {
+	return errWrongTxType
+}
+
+func (*ProposalTxExecutor) BaseTx(*txs.BaseTx) error {
 	return errWrongTxType
 }
 
@@ -85,6 +93,10 @@ func (*AtomicTxExecutor) RewardsImportTx(*txs.RewardsImportTx) error {
 	return errWrongTxType
 }
 
+func (*AtomicTxExecutor) BaseTx(*txs.BaseTx) error {
+	return errWrongTxType
+}
+
 // MemPool
 
 func (v *MempoolTxVerifier) AddressStateTx(tx *txs.AddressStateTx) error {
@@ -108,5 +120,9 @@ func (v *MempoolTxVerifier) RegisterNodeTx(tx *txs.RegisterNodeTx) error {
 }
 
 func (v *MempoolTxVerifier) RewardsImportTx(tx *txs.RewardsImportTx) error {
+	return v.standardTx(tx)
+}
+
+func (v *MempoolTxVerifier) BaseTx(tx *txs.BaseTx) error {
 	return v.standardTx(tx)
 }

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -39,6 +39,11 @@ func (i *issuer) RewardsImportTx(*txs.RewardsImportTx) error {
 	return nil
 }
 
+func (i *issuer) BaseTx(*txs.BaseTx) error {
+	i.m.addDecisionTx(i.tx)
+	return nil
+}
+
 // Remover
 
 func (r *remover) AddressStateTx(*txs.AddressStateTx) error {
@@ -67,6 +72,11 @@ func (r *remover) RegisterNodeTx(*txs.RegisterNodeTx) error {
 }
 
 func (r *remover) RewardsImportTx(*txs.RewardsImportTx) error {
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
+	return nil
+}
+
+func (r *remover) BaseTx(*txs.BaseTx) error {
 	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }

--- a/wallet/chain/p/camino_visitor.go
+++ b/wallet/chain/p/camino_visitor.go
@@ -34,6 +34,12 @@ func (*backendVisitor) RewardsImportTx(*txs.RewardsImportTx) error {
 	return errUnsupportedTxType
 }
 
+func (b *backendVisitor) BaseTx(tx *txs.BaseTx) error {
+	return b.baseTx(tx)
+}
+
+// signer
+
 func (s *signerVisitor) AddressStateTx(tx *txs.AddressStateTx) error {
 	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
 	if err != nil {
@@ -76,4 +82,12 @@ func (s *signerVisitor) RegisterNodeTx(tx *txs.RegisterNodeTx) error {
 
 func (*signerVisitor) RewardsImportTx(*txs.RewardsImportTx) error {
 	return errUnsupportedTxType
+}
+
+func (s *signerVisitor) BaseTx(tx *txs.BaseTx) error {
+	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
+	if err != nil {
+		return err
+	}
+	return sign(s.tx, txSigners)
 }


### PR DESCRIPTION
## Why this should be merged
This PR allows to make p-chain transfers with baseTx
## How this works
Adds execution logic for baseTx: verifyNoLocks + verifySpend + produce/consume
## How this was tested
Relying on existing unit tests
