### PR TITLE
Updated columbus genesis file to the latest state removing 2 initial validators

### DIFF
--- a/genesis/genesis_columbus.json
+++ b/genesis/genesis_columbus.json
@@ -2546,8 +2546,6 @@
         "platformAllocations": [
           {
             "amount": 100000000000000,
-            "nodeID": "NodeID-EPnVak5NCap1wdxJRWxKRQNaBfHi9MoVd",
-            "validatorDuration": 31276800,
             "depositDuration": 110376000,
             "depositOfferMemo": "PreSale 3 Years 8%",
             "memo": "125"
@@ -6560,8 +6558,6 @@
         "platformAllocations": [
           {
             "amount": 200000000000000,
-            "nodeID": "NodeID-9pygZskxbgi5ZKicwu5ES2ZwteTK6MnMH",
-            "validatorDuration": 30412800,
             "depositDuration": 110376000,
             "depositOfferMemo": "PreSale 3 Years 8%",
             "memo": "318"

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -374,7 +374,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "2gjCDJT8RDcj7o47LGwgPDtLMgwGcobhjwp8gBzrydmYAkkjtf",
+			expectedID: "jfUsiA4CdVRMS5M9JSVsYpU2qpVd7iVFqgWAaZoiYsHBpzK7Q",
 		},
 		{
 			networkID:  constants.KopernikusID,


### PR DESCRIPTION
## Why this should be merged
To update the columbus genesis file to the latest state.

## How this works
The updated columbus genesis file will automatically be active for the next version by default.

## How this was tested
By updating the test hash for the newly created genesis file.
