### PR TITLE
[PVM] Missing check of ImportTx ImportedInputs are not locked

### DIFF
--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -425,6 +425,9 @@ func (e *CaminoStandardTxExecutor) ImportTx(tx *txs.ImportTx) error {
 	if err := locked.VerifyNoLocks(tx.Ins, tx.Outs); err != nil {
 		return err
 	}
+	if err := locked.VerifyNoLocks(tx.ImportedInputs, nil); err != nil {
+		return err
+	}
 
 	return e.StandardTxExecutor.ImportTx(tx)
 }


### PR DESCRIPTION
## Why this should be merged
An executor of the ImportTx transaction does not verify that
tx.ImportedInputs does not have locked inputs via locked.VerifyNoLocks.
Although it does not seem possible to export a locked UTXO from C-Chain
at the moment of audit due to lack of [locked.In](http://locked.in/) and locked.Out definitions
in C-Chain transaction codec, it might be possible to do so in future.

## How this works

Adds missing check.

## How this was tested
