### PR TITLE
[PVM] RewardsImportTx / cross-chain message fixes

### DIFF
--- a/vms/components/avax/camino_transferables.go
+++ b/vms/components/avax/camino_transferables.go
@@ -39,11 +39,11 @@ func SortTransferableInputs(ins []*TransferableInput) {
 	sort.Sort(&innerSortTransferableInputs{ins: ins})
 }
 
-type innerSortTransferableTimedUTXOs struct {
-	utxos []*TimedUTXO
+type innerSortTransferableUTXOs struct {
+	utxos []*UTXO
 }
 
-func (utxos *innerSortTransferableTimedUTXOs) Less(i, j int) bool {
+func (utxos *innerSortTransferableUTXOs) Less(i, j int) bool {
 	iID, iIndex := utxos.utxos[i].InputSource()
 	jID, jIndex := utxos.utxos[j].InputSource()
 
@@ -57,15 +57,15 @@ func (utxos *innerSortTransferableTimedUTXOs) Less(i, j int) bool {
 	}
 }
 
-func (utxos *innerSortTransferableTimedUTXOs) Len() int {
+func (utxos *innerSortTransferableUTXOs) Len() int {
 	return len(utxos.utxos)
 }
 
-func (utxos *innerSortTransferableTimedUTXOs) Swap(i, j int) {
+func (utxos *innerSortTransferableUTXOs) Swap(i, j int) {
 	utxos.utxos[j], utxos.utxos[i] = utxos.utxos[i], utxos.utxos[j]
 }
 
-// SortTransferableTimedUTXOs sorts the utxos based on the utxoid
-func SortTransferableTimedUTXOs(utxos []*TimedUTXO) {
-	sort.Sort(&innerSortTransferableTimedUTXOs{utxos: utxos})
+// SortTransferableUTXOs sorts the utxos based on the utxoid
+func SortTransferableUTXOs(utxos []*UTXO) {
+	sort.Sort(&innerSortTransferableUTXOs{utxos: utxos})
 }

--- a/vms/platformvm/blocks/builder/camino_network.go
+++ b/vms/platformvm/blocks/builder/camino_network.go
@@ -62,5 +62,11 @@ func (n *caminoNetwork) CrossChainAppRequest(_ context.Context, chainID ids.ID, 
 	n.ctx.Lock.Lock()
 	defer n.ctx.Lock.Unlock()
 
-	return n.blkBuilder.AddUnverifiedTx(tx)
+	if err := n.blkBuilder.AddUnverifiedTx(tx); err != nil {
+		n.ctx.Log.Error("caminoCrossChainAppRequest couldn't add rewardsImportTx to mempool", zap.Error(err))
+		// we don't want fatal here: its better to have network running
+		// and try to repair stalled reward imports, than crash the whole network
+	}
+
+	return nil
 }

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1215,6 +1215,8 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 			return fmt.Errorf("there are %d inputs and %d utxos: %w", len(tx.Ins), len(utxos), errInputsUTXOSMismatch)
 		}
 
+		avax.SortTransferableUTXOs(utxos)
+
 		for i, in := range tx.Ins {
 			utxo := utxos[i]
 


### PR DESCRIPTION
Make CrossChainAppRequest handler return no error if it wasn't able to add tx to mempool. Error in handler will result in fatal and crash every node that did it (whole network)

Sort utxos in RewardsImportTx executor. UTXOs in shared memory are unsorted, so tx can sometimes fail cause of different sorting order of utxos and imported inputs.

