### PR TITLE
Add Beacon nodes for Mainnet

### DIFF
--- a/genesis/beacons.go
+++ b/genesis/beacons.go
@@ -37,6 +37,19 @@ func getNodes(networkID uint32) []node {
 				nodeID: "NodeID-6rsqgkg4F1i3SBjzj4tS5ucQWH7JMEouj",
 			},
 		}
+	case constants.CaminoID:
+		return []node{
+			// Camino Foundation
+			{
+				ip:     "34.79.120.198",
+				nodeID: "NodeID-MUTNPmSqwWtchZhVvkWRfF8SUK8FtfnwP",
+			},
+			// Chain4Travel
+			{
+				ip:     "34.147.107.229",
+				nodeID: "NodeID-KumZcRwRSAE7CUkFE18ZLMnPsCVDpQXz8",
+			},
+		}
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Why this should be merged
We need mainnet beacon nodes for the network to bootstrap properly

This PR adds the Validators of:
- Chain4Travel
- Camino Foundation

