### PR TITLE
Updated genesis for camino

### DIFF
--- a/genesis/camino_genesis_test.go
+++ b/genesis/camino_genesis_test.go
@@ -24,7 +24,7 @@ func TestGenesisChainData(t *testing.T) {
 			networkID: constants.CaminoID,
 			vmTest: vmTest{
 				vmIDs:      []ids.ID{constants.AVMID, constants.EVMID},
-				expectedID: []string{"yMQo4UEa2Gkk6aSmifkUuBsystV1iu1NppatvoYz6yCDnRjiq", "RinAZCjd5Dm4wk1FBWiXiiSW2VZkjzgNyR7nNBRkuCvG9zRkJ"},
+				expectedID: []string{"4Y8KXHrpNRiRBAC3nC6mMzGiE19Rnnwh2rUQ6RU7HdMhvfkS3", "2qv12ysjDcdVpJvz3xSaPduX4XhkQNGXafLvvJFLrJgVF7CSjU"},
 			},
 		},
 	}

--- a/genesis/genesis_camino.go
+++ b/genesis/genesis_camino.go
@@ -30,9 +30,9 @@ var (
 			MinValidatorStake: 100 * units.KiloAvax,
 			MaxValidatorStake: 100 * units.KiloAvax,
 			MinDelegatorStake: 25 * units.Avax,
-			MinDelegationFee:  20000, // 2%
-			MinStakeDuration:  183 * 24 * time.Hour, // 1/2 year (+.5 days)
-			MaxStakeDuration:  5 * 365 * 24 * time.Hour, // 5 years 
+			MinDelegationFee:  20000,                    // 2%
+			MinStakeDuration:  183 * 24 * time.Hour,     // 1/2 year (+.5 days)
+			MaxStakeDuration:  5 * 365 * 24 * time.Hour, // 5 years
 			RewardConfig: reward.Config{
 				MaxConsumptionRate: .12 * reward.PercentDenominator,
 				MinConsumptionRate: .10 * reward.PercentDenominator,

--- a/genesis/genesis_camino.go
+++ b/genesis/genesis_camino.go
@@ -31,8 +31,8 @@ var (
 			MaxValidatorStake: 100 * units.KiloAvax,
 			MinDelegatorStake: 25 * units.Avax,
 			MinDelegationFee:  20000, // 2%
-			MinStakeDuration:  14 * 24 * time.Hour,
-			MaxStakeDuration:  365 * 24 * time.Hour,
+			MinStakeDuration:  183 * 24 * time.Hour, // 1/2 year (+.5 days)
+			MaxStakeDuration:  5 * 365 * 24 * time.Hour, // 5 years 
 			RewardConfig: reward.Config{
 				MaxConsumptionRate: .12 * reward.PercentDenominator,
 				MinConsumptionRate: .10 * reward.PercentDenominator,

--- a/genesis/genesis_camino.json
+++ b/genesis/genesis_camino.json
@@ -811,7 +811,7 @@
             "amount": 45000000000000000,
             "depositDuration": 157680000,
             "depositOfferMemo": "Undeposit 5 Years 0%",
-            "memo": "ID:'43', Bucket:'07 Listing'"
+            "memo": "ID:'43', Bucket:'07 IEO'"
           }
         ]
       },
@@ -826,7 +826,7 @@
         "platformAllocations": [
           {
             "amount": 30000000000000000,
-            "memo": "ID:'44', Bucket:'07 Listing', Type: 'unlocked'"
+            "memo": "ID:'44', Bucket:'07 IEO', Type: 'unlocked'"
           }
         ]
       },

--- a/genesis/genesis_camino.json
+++ b/genesis/genesis_camino.json
@@ -1,7 +1,7 @@
 {
   "networkID": 1000,
   "allocations": null,
-  "startTime": 1166713120,
+  "startTime": 1667217600,
   "initialStakeDuration": 0,
   "initialStakeDurationOffset": 3600,
   "initialStakedFunds": null,
@@ -108,251 +108,7 @@
         "platformAllocations": [
           {
             "amount": 100000000000,
-            "memo": "2+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino13r5xljkdl7w4g9tcqynfafm4g89mx52ektkrju",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "nodeID": "NodeID-KumZcRwRSAE7CUkFE18ZLMnPsCVDpQXz8",
-            "validatorDuration": 63072000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "3"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1lj38gmfuwhd9l3gcn0vavms64xe76ljpx5wu5f",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "nodeID": "NodeID-MUTNPmSqwWtchZhVvkWRfF8SUK8FtfnwP",
-            "validatorDuration": 63936000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "4"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino19m2e8p6ce2yx9uf00rw5jm70l4w24x0s8gt55y",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1150000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "5"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1udd7y4uv9kfyh2jsckfztz9crgfve3gcxjmtm7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "6"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15gmmr9we6yhgd7z45ryy886cyqgeuuxcsq4um7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "7"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ca5yhrucv5haavjsw4m8nwx28tzva6f8nafte3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 135000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "8"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino12rxesrlk8qy6yydz9qegsx9rt9jj32gm8x80kw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "9"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1jpsr4vqdek4kt79ccndunxscyq2n09ljpz5aen",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1207000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "10"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino146qrj047eaapww0mrv52zcg30ycljhhyel9x2x",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 3600000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "11"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino13tfvfqqacg79akws0l42lktgc00q6e7wckduh3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 3600000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "12"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino18q6scezgt2646rzpc8fmw4jce5zmcvgvhzq7vy",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 3600000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "13"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1vctr8ha7zna8fxdkazt5k6cnlj7fmg7eg4htx4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 215000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "14"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1emp8mkj8g24wmln7dskagu5a8r3p7qef4pkqpg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "15"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino10jsl9f669s9dn6zpxjgerv57pmhnaup5s88dax",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 3000000000000000,
-            "nodeID": "NodeID-NyGcFbhSLRy5BHGc29v2h4kwUKMBqNtNq",
-            "validatorDuration": 32832000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "16"
+            "memo": "ID:'2', Bucket:'01 ADMIN', Type: 'unlocked'"
           }
         ]
       },
@@ -369,7 +125,7 @@
             "amount": 36150000000000000,
             "depositDuration": 157680000,
             "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "17"
+            "memo": "ID:'3', Bucket:'02 Founders'"
           }
         ]
       },
@@ -386,7 +142,7 @@
             "amount": 11550000000000000,
             "depositDuration": 157680000,
             "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "18"
+            "memo": "ID:'4', Bucket:'02 Founders'"
           }
         ]
       },
@@ -403,7 +159,7 @@
             "amount": 2800000000000000,
             "depositDuration": 157680000,
             "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "19"
+            "memo": "ID:'5', Bucket:'02 Founders'"
           }
         ]
       },
@@ -420,7 +176,7 @@
             "amount": 11550000000000000,
             "depositDuration": 157680000,
             "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "20"
+            "memo": "ID:'6', Bucket:'02 Founders'"
           }
         ]
       },
@@ -437,13 +193,13 @@
             "amount": 2800000000000000,
             "depositDuration": 157680000,
             "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "21"
+            "memo": "ID:'7', Bucket:'02 Founders'"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ak489h9rs6e728wvrgpkx7rzuu9hf4kutfspm0",
+        "avaxAddr": "X-camino1crv6z0h3zdzj2mwjacelywa9twyg7wj9ud4jah",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -451,16 +207,61 @@
         },
         "platformAllocations": [
           {
-            "amount": 10000000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "22"
-          },
+            "amount": 3000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'8', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yqn8cjps7szj8pl2sj425fg2v7tjyz4rsdh0wx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
           {
-            "amount": 100000000000000,
-            "timestampOffset": 5270400,
-            "memo": "22+"
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'9', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino153uxhwgdunhyzmaq6t2azlp77aqpnlkpqk8ms6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'10', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15cxxvhc3v23z86duy7ryuaraqjgnzjfcq0es6k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'11', Bucket:'02 Founders'"
           }
         ]
       },
@@ -478,7 +279,7 @@
             "depositDuration": 110376000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "23"
+            "memo": "ID:'12', Bucket:'03 Seed'"
           }
         ]
       },
@@ -496,7 +297,7 @@
             "depositDuration": 110376000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "24"
+            "memo": "ID:'13', Bucket:'03 Seed'"
           }
         ]
       },
@@ -514,7 +315,7 @@
             "depositDuration": 110376000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "25"
+            "memo": "ID:'14', Bucket:'03 Seed'"
           }
         ]
       },
@@ -532,7 +333,7 @@
             "depositDuration": 110376000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "26"
+            "memo": "ID:'15', Bucket:'03 Seed'"
           }
         ]
       },
@@ -550,5984 +351,7 @@
             "depositDuration": 110376000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "27"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1396cw839aatmnf2f3nmuuh6p6zn2vesyquzuzm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "28"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "28+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1nqsk0mwued2l8zy7calqhnemxuzct89x4nlv0n",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "29"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "29+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1vedj99e90uppeyza86qmhyyhfcfyhh054y30uh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "30"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "30+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ry0f50cfu670mxgj0nz6rz0d9jwqyg2kalk5vr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "31"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "31+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1tmq8ltmqrsud5ehqsd08lmg0vgxn57mkvm26yr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "32"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "32+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1k05g5q6alpm03ektp6w4y25uqz9nph7dzmnsqh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "33"
-          },
-          {
-            "amount": 150000000000,
-            "timestampOffset": 5270400,
-            "memo": "33+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1mcs8pk0f67p9s0mmtz9eyph26kp848rdsnpmh0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "34"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "34+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16ryrmg6csk09mmnswmnkdvtv2a7ug0777348qe",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "35"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "35+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1039z9rhr70sg02s2qysd0ydkxm4p5ljvj39sg5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 40000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "36"
-          },
-          {
-            "amount": 400000000000,
-            "timestampOffset": 5270400,
-            "memo": "36+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino14kmjrlcreau6duuh3a4r78p30rt9cauglprnzq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "37"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "37+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1u3p0peu345nvsnh27jcqun2yq89le838ylxzq0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "38"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "38+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1r7mmvmcszwtzxjhpeu4zgj6arfztch6t80jay0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "39"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "39+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1kje90w7g29xjwps75qwqyca84yvetp342xzt7c",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "40"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "40+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1mp7f8rt2jd604ywnhetk2xq4mmj9qluvxf2d8w",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "41"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "41+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1f4c73ufv6d9z93580jau6ugky9px22y0l6uxar",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "42"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "42+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino12kjwnczd3vcjctjjjwu58qs2c76ak4c36w7f40",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "43"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "43+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1jxlplag5299kcns2q86kzpp9jffvww3gfp2jx5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "44"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "44+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1uv72wn6ynluam4mmhf74vtfn7sq5xl9le4qvhr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "45"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "45+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1eyunyvyxfq8c9le0pc24xkdum2xehaums2ldxq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "46"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "46+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrdn5j3s",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "47"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "47+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino17qgahrsfwkkvqhpacf330w37edwt2fdy0pp7ze",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "nodeID": "NodeID-ADyRxZndN569FitkbBzpr8oSe6FnYCMUr",
-            "validatorDuration": 29980800,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "48"
-          },
-          {
-            "amount": 5000000000000,
-            "timestampOffset": 5270400,
-            "memo": "48+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino18fwezlvf9knlalnevyj20lrk6459ypyyhggx2j",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "49"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "49+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1dukvf6l4k928t4ngpcd2w3h3zyvnd278rzcyc7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "50"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "50+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino12eah23v9dcwcsjps267777klj8kkvwdyysdzzx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "51"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "51+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1t5ayje5edr2msh2dqtg4m6xp0fuv4k3qt4tdj9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 600000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "52"
-          },
-          {
-            "amount": 6000000000000,
-            "timestampOffset": 5270400,
-            "memo": "52+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ldpfsrvxh674jze42wxr7nwsrwatqpjnylu7vu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "53"
-          },
-          {
-            "amount": 5000000000000,
-            "timestampOffset": 5270400,
-            "memo": "53+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1heerqcl59yn3jtw99szd8l7q7a6jq24hpu380m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "54"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "54+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qy5zgzyxn7j22gtj5pd0r8gdgfrsduwrm8n7um",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "55"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "55+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino12e08wmmlauses9u4z7sj306mlpycq0gz0egjz6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "56"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "56+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1gqe0v4mamv5gxj9qh4hanftkhqvpnzecw2exme",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "57"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "57+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1hmrn6czfq65kqwfeq537ktp8ygzxdx4qr5m554",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "58"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "58+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1su5tl8scmw4zwjnacaw48wkl8vlz0vkd72rdyt",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "59"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "59+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1slw8htng4clqqwyk0nfvrydte2prmt2fdaf5ev",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "60"
-          },
-          {
-            "amount": 150000000000,
-            "timestampOffset": 5270400,
-            "memo": "60+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1udazut0vnsnsj674sl7zngtguxh9ze4mpz0ae5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "61"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "61+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino19fnu72sdpd0550h59g7gznlgrayzwulpc53chh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 60000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "62"
-          },
-          {
-            "amount": 600000000000,
-            "timestampOffset": 5270400,
-            "memo": "62+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1hs88mzs5s37t8nueennxy7gxz2stdpjel09zeq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "63"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "63+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1rklz6e8h8h4875pt55kgpwutd7gy3rps3q4hzt",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "64"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "64+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1kklwkxzvuefl4kvg4dkzw8hp5dq2marxdkfwz7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "65"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "65+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1277jph854ltpp9zxavp4fk2jjurprsd9jlusy0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "66"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "66+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1scefvccult0p9g9vvk2zp6qq7n44cmumnhm65q",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "67"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "67+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1lgjzmekp359u28dkngdf98spe88050swhe9l5h",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "68"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "68+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1auylykzk6zqxsvrrx6gy2dc4v4l9fp3tsal6k8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "69"
-          },
-          {
-            "amount": 150000000000,
-            "timestampOffset": 5270400,
-            "memo": "69+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1p6wvd9jd0dxueuseghgpnvgl979elus4xrl5vd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "70"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "70+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1t907jgamny9vqkl3ec7sfpdvskqf6wspezcy0m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "71"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "71+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino156x6huxhlqw28awt2cqd0q02qrfxne6hpsegmg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "72"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "72+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1mxzvy5vpt7danrzvgkvvlw3x7wypea3lzdvd3s",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "73"
-          },
-          {
-            "amount": 150000000000,
-            "timestampOffset": 5270400,
-            "memo": "73+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qtdntjtqcqqnvfsx4c5gc2phtktmjca8q57tvt",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "74"
-          },
-          {
-            "amount": 250000000000,
-            "timestampOffset": 5270400,
-            "memo": "74+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1f2ur6q69hstytk7002mgqsuvhr9psmewvf45x2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "75"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "75+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1cvd8ardpsynhgfhdaapf7akhqv6sc7m99098vy",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "76"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "76+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1xpj2lh6dzlx22pjuyaelf75g0vug44qghehc45",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "77"
-          },
-          {
-            "amount": 5000000000000,
-            "timestampOffset": 5270400,
-            "memo": "77+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1q50k78pse6vky5gwdsmuf7njcp8ahdlugw2ceu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "78"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "78+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15nnu9w2g3zj5sku9gl62gl5sdj6m5fdd2t8me7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "79"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "79+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino19vvz56u2c7mstv88fmnmlm2kfa8vyp2ahl06e0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "80"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "80+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1avxc8uyqzf9hzwa9eacgg2x8y473j85sd2jwdt",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "81"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "81+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1zkny353z0srmc3yuajv2x2hjstkcun3aq3ww3u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "nodeID": "NodeID-EPnVak5NCap1wdxJRWxKRQNaBfHi9MoVd",
-            "validatorDuration": 30412800,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "82"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "82+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ne69lm0mplfxcxmqlv3ls6wk5z8m3tc3dr3rpj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "83"
-          },
-          {
-            "amount": 150000000000,
-            "timestampOffset": 5270400,
-            "memo": "83+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino19hw2tjza5vuyjrgv0nlcle4mw573wxp507udyx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "84"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "84+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1sey28879jhn9uy822u38vxw3uke8pazwsxlgr4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "85"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 5270400,
-            "memo": "85+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino124aw7ncdfefyqm4srujj9h3yxt9qzpsacsdk26",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "86"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "86+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ydmngswj235mczwktxz6d2zj64nh5cp8h5ht2r",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "87"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "87+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1gyk9tf69huuc7lrrt6myuzufg4zv4tewyw9s72",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "88"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "88+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1lc4qzvsqfzt2yy9k4596v394se6pg97lmjvgel",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "89"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "89+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1lf62vgkt80dcgq0ljmjedvptrj8h93vnmej4xv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "90"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "90+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1zc75guv3vwlhheq76egjesu23eccaa9kz097tn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "91"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "91+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1cmtfkrzpeau8jy87cftmr87x5vs8vrg26lere9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "92"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "92+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino154ys5gaceac0m2sj0fskwzptr6tl77lwe3w3v7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "93"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "93+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1tvlzzcgfey8mc7z3mhwepk84kagutdwmw0m2ul",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "94"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "94+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino17v6mxjg8t0w5lq9w6qx76k3p7ar7z8q2k532rl",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "95"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "95+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1yqgm4zkumgv5hf2afp798arjm59tat3ve9l4d8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "96"
-          },
-          {
-            "amount": 250000000000,
-            "timestampOffset": 5270400,
-            "memo": "96+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1sd7q4a5v0t3g3r86uzwzkmxdf5mqs6unerwxa4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "97"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "97+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1pvpjqg5p8xwqgcjeqv5vzdlmzlmpw06whegrvm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "98"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "98+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ldtg0fl6reuf9w27w6xt9hvqfjal7lggkq3x33",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "99"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 5270400,
-            "memo": "99+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1yfpzkqaqgqrs4z4ta9stwht4cgmfqeae7dyjnz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 30000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "100"
-          },
-          {
-            "amount": 300000000000,
-            "timestampOffset": 5270400,
-            "memo": "100+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1xfj26sj8yjtzu632hwryw6k5k8q4t4a8h3jt65",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "101"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "101+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1jp56myed7nwy3sre4u445mepkpe79ymmzfr905",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "102"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "102+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino17z889qchneqk94x9mjxw0m0xgcgls9d53s7dvg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "103"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "103+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1a3l20l8nwejvkfszggzjeac8lepymh6e3pzm2u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "104"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "104+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino174v5ghmdy20xtmyjnqsmnn6yv99jcxtmcsmhkg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "105"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "105+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino13yjkkxgkg0mk7k727f30hwy78zukld6zwfdxy9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "106"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "106+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1edf9wnssqddknydsdym28al5axq7dum75da6fl",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "107"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "107+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1kfapm9d2r8n5rmjvvv5284qp2rdr7t69nul5j8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "108"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "108+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16l5nmctdj4qqk4zqmy8zlkmsaypjzkw4ehfpkp",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 400000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "109"
-          },
-          {
-            "amount": 4000000000000,
-            "timestampOffset": 5270400,
-            "memo": "109+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15tt8kvkah5qcs8r24d9v7w2eymg4hq2nk77gfu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 2000000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "110"
-          },
-          {
-            "amount": 20000000000000,
-            "timestampOffset": 5270400,
-            "memo": "110+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1vwlkq9xandunkreu49gwkql8vtnxa0ltslq8k5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "111"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "111+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1sjsdrw4avghcnvm4rkvsd5clhcujgm8dp292ke",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "112"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "112+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1pfl4x5q63wl6e76m2jrncxchsh4eruw32kqmlu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "113"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "113+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16g8j2vrcywjskaygezkm5rl40df6m063df2e8g",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "114"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 5270400,
-            "memo": "114+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1am4366ap64h8gftnfd5xcx6gspk237y8vrnd97",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "115"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "115+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1258ga93qdkk7x58rrfp88zt5y9w64sr6p38kc9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "116"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "116+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1u8cuvpxmq807q95newex63za3kpw3nqwyj4g7e",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "117"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "117+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ezjkht68k5rz69c5xeetn59vs3wmw6ffa4x5ze",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "118"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "118+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1vw4u7j0dwzampvvmyt65rckvfjyykkkgcrf04h",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "119"
-          },
-          {
-            "amount": 150000000000,
-            "timestampOffset": 5270400,
-            "memo": "119+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ku4xvfreup02ugju8ls6npyfeu2d0vp2n7c4d9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "120"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16g8j2vrcywjskaygezkm5rl40df6m063df2e8g",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "121"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16dkxe6puk3y4qm7hjfvg2lwl8r92e27sj70dxt",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 300000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "122"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ty3unkry6cqhyyrv4hl6zuhx0k6z59xyezf726",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "123"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1s5nvfwlytnphhzjqm7ep9w7xe25zrep9vm4ua3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 300000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "124"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16kqqmrpa92upyxy63z02zjyuvdwjtlhzlsm92c",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 300000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "125"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1yz03v8cyvgglekensauc8f40vn9mxdnt2xvkef",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "126"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1k6z0skaz3333445zz6vgl9nsmzkm2a89xskxqs",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "127"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "127+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qh9nzgm6q5cfa2mpshwu9guzahf5se7furw6fa",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 600000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "128"
-          },
-          {
-            "amount": 6000000000000,
-            "timestampOffset": 5270400,
-            "memo": "128+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino13kzrxg5y4qs97qzf4zdqw9m4z9ydkku6xudkk9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "129"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "129+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1jm8694tdqc6q27my8wnwhe7mmpl93scy3rgrvm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "130"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 5270400,
-            "memo": "130+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1gqj0qsm8dhyer2alw57rwvt0wqp8hhvk83lk9p",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "131"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "131+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1els93ysuw4ansfqxe55wlf7ca2rzl0xhhe97pc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "132"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "132+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1e9kkysfkfq5xr93qyyxsfz0mg43x2fgdl49e5v",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "133"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "133+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1nsh2rw3sjvylgd9gk3jpmfx4dlfgm92ylwms58",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "134"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "134+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1uxp2phhpxh7q2zrfmy8pnzt4q9ytg084rpzasv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "135"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "135+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1nkjv6uvpn0u7qg5g24yaey0ch3upjgcycp3rne",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 30000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "136"
-          },
-          {
-            "amount": 300000000000,
-            "timestampOffset": 5270400,
-            "memo": "136+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino124qh486fhjst6c2zysxgvusz0vlu867qn3lxxy",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "137"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "137+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1pg3wvrpe3efjt8phj5pf5ftmrk66jr5lzm2jge",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "138"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "138+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1whhfteexl2x4sdl0jfs4nqvdvyh0qx7hvgvvcs",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "nodeID": "NodeID-nj5YW9BXAYQSWunEV5sUqS68vHdnU2Aw",
-            "validatorDuration": 34128000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "139"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "139+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1rn52cw296jemvujuv6h9824aezv3w2p4fkldf0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "140"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "140+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1f3jtdegkvq8m8avdfqs478hg94xu097hmknwyy",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "141"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "141+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1yyrg823l0pjxvtle9d4hjqgegttharh4kzh79k",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "142"
-          },
-          {
-            "amount": 2500000000000,
-            "timestampOffset": 5270400,
-            "memo": "142+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1txd4zzds5w07vw7hk9cwmuq3fv0e42uerghsar",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "143"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "143+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1zqt6l7yyks097mf4errxd2wjcz6mxd96gjtaxm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "144"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 5270400,
-            "memo": "144+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino19jfth3scmug3640fq5zhpye5cw88yqryzz2s32",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "145"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "145+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1kpd227tfx0x9mfcg4m62tl2mm9d7eag0mwp4kw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "146"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "146+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ga0ut4yez75rp8077g77uycgchnxyg28gu4w3r",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "147"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "147+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1sjxkh9rcjjt4n3nj907rhh5ejey4wa022hl26f",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "148"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "148+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1j2kypzc2t4l9qd57qh8ql3ujng65cr33mhzv8s",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "149"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "149+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1u5s70nmxd7pydjtt70kp842h9pjn3sfu6ky6s4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "150"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 5270400,
-            "memo": "150+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qcjys29pzv8m75fdt9nszl0llkhjv4n9q5ldwc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "151"
-          },
-          {
-            "amount": 250000000000,
-            "timestampOffset": 5270400,
-            "memo": "151+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1gxw932wm6g0up8pt76af60y4racuuged6j7kgx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "152"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "152+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1k0lnzgar08aa95daf5k066kvuvj0fscxgemrmj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "153"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "153+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1yfq50nt44nvf8nt03cqdtwazpw6lthnk4sjur6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "154"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "154+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1scyvhvrepne0fekev9kw6w0u4caq5dyst3upk0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "155"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "155+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1jjrm4p75euylsy70jxr9p6dsjnnec3qm4gvq3d",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "156"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "156+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1f2cy4rqyg76q8l8e7xpagj4qgx7nzjdcpx98m0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "157"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "157+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15nanl7nh4p8f0w7d35xy9z0zg2e6cagqwjssly",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "158"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "158+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1la56pfek0mpc0x476k40h97kwkh0g73jram8he",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "159"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "159+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1aytql7x689t96yvf5ctdr23d2gx646lv2jfd4l",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "160"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "160+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1y30tmzcz0na4nu0uqdh4460dute9nwhvymyuxr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "161"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "161+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1vpqxc97jyqecl0arr7t0je08z06nljv0ytqq9y",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "162"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "162+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1whe7zklwmyxw4ct0x2wsex0ztcfd0dyyhx365g",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "163"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "163+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1k8ahvt0k5uyycvtzs94cavjk26ratnhuw3c07f",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "164"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "164+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvng9gkd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "165"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "165+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino19ayweyate24cq9enm97mys6yvpj4hg0tp8kx5j",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "166"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "166+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1wtjqyemv7ud2t8mzr9m5p25sruukkvq59qqhv0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 400000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "167"
-          },
-          {
-            "amount": 4000000000000,
-            "timestampOffset": 5270400,
-            "memo": "167+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1dzkq4k65usyu6ehqp28wemdjyj84jjzn0haq7l",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "168"
-          },
-          {
-            "amount": 2500000000000,
-            "timestampOffset": 5270400,
-            "memo": "168+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1hu4fnqlfze3kedxy8dgg9d2g9uhr9zwgp9lew0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "169"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "169+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16mam24ag695vh9tdfwsxeejg3wtg0ms3264kfz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "170"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "170+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1sgctncsl8zaryp5w62xp25qqjhskzqr7w6qfg9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "171"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "171+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino19gk9fzxx52u2lshxvpsp76vamj4q265cvta7j4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "172"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "172+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1shlcs8lgwxcnsc66gs2yn0k0qqft77hpzd9ak4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 2000000000000000,
-            "nodeID": "NodeID-2me9yUEwfwQCC53Zod1d52M2LKmJPJHVd",
-            "validatorDuration": 30672000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "173"
-          },
-          {
-            "amount": 20000000000000,
-            "timestampOffset": 5270400,
-            "memo": "173+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16273wcdf2jvytsauu7jd78sjp4fh2j8qkv9j2y",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "174"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "174+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15esv7xd09h2y0fltt83zxgqtzw9xxprkfu0u3m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "175"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "175+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino18har8esnq6gww24qhgsq39g390mn8p7kmphn7e",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "176"
-          },
-          {
-            "amount": 5000000000000,
-            "timestampOffset": 5270400,
-            "memo": "176+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ty8y07xy43el4w8awz7srwqc8had8ndyukfl9f",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "nodeID": "NodeID-8UfSECBBuFwPAupRQHYFZLUZaQvbpmAoB",
-            "validatorDuration": 30758400,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "177"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "177+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1c3kd4e02r5mzg83ezs7yxhwrvyfstqnj6jj879",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "178"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "178+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1m56g7kzpyvwlcc3mzz9rs5x4u3xuqasqu4y73k",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "179"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "179+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1dxd66ecwj99xyezr4p5fq7cfwcqqhj29hapxad",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "180"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "180+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ejtfvvpd268hg8xdjpxfagcnj7x52cepurftz8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 75000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "181"
-          },
-          {
-            "amount": 750000000000,
-            "timestampOffset": 5270400,
-            "memo": "181+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ml9g8xcuemh3gly6pn90udkadtvqk49uu6x462",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 400000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "182"
-          },
-          {
-            "amount": 4000000000000,
-            "timestampOffset": 5270400,
-            "memo": "182+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino12ymv8mufsrdal5ej3ce9cyjwwmu7kclgag4v7m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "183"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "183+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino13384dvk54kl83cdcapcl6nzxq35nxlweawk38q",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "184"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "184+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1d4326e6qataqhz5zpfjtsvg0325pqpd67nhuqg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "185"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "185+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16wusq5lzn8ngtea7ff4e3v9thzxlac70twp4hz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "186"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "186+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1a28tjjxyplz3uq0737tgwv7k29e8dj24azfrlk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "187"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "187+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1d3cul3elpugpu99p62gpu8ml9mx6zhdrqcl4ja",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "188"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "188+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1xwerkdrpkuhq0u9uprvp0dms6tc7y5angf654p",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "189"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "189+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1muy0sy676mc383d566he9lw5a32dkslfdgxzat",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "190"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "190+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15trkm623zm2r23j2hrqjsry636sckxcz7zzqgl",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "191"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "191+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1yatmadtt3qpn7em0r2vmd6ncavdqjlf7jg5nve",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "192"
-          },
-          {
-            "amount": 250000000000,
-            "timestampOffset": 5270400,
-            "memo": "192+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino10thamqpnlvawz4zqayvj7t9s0x6uzwz6hm5kv6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "193"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "193+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino196lwrtuwr2vf79r5jympkjugtsmxkgtwv5etr6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "194"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "194+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1y7mc7hekqxxhuerst0ukpeq9k63zy3783ga4vr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "195"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "195+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino153ejpsghh0tzamey70clpcd7g0y9r6g699ctgk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "196"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "196+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1lx0paymqrp528j5t9hjks6auapgfq49vzqj8ky",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "197"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "197+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1fxsxvek9w0u6q2dy5zkcqxqqlf0kje67t9afx5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "198"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "198+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1zl5pd3x9h2tj47v7nfwusue3t3lu967znpzfa9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "199"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "199+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qmgvg3qw95ft4sww5lkk0vkypjs737fds808k7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "200"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "200+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1anj83lc0h839vmvltws0a6h7k5znlyq8wvl768",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "201"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "201+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1gaxcm3petj9z6kvp2w5kcr4usvdvq3hvf0xqn9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "202"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "202+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvng9gkd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "203"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "203+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1tskv880tp95hrpqs7wrqxmp7wrmmr3lcwvjaj6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "204"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "204+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qwu3jm84hr3sh9kpst3gxlakd22r5vjad4v5x9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "205"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "205+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ysa48z2anf29ckcmg8rak384s0k8uwd2ra5wsa",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "206"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "206+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1zddlpr6hjzjrunts8qdzkwfpx02nu274jv9dct",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "207"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 5270400,
-            "memo": "207+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino18q6scezgt2646rzpc8fmw4jce5zmcvgvhzq7vy",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "208"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "208+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1yws8zcjfsnfgq39c6chsgtm94mt9596m5pul58",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "209"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "209+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino18eqxyetaqt8kym2nqhat532gxtewfsvk2zpq4m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "210"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "210+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1kklwkxzvuefl4kvg4dkzw8hp5dq2marxdkfwz7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "211"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "211+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1gyk9tf69huuc7lrrt6myuzufg4zv4tewyw9s72",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "212"
-          },
-          {
-            "amount": 500000000000,
-            "timestampOffset": 5270400,
-            "memo": "212+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtakqwzx3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "213"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "213+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino160l526l8mkfjeacnhyv5ucvp6uekv9cchhzqdx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "214"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "214+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino13hvsse9lhszwcktwyy74tgzzzmrqvjxk4nr00u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "215"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "215+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1gxvvskyrpk7cjrd934rgmmxysqrvgqy76dcd28",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "216"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "216+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1wgepplh320jtxdfwpnlr3pqpt4sj3xctemynt4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "nodeID": "NodeID-4EQFrUN4H512882gcc4UPkwDueQwM49bx",
-            "validatorDuration": 31795200,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "217"
-          },
-          {
-            "amount": 5000000000000,
-            "timestampOffset": 5270400,
-            "memo": "217+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1jl4gs84hu6s2k24kxrj7549seyczw5cr0xwe8q",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "218"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "218+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16g5l0fngqc9dlzvug7k6el6syey8r375ctthl3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "219"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "219+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1c78g2twqemmav8dr0u6cncuvn9nf9zm30r4jeu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "220"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "220+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1td7w8a2ktccxktvh72275txv4dpzcn5y9u2xgp",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "221"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "221+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino14u3mjp2zwrm7l8v5x7yxn4ed5t29gu0y5zhtng",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "222"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "222+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qtnwfkkvwl5haylwl4ppy9tzkffmq560x3eth0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "223"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "223+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1t7hagl6tr9hj7hvt66xv73au3edt8fj0xxk2ha",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "224"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 5270400,
-            "memo": "224+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1p4xp6m8qgt202aqklwcnhfqx5rg9c2hurcv6py",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "225"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "225+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1236v9648strvh8xmvl3g7hcmxmn5q7366dfmxx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "226"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "226+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1cdr7whau0kjreg2u6awc4k04jx2yp2sw06yqmh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "227"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "227+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15xxam9nwdz53wdl9zsewqpnjel0arf0wmhpwku",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "228"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 5270400,
-            "memo": "228+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1smeeegnxaaamfazx98d0qpnrkkx5qrwkhz08r4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "229"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "229+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1537zcugeec0243matenf36nc90qg0rhh2jkvc3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 300000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "230"
-          },
-          {
-            "amount": 3000000000000,
-            "timestampOffset": 5270400,
-            "memo": "230+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1j8ux8qvav9rv36zw6e5lkwcdupazruadewcdv4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 70000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "231"
-          },
-          {
-            "amount": 700000000000,
-            "timestampOffset": 5270400,
-            "memo": "231+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1rdh6676x0fdevchtu2xjxpm0pf9xun4khtwudn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "232"
-          },
-          {
-            "amount": 2500000000000,
-            "timestampOffset": 5270400,
-            "memo": "232+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1cvt8hhmkysu5rdjzvdvvp70tq5u7ae4pmug2yc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "233"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "233+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ml9g8xcuemh3gly6pn90udkadtvqk49uu6x462",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "234"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "234+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15dw76k56hd7x2s7k9rnvkzsv56sam5uj4sh9w8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "235"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "235+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1mq4ruc3zgamspv94ej3ws8c35crqgwyxes6jl5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "236"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "236+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1cvd8ardpsynhgfhdaapf7akhqv6sc7m99098vy",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "237"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "237+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ylvqqfp9fyyr52rnpl4faghh5fmzm5fhwga6fk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "238"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "238+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1upeztlw8cktcf8w78ayt72g65z05egnxnsyxyh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "239"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "239+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino13ugty8yv3xn96kcet56kkvjx26m9e88vujvnln",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "240"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "240+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1vntz0u4d88yjxsfm9rmpczrx7295wu9ga396pc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "241"
-          },
-          {
-            "amount": 150000000000,
-            "timestampOffset": 5270400,
-            "memo": "241+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1xp9tyghuh7j7a8exqk9uqpmyath7pklefm93zv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "242"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "242+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1uaasrym74ld4esmdz6wjxse69zpjkmml85c36t",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "243"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "243+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qajjjmwlnytjfe6l8jtqhev4helx9x47vgy8vh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1500000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "244"
-          },
-          {
-            "amount": 15000000000000,
-            "timestampOffset": 5270400,
-            "memo": "244+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1hv5tlf84nxcqkvsdtnetfdyw3wfnvhl9zqjlpc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 30000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "245"
-          },
-          {
-            "amount": 300000000000,
-            "timestampOffset": 5270400,
-            "memo": "245+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino12l7dlgqkq3ue89vsckgw35vv5wpp7605s3kmh0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "246"
-          },
-          {
-            "amount": 2500000000000,
-            "timestampOffset": 5270400,
-            "memo": "246+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1enn02mahvwyrjdca5htg9rydqrnksscmtffz5m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "247"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "247+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1j9nsdtrff2m9w97m7wsnxwyx7dvax2v2rhmlgw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "248"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "248+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino13m4yh7ztmps4hjsnyhwy0rxyh6w7ufj6dn7jc5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "249"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "249+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino12n9pnwrh2rqqp8a9kad6wadc2hc62ts7zpymmr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "250"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "250+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1d68vs6523kp60s8ls67pexr5wmx539naur9pxw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "251"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "251+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1z0hl0jpetf53mxj8d7n9mt70l0l99ng95vc533",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "252"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "252+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1zpkv5m338vccu9d5fln6wysjdhl05wp2m96tk3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "253"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "253+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino18n7y8k9yfv9ah4knxhll9hhuaf0r0hgr2ma40g",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "254"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "254+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ypmdpy7tlep95za2nt9tx5a8tvjykxxstx2jf4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "255"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "255+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1wgthf6t2m26sgfenejht7agnzm4wqa20ws3zwc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "256"
-          },
-          {
-            "amount": 200000000000,
-            "timestampOffset": 5270400,
-            "memo": "256+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1rpp52fc6d9gwr2pcshlk3565nqazqym4kyhev2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 2500000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "257"
-          },
-          {
-            "amount": 25000000000000,
-            "timestampOffset": 5270400,
-            "memo": "257+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino14f5k9f27nwagph2f46xlcszqa8zq9zz76jdhvf",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "258"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 5270400,
-            "memo": "258+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1h7u9p4pa9faxj3zezs9udxvj8quuqymraqddam",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "259"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "259+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1kfnsy5p7pfsqh76k5zzmj2kd5svaf0qwcfpt20",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "nodeID": "NodeID-Ka4EiYpFwSdUXVji39DqNjtjJ2n3jiBki",
-            "validatorDuration": 32400000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "260"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "260+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1hc9ffgdtgeznl4h08gckxncv8at744t9l20uyn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "261"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 5270400,
-            "memo": "261+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1qql75cyftxtf923vny3qr9hkmdayyny6ltw4v3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "262"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "262+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1pvmnzwj7pdd4nec3kp0fgdf9w0hp9h6nfeaqek",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 115000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "263"
-          },
-          {
-            "amount": 1150000000000,
-            "timestampOffset": 5270400,
-            "memo": "263+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino133alnuggsul62aajwhynp7uhsvc8val6j7rd3j",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "264"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "264+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1swq7jndpq8seupaehfhpwc8tjy8z6j7zpn666f",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "nodeID": "NodeID-4NTFqo7zYHmupX3j8em6qnw3cKrXEYu8v",
-            "validatorDuration": 32659200,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "265"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 5270400,
-            "memo": "265+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1lsgwstc8edestl9v9t65kcfwjcy4gh8qhpvdej",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "266"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "266+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1jgvgunr3jck6tn7xkzdrrj7khlge7rkvlzd9c6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "267"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "267+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ztkd0srlqersv4c53kfg3cc5kg03ww7946a2e6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "nodeID": "NodeID-9pygZskxbgi5ZKicwu5ES2ZwteTK6MnMH",
-            "validatorDuration": 31104000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "268"
-          },
-          {
-            "amount": 2000000000000,
-            "timestampOffset": 5270400,
-            "memo": "268+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15r9s9pctuhf4as2h67naa7ct58fnpn4sapnzl5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "269"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "269+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino104gqfegwvksn3kfu95dn6upy48vtpuxcg6l8lz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "270"
-          },
-          {
-            "amount": 5000000000000,
-            "timestampOffset": 5270400,
-            "memo": "270+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1teh54u7kjz4p36l63utcu3jcfkygxjp4sl4j9a",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "271"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "271+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1czgaf8lqfu8cfa74gyuh8ngtfysqlm0xxn593l",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "272"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "272+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino12neqhcynnfy82lxcdcgj0lmqazr4yn77yq68vt",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "273"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "273+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1cq4ge3ww6etrsa6t9695yyqmvgzus6l2056ufs",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "274"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "274+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino120jls24pylcuf8jpu55a0nle9r776reja8lz06",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "275"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 5270400,
-            "memo": "275+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15mzhyljgn57752z877zwshx2kfm4qp4a3z5x6p",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "276"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "276+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1f9z05t8uweh6e3e7q75xf7p4745hm5c8059ga8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "277"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino17ds4n2ukuj2nt46jtuep8z2gcv722ryajftwwk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "nodeID": "NodeID-4hcbnsrf4wDYBpNHE74qd7JURAoty4Hsz",
-            "validatorDuration": 32745600,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "278"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "278+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1253vr70qkvynz4nyj6retgftjw8zu7zts4f49n",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "279"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 5270400,
-            "memo": "279+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino14jw3xrysalfq33n22e4wgmfwnumjkt4ukn4wd0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15200000000000000,
-            "memo": "280+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino14jw3xrysalfq33n22e4wgmfwnumjkt4ukn4wd0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 40000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Undeposit 5 Years 0%",
-            "memo": "281"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino123q64vzr4kdsgxfntwujjhxapdakz4xs2cwec2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1500000000000000,
-            "memo": "282+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino123q64vzr4kdsgxfntwujjhxapdakz4xs2cwec2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 18600000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Undeposit 5 Years 0%",
-            "memo": "283"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1u3fe3uet9s08d0aja5zme7dy9yx23n8d7tweuz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 30000000000000000,
-            "memo": "284+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1u3fe3uet9s08d0aja5zme7dy9yx23n8d7tweuz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 45000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Undeposit 5 Years 0%",
-            "memo": "285"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 75000000000000000,
-            "memo": "286+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 75000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Undeposit 5 Years 0%",
-            "memo": "287"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "288"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1xsww8kttcufckh84x49287u8wprz89rfhextn6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000000,
-            "memo": "289+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1xsww8kttcufckh84x49287u8wprz89rfhextn6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Undeposit 5 Years 0%",
-            "memo": "290"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1s43aum9ctvdyxgdfnyapqdfvy7ddjmc58ptrqm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 75000000000000000,
-            "memo": "291+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1ext8a4n2ufqvgfhunzq8cvlexz9w8xhxrqz0hq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 240567110000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "292"
+            "memo": "ID:'16', Bucket:'03 Seed'"
           }
         ]
       },
@@ -6547,7 +371,511 @@
             "depositDuration": 110376000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "293"
+            "memo": "ID:'17', Bucket:'03 Seed'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19m2e8p6ce2yx9uf00rw5jm70l4w24x0s8gt55y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1150000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'18', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1udd7y4uv9kfyh2jsckfztz9crgfve3gcxjmtm7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'19', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15gmmr9we6yhgd7z45ryy886cyqgeuuxcsq4um7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'20', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ca5yhrucv5haavjsw4m8nwx28tzva6f8nafte3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 135000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'21', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12rxesrlk8qy6yydz9qegsx9rt9jj32gm8x80kw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'22', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jpsr4vqdek4kt79ccndunxscyq2n09ljpz5aen",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1207000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'23', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino146qrj047eaapww0mrv52zcg30ycljhhyel9x2x",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'24', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13tfvfqqacg79akws0l42lktgc00q6e7wckduh3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'25', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18q6scezgt2646rzpc8fmw4jce5zmcvgvhzq7vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'26', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vctr8ha7zna8fxdkazt5k6cnlj7fmg7eg4htx4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 215000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'27', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1emp8mkj8g24wmln7dskagu5a8r3p7qef4pkqpg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'28', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino10jsl9f669s9dn6zpxjgerv57pmhnaup5s88dax",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3000000000000000,
+            "nodeID": "NodeID-NyGcFbhSLRy5BHGc29v2h4kwUKMBqNtNq",
+            "validatorDuration": 32832000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'29', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f9z05t8uweh6e3e7q75xf7p4745hm5c8059ga8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'30', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ku4xvfreup02ugju8ls6npyfeu2d0vp2n7c4d9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'31', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16g8j2vrcywjskaygezkm5rl40df6m063df2e8g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'32', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16dkxe6puk3y4qm7hjfvg2lwl8r92e27sj70dxt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'33', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ty3unkry6cqhyyrv4hl6zuhx0k6z59xyezf726",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'34', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1s5nvfwlytnphhzjqm7ep9w7xe25zrep9vm4ua3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'35', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16kqqmrpa92upyxy63z02zjyuvdwjtlhzlsm92c",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'36', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yz03v8cyvgglekensauc8f40vn9mxdnt2xvkef",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'37', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino123q64vzr4kdsgxfntwujjhxapdakz4xs2cwec2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 18600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'38', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino123q64vzr4kdsgxfntwujjhxapdakz4xs2cwec2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1500000000000000,
+            "memo": "ID:'39', Bucket:'05 Advisor', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'40', Bucket:'06 dApp Incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'41', Bucket:'06 dApp Incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000000,
+            "memo": "ID:'42', Bucket:'06 dApp Incentive', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u3fe3uet9s08d0aja5zme7dy9yx23n8d7tweuz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 45000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'43', Bucket:'07 Listing'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u3fe3uet9s08d0aja5zme7dy9yx23n8d7tweuz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000000,
+            "memo": "ID:'44', Bucket:'07 Listing', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xsww8kttcufckh84x49287u8wprz89rfhextn6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'45', Bucket:'08 Marketing'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xsww8kttcufckh84x49287u8wprz89rfhextn6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000000,
+            "memo": "ID:'46', Bucket:'08 Marketing', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ext8a4n2ufqvgfhunzq8cvlexz9w8xhxrqz0hq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 241067110000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'47', Bucket:'09 Reserve'"
           }
         ]
       },
@@ -6562,7 +890,7 @@
         "platformAllocations": [
           {
             "amount": 20000000000,
-            "memo": "294+"
+            "memo": "ID:'48', Bucket:'09 Reserve', Type: 'unlocked'"
           }
         ]
       },
@@ -6577,13 +905,51 @@
         "platformAllocations": [
           {
             "amount": 20000000000,
-            "memo": "295+"
+            "memo": "ID:'49', Bucket:'09 Reserve', Type: 'unlocked'"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1crv6z0h3zdzj2mwjacelywa9twyg7wj9ud4jah",
+        "avaxAddr": "X-camino13r5xljkdl7w4g9tcqynfafm4g89mx52ektkrju",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-KumZcRwRSAE7CUkFE18ZLMnPsCVDpQXz8",
+            "validatorDuration": 63072000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'50', Bucket:'10 Chain4Travel AG Initial Validator'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lj38gmfuwhd9l3gcn0vavms64xe76ljpx5wu5f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-MUTNPmSqwWtchZhVvkWRfF8SUK8FtfnwP",
+            "validatorDuration": 63936000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'51', Bucket:'11 Camino Network Foundation Initial Validator'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1s43aum9ctvdyxgdfnyapqdfvy7ddjmc58ptrqm",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -6591,16 +957,14 @@
         },
         "platformAllocations": [
           {
-            "amount": 3000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "296"
+            "amount": 75000000000000000,
+            "memo": "ID:'52', Bucket:'12 SecondSale', Type: 'unlocked'"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1yqn8cjps7szj8pl2sj425fg2v7tjyz4rsdh0wx",
+        "avaxAddr": "X-camino14jw3xrysalfq33n22e4wgmfwnumjkt4ukn4wd0",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -6608,16 +972,16 @@
         },
         "platformAllocations": [
           {
-            "amount": 1000000000000000,
+            "amount": 40000000000000000,
             "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "297"
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'53', Bucket:'13 Team '"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino153uxhwgdunhyzmaq6t2azlp77aqpnlkpqk8ms6",
+        "avaxAddr": "X-camino14jw3xrysalfq33n22e4wgmfwnumjkt4ukn4wd0",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -6625,16 +989,37 @@
         },
         "platformAllocations": [
           {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "298"
+            "amount": 15200000000000000,
+            "memo": "ID:'54', Bucket:'13 Team ', Type: 'unlocked'"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino15cxxvhc3v23z86duy7ryuaraqjgnzjfcq0es6k",
+        "avaxAddr": "X-camino1vedj99e90uppeyza86qmhyyhfcfyhh054y30uh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'55', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'55', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1tmq8ltmqrsud5ehqsd08lmg0vgxn57mkvm26yr",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -6642,16 +1027,91 @@
         },
         "platformAllocations": [
           {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "299"
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'56', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'56', Bucket:'14 Presale', Type: 'unlocked incentive'"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1jvtwr8mx0c6d6dx5x35s2rxlh8scpwnsg8mmz8",
+        "avaxAddr": "X-camino1k05g5q6alpm03ektp6w4y25uqz9nph7dzmnsqh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'57', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'57', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1039z9rhr70sg02s2qysd0ydkxm4p5ljvj39sg5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 40000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'58', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 400000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'58', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1r7mmvmcszwtzxjhpeu4zgj6arfztch6t80jay0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'59', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'59', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f4c73ufv6d9z93580jau6ugky9px22y0l6uxar",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -6660,21 +1120,21 @@
         "platformAllocations": [
           {
             "amount": 10000000000000,
-            "depositDuration": 173448000,
+            "depositDuration": 110376000,
             "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "300"
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'60', Bucket:'14 Presale'"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 5270400,
-            "memo": "300+"
+            "memo": "ID:'60', Bucket:'14 Presale', Type: 'unlocked incentive'"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino16ukqv0wqy0hwkhe29zr5wfcapqfyf022ykzlx7",
+        "avaxAddr": "X-camino12kjwnczd3vcjctjjjwu58qs2c76ak4c36w7f40",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -6682,9 +1142,2834 @@
         },
         "platformAllocations": [
           {
-            "amount": 500000000000000,
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
             "timestampOffset": 5270400,
-            "memo": "301+"
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'61', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'61', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jxlplag5299kcns2q86kzpp9jffvww3gfp2jx5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'62', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'62', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1uv72wn6ynluam4mmhf74vtfn7sq5xl9le4qvhr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'63', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'63', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1eyunyvyxfq8c9le0pc24xkdum2xehaums2ldxq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'64', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'64', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrdn5j3s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'65', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'65', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17qgahrsfwkkvqhpacf330w37edwt2fdy0pp7ze",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "nodeID": "NodeID-ADyRxZndN569FitkbBzpr8oSe6FnYCMUr",
+            "validatorDuration": 29980800,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'66', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'66', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12e08wmmlauses9u4z7sj306mlpycq0gz0egjz6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'67', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'67', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gqe0v4mamv5gxj9qh4hanftkhqvpnzecw2exme",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'68', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'68', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hmrn6czfq65kqwfeq537ktp8ygzxdx4qr5m554",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'69', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'69', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1su5tl8scmw4zwjnacaw48wkl8vlz0vkd72rdyt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'70', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'70', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19fnu72sdpd0550h59g7gznlgrayzwulpc53chh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 60000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'71', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 600000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'71', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rklz6e8h8h4875pt55kgpwutd7gy3rps3q4hzt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'72', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'72', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1277jph854ltpp9zxavp4fk2jjurprsd9jlusy0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'73', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'73', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1scefvccult0p9g9vvk2zp6qq7n44cmumnhm65q",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'74', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'74', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lgjzmekp359u28dkngdf98spe88050swhe9l5h",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'75', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'75', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1p6wvd9jd0dxueuseghgpnvgl979elus4xrl5vd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'76', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'76', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino156x6huxhlqw28awt2cqd0q02qrfxne6hpsegmg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'77', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'77', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qtdntjtqcqqnvfsx4c5gc2phtktmjca8q57tvt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'78', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'78', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f2ur6q69hstytk7002mgqsuvhr9psmewvf45x2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'79', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'79', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cvd8ardpsynhgfhdaapf7akhqv6sc7m99098vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'80', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'80', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15nnu9w2g3zj5sku9gl62gl5sdj6m5fdd2t8me7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'81', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'81', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19vvz56u2c7mstv88fmnmlm2kfa8vyp2ahl06e0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'82', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'82', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zkny353z0srmc3yuajv2x2hjstkcun3aq3ww3u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-EPnVak5NCap1wdxJRWxKRQNaBfHi9MoVd",
+            "validatorDuration": 30412800,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'83', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'83', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19hw2tjza5vuyjrgv0nlcle4mw573wxp507udyx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'84', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'84', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino124aw7ncdfefyqm4srujj9h3yxt9qzpsacsdk26",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'85', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'85', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ydmngswj235mczwktxz6d2zj64nh5cp8h5ht2r",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'86', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'86', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gyk9tf69huuc7lrrt6myuzufg4zv4tewyw9s72",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'87', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'87', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lf62vgkt80dcgq0ljmjedvptrj8h93vnmej4xv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'88', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'88', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zc75guv3vwlhheq76egjesu23eccaa9kz097tn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'89', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'89', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cmtfkrzpeau8jy87cftmr87x5vs8vrg26lere9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'90', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'90', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino154ys5gaceac0m2sj0fskwzptr6tl77lwe3w3v7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'91', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'91', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1tvlzzcgfey8mc7z3mhwepk84kagutdwmw0m2ul",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'92', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'92', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pvpjqg5p8xwqgcjeqv5vzdlmzlmpw06whegrvm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'93', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'93', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ldtg0fl6reuf9w27w6xt9hvqfjal7lggkq3x33",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'94', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'94', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yfpzkqaqgqrs4z4ta9stwht4cgmfqeae7dyjnz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'95', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'95', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xfj26sj8yjtzu632hwryw6k5k8q4t4a8h3jt65",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'96', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'96', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1a3l20l8nwejvkfszggzjeac8lepymh6e3pzm2u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'97', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'97', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino174v5ghmdy20xtmyjnqsmnn6yv99jcxtmcsmhkg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'98', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'98', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13yjkkxgkg0mk7k727f30hwy78zukld6zwfdxy9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'99', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'99', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1edf9wnssqddknydsdym28al5axq7dum75da6fl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'100', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'100', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pfl4x5q63wl6e76m2jrncxchsh4eruw32kqmlu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'101', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'101', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16g8j2vrcywjskaygezkm5rl40df6m063df2e8g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'102', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'102', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1258ga93qdkk7x58rrfp88zt5y9w64sr6p38kc9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'103', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'103', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1k6z0skaz3333445zz6vgl9nsmzkm2a89xskxqs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'104', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'104', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qh9nzgm6q5cfa2mpshwu9guzahf5se7furw6fa",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 600000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'105', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 6000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'105', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jm8694tdqc6q27my8wnwhe7mmpl93scy3rgrvm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'106', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'106', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1nsh2rw3sjvylgd9gk3jpmfx4dlfgm92ylwms58",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'107', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'107', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1uxp2phhpxh7q2zrfmy8pnzt4q9ytg084rpzasv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'108', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'108', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1nkjv6uvpn0u7qg5g24yaey0ch3upjgcycp3rne",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'109', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'109', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pg3wvrpe3efjt8phj5pf5ftmrk66jr5lzm2jge",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'110', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'110', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rn52cw296jemvujuv6h9824aezv3w2p4fkldf0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'111', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'111', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1txd4zzds5w07vw7hk9cwmuq3fv0e42uerghsar",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'112', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'112', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zqt6l7yyks097mf4errxd2wjcz6mxd96gjtaxm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'113', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'113', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ga0ut4yez75rp8077g77uycgchnxyg28gu4w3r",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'114', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'114', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1j2kypzc2t4l9qd57qh8ql3ujng65cr33mhzv8s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'115', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'115', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yfq50nt44nvf8nt03cqdtwazpw6lthnk4sjur6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'116', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'116', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1scyvhvrepne0fekev9kw6w0u4caq5dyst3upk0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'117', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'117', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f2cy4rqyg76q8l8e7xpagj4qgx7nzjdcpx98m0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'118', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'118', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19ayweyate24cq9enm97mys6yvpj4hg0tp8kx5j",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'119', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'119', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hu4fnqlfze3kedxy8dgg9d2g9uhr9zwgp9lew0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'120', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'120', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sgctncsl8zaryp5w62xp25qqjhskzqr7w6qfg9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'121', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'121', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16273wcdf2jvytsauu7jd78sjp4fh2j8qkv9j2y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'122', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'122', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15esv7xd09h2y0fltt83zxgqtzw9xxprkfu0u3m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'123', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'123', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18har8esnq6gww24qhgsq39g390mn8p7kmphn7e",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'124', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'124', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ty8y07xy43el4w8awz7srwqc8had8ndyukfl9f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "nodeID": "NodeID-8UfSECBBuFwPAupRQHYFZLUZaQvbpmAoB",
+            "validatorDuration": 30758400,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'125', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'125', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1c3kd4e02r5mzg83ezs7yxhwrvyfstqnj6jj879",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'126', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'126', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1m56g7kzpyvwlcc3mzz9rs5x4u3xuqasqu4y73k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'127', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'127', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1dxd66ecwj99xyezr4p5fq7cfwcqqhj29hapxad",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'128', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'128', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ml9g8xcuemh3gly6pn90udkadtvqk49uu6x462",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'129', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'129', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13384dvk54kl83cdcapcl6nzxq35nxlweawk38q",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'130', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'130', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1a28tjjxyplz3uq0737tgwv7k29e8dj24azfrlk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'131', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'131', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xwerkdrpkuhq0u9uprvp0dms6tc7y5angf654p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'132', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'132', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1muy0sy676mc383d566he9lw5a32dkslfdgxzat",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'133', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'133', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yatmadtt3qpn7em0r2vmd6ncavdqjlf7jg5nve",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'134', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'134', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino10thamqpnlvawz4zqayvj7t9s0x6uzwz6hm5kv6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'135', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'135', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1y7mc7hekqxxhuerst0ukpeq9k63zy3783ga4vr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'136', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'136', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino153ejpsghh0tzamey70clpcd7g0y9r6g699ctgk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'137', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'137', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lx0paymqrp528j5t9hjks6auapgfq49vzqj8ky",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'138', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'138', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1fxsxvek9w0u6q2dy5zkcqxqqlf0kje67t9afx5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'139', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'139', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zl5pd3x9h2tj47v7nfwusue3t3lu967znpzfa9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'140', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'140', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qmgvg3qw95ft4sww5lkk0vkypjs737fds808k7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'141', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'141', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1anj83lc0h839vmvltws0a6h7k5znlyq8wvl768",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'142', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'142', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvng9gkd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'143', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'143', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qwu3jm84hr3sh9kpst3gxlakd22r5vjad4v5x9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'144', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'144', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ysa48z2anf29ckcmg8rak384s0k8uwd2ra5wsa",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'145', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'145', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18eqxyetaqt8kym2nqhat532gxtewfsvk2zpq4m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'146', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'146', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kklwkxzvuefl4kvg4dkzw8hp5dq2marxdkfwz7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'147', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'147', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtakqwzx3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'148', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'148', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wgepplh320jtxdfwpnlr3pqpt4sj3xctemynt4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "nodeID": "NodeID-4EQFrUN4H512882gcc4UPkwDueQwM49bx",
+            "validatorDuration": 31795200,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'149', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'149', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jl4gs84hu6s2k24kxrj7549seyczw5cr0xwe8q",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'150', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'150', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1c78g2twqemmav8dr0u6cncuvn9nf9zm30r4jeu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'151', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'151', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1td7w8a2ktccxktvh72275txv4dpzcn5y9u2xgp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'152', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'152', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino14u3mjp2zwrm7l8v5x7yxn4ed5t29gu0y5zhtng",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'153', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'153', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1t7hagl6tr9hj7hvt66xv73au3edt8fj0xxk2ha",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'154', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'154', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1p4xp6m8qgt202aqklwcnhfqx5rg9c2hurcv6py",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'155', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'155', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cdr7whau0kjreg2u6awc4k04jx2yp2sw06yqmh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'156', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'156', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15xxam9nwdz53wdl9zsewqpnjel0arf0wmhpwku",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'157', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'157', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1smeeegnxaaamfazx98d0qpnrkkx5qrwkhz08r4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'158', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'158', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1537zcugeec0243matenf36nc90qg0rhh2jkvc3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'159', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 3000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'159', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cvt8hhmkysu5rdjzvdvvp70tq5u7ae4pmug2yc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'160', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'160', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15dw76k56hd7x2s7k9rnvkzsv56sam5uj4sh9w8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'161', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'161', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cvd8ardpsynhgfhdaapf7akhqv6sc7m99098vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'162', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'162', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ylvqqfp9fyyr52rnpl4faghh5fmzm5fhwga6fk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'163', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'163', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1upeztlw8cktcf8w78ayt72g65z05egnxnsyxyh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'164', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'164', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xp9tyghuh7j7a8exqk9uqpmyath7pklefm93zv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'165', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'165', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1uaasrym74ld4esmdz6wjxse69zpjkmml85c36t",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'166', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'166', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1enn02mahvwyrjdca5htg9rydqrnksscmtffz5m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'167', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'167', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13m4yh7ztmps4hjsnyhwy0rxyh6w7ufj6dn7jc5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'168', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'168', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1d68vs6523kp60s8ls67pexr5wmx539naur9pxw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'169', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'169', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1z0hl0jpetf53mxj8d7n9mt70l0l99ng95vc533",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'170', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'170', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zpkv5m338vccu9d5fln6wysjdhl05wp2m96tk3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'171', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'171', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18n7y8k9yfv9ah4knxhll9hhuaf0r0hgr2ma40g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'172', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'172', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rpp52fc6d9gwr2pcshlk3565nqazqym4kyhev2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'173', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 25000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'173', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1h7u9p4pa9faxj3zezs9udxvj8quuqymraqddam",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'174', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'174', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kfnsy5p7pfsqh76k5zzmj2kd5svaf0qwcfpt20",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-Ka4EiYpFwSdUXVji39DqNjtjJ2n3jiBki",
+            "validatorDuration": 32400000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'175', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'175', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lsgwstc8edestl9v9t65kcfwjcy4gh8qhpvdej",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'176', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'176', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ztkd0srlqersv4c53kfg3cc5kg03ww7946a2e6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "nodeID": "NodeID-9pygZskxbgi5ZKicwu5ES2ZwteTK6MnMH",
+            "validatorDuration": 31104000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'177', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'177', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15r9s9pctuhf4as2h67naa7ct58fnpn4sapnzl5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'178', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'178', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino104gqfegwvksn3kfu95dn6upy48vtpuxcg6l8lz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'179', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'179', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12neqhcynnfy82lxcdcgj0lmqazr4yn77yq68vt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'180', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'180', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino120jls24pylcuf8jpu55a0nle9r776reja8lz06",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'181', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'181', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15mzhyljgn57752z877zwshx2kfm4qp4a3z5x6p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'182', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'182', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1253vr70qkvynz4nyj6retgftjw8zu7zts4f49n",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'183', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'183', Bucket:'14 Presale', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -6702,35 +3987,12 @@
             "depositDuration": 110376000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "302"
+            "memo": "ID:'184', Bucket:'14 Presale'"
           },
           {
             "amount": 5000000000000,
             "timestampOffset": 5270400,
-            "memo": "302+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino165zf3m4ct6rsdkn49mpk5tlwla7hc9u86f6r96",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 5270400,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "303"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 5270400,
-            "memo": "303+"
+            "memo": "ID:'184', Bucket:'14 Presale', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -6748,12 +4010,2734 @@
             "depositDuration": 110376000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "304"
+            "memo": "ID:'185', Bucket:'14 Presale'"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 5270400,
-            "memo": "304+"
+            "memo": "ID:'185', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1396cw839aatmnf2f3nmuuh6p6zn2vesyquzuzm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'186', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'186', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1nqsk0mwued2l8zy7calqhnemxuzct89x4nlv0n",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'187', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'187', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16ryrmg6csk09mmnswmnkdvtv2a7ug0777348qe",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'188', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'188', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u3p0peu345nvsnh27jcqun2yq89le838ylxzq0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'189', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'189', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kje90w7g29xjwps75qwqyca84yvetp342xzt7c",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'190', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'190', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1t5ayje5edr2msh2dqtg4m6xp0fuv4k3qt4tdj9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 600000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'191', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 6000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'191', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ldpfsrvxh674jze42wxr7nwsrwatqpjnylu7vu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'192', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'192', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1slw8htng4clqqwyk0nfvrydte2prmt2fdaf5ev",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'193', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'193', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1t907jgamny9vqkl3ec7sfpdvskqf6wspezcy0m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'194', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'194', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xpj2lh6dzlx22pjuyaelf75g0vug44qghehc45",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'195', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'195', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yqgm4zkumgv5hf2afp798arjm59tat3ve9l4d8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'196', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'196', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15tt8kvkah5qcs8r24d9v7w2eymg4hq2nk77gfu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2000000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'197', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 20000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'197', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vwlkq9xandunkreu49gwkql8vtnxa0ltslq8k5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'198', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'198', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vw4u7j0dwzampvvmyt65rckvfjyykkkgcrf04h",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'199', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'199', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1els93ysuw4ansfqxe55wlf7ca2rzl0xhhe97pc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'200', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'200', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gxw932wm6g0up8pt76af60y4racuuged6j7kgx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'201', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'201', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15nanl7nh4p8f0w7d35xy9z0zg2e6cagqwjssly",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'202', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'202', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19gk9fzxx52u2lshxvpsp76vamj4q265cvta7j4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'203', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'203', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1shlcs8lgwxcnsc66gs2yn0k0qqft77hpzd9ak4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2000000000000000,
+            "nodeID": "NodeID-2me9yUEwfwQCC53Zod1d52M2LKmJPJHVd",
+            "validatorDuration": 30672000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'204', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 20000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'204', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12ymv8mufsrdal5ej3ce9cyjwwmu7kclgag4v7m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'205', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'205', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1d4326e6qataqhz5zpfjtsvg0325pqpd67nhuqg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'206', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'206', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16wusq5lzn8ngtea7ff4e3v9thzxlac70twp4hz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'207', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'207', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1236v9648strvh8xmvl3g7hcmxmn5q7366dfmxx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'208', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'208', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rdh6676x0fdevchtu2xjxpm0pf9xun4khtwudn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'209', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'209', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vntz0u4d88yjxsfm9rmpczrx7295wu9ga396pc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'210', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'210', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qql75cyftxtf923vny3qr9hkmdayyny6ltw4v3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'211', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'211', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino133alnuggsul62aajwhynp7uhsvc8val6j7rd3j",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'212', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'212', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1swq7jndpq8seupaehfhpwc8tjy8z6j7zpn666f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "nodeID": "NodeID-4NTFqo7zYHmupX3j8em6qnw3cKrXEYu8v",
+            "validatorDuration": 32659200,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'213', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'213', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jgvgunr3jck6tn7xkzdrrj7khlge7rkvlzd9c6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'214', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'214', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1czgaf8lqfu8cfa74gyuh8ngtfysqlm0xxn593l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'215', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'215', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ak489h9rs6e728wvrgpkx7rzuu9hf4kutfspm0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'216', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'216', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ry0f50cfu670mxgj0nz6rz0d9jwqyg2kalk5vr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'217', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'217', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mcs8pk0f67p9s0mmtz9eyph26kp848rdsnpmh0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'218', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'218', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino14kmjrlcreau6duuh3a4r78p30rt9cauglprnzq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'219', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'219', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mp7f8rt2jd604ywnhetk2xq4mmj9qluvxf2d8w",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'220', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'220', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18fwezlvf9knlalnevyj20lrk6459ypyyhggx2j",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'221', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'221', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1dukvf6l4k928t4ngpcd2w3h3zyvnd278rzcyc7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'222', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'222', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12eah23v9dcwcsjps267777klj8kkvwdyysdzzx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'223', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'223', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1heerqcl59yn3jtw99szd8l7q7a6jq24hpu380m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'224', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'224', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qy5zgzyxn7j22gtj5pd0r8gdgfrsduwrm8n7um",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'225', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'225', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1udazut0vnsnsj674sl7zngtguxh9ze4mpz0ae5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'226', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'226', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hs88mzs5s37t8nueennxy7gxz2stdpjel09zeq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'227', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'227', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kklwkxzvuefl4kvg4dkzw8hp5dq2marxdkfwz7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'228', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'228', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1auylykzk6zqxsvrrx6gy2dc4v4l9fp3tsal6k8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'229', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'229', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mxzvy5vpt7danrzvgkvvlw3x7wypea3lzdvd3s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'230', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'230', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1q50k78pse6vky5gwdsmuf7njcp8ahdlugw2ceu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'231', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'231', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1avxc8uyqzf9hzwa9eacgg2x8y473j85sd2jwdt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'232', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'232', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ne69lm0mplfxcxmqlv3ls6wk5z8m3tc3dr3rpj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'233', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'233', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sey28879jhn9uy822u38vxw3uke8pazwsxlgr4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'234', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'234', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lc4qzvsqfzt2yy9k4596v394se6pg97lmjvgel",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'235', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'235', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17v6mxjg8t0w5lq9w6qx76k3p7ar7z8q2k532rl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'236', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'236', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sd7q4a5v0t3g3r86uzwzkmxdf5mqs6unerwxa4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'237', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'237', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jp56myed7nwy3sre4u445mepkpe79ymmzfr905",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'238', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'238', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17z889qchneqk94x9mjxw0m0xgcgls9d53s7dvg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'239', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'239', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kfapm9d2r8n5rmjvvv5284qp2rdr7t69nul5j8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'240', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'240', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16l5nmctdj4qqk4zqmy8zlkmsaypjzkw4ehfpkp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'241', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'241', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sjsdrw4avghcnvm4rkvsd5clhcujgm8dp292ke",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'242', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'242', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1am4366ap64h8gftnfd5xcx6gspk237y8vrnd97",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'243', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'243', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u8cuvpxmq807q95newex63za3kpw3nqwyj4g7e",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'244', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'244', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ezjkht68k5rz69c5xeetn59vs3wmw6ffa4x5ze",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'245', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'245', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13kzrxg5y4qs97qzf4zdqw9m4z9ydkku6xudkk9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'246', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'246', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gqj0qsm8dhyer2alw57rwvt0wqp8hhvk83lk9p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'247', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'247', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1e9kkysfkfq5xr93qyyxsfz0mg43x2fgdl49e5v",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'248', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'248', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino124qh486fhjst6c2zysxgvusz0vlu867qn3lxxy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'249', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'249', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1whhfteexl2x4sdl0jfs4nqvdvyh0qx7hvgvvcs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-nj5YW9BXAYQSWunEV5sUqS68vHdnU2Aw",
+            "validatorDuration": 34128000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'250', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'250', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f3jtdegkvq8m8avdfqs478hg94xu097hmknwyy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'251', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'251', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yyrg823l0pjxvtle9d4hjqgegttharh4kzh79k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'252', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'252', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19jfth3scmug3640fq5zhpye5cw88yqryzz2s32",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'253', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'253', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kpd227tfx0x9mfcg4m62tl2mm9d7eag0mwp4kw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'254', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'254', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sjxkh9rcjjt4n3nj907rhh5ejey4wa022hl26f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'255', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'255', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u5s70nmxd7pydjtt70kp842h9pjn3sfu6ky6s4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'256', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'256', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qcjys29pzv8m75fdt9nszl0llkhjv4n9q5ldwc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'257', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'257', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1k0lnzgar08aa95daf5k066kvuvj0fscxgemrmj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'258', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'258', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jjrm4p75euylsy70jxr9p6dsjnnec3qm4gvq3d",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'259', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'259', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1la56pfek0mpc0x476k40h97kwkh0g73jram8he",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'260', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'260', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1aytql7x689t96yvf5ctdr23d2gx646lv2jfd4l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'261', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'261', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1y30tmzcz0na4nu0uqdh4460dute9nwhvymyuxr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'262', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'262', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vpqxc97jyqecl0arr7t0je08z06nljv0ytqq9y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'263', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'263', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1whe7zklwmyxw4ct0x2wsex0ztcfd0dyyhx365g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'264', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'264', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1k8ahvt0k5uyycvtzs94cavjk26ratnhuw3c07f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'265', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'265', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvng9gkd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'266', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'266', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wtjqyemv7ud2t8mzr9m5p25sruukkvq59qqhv0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'267', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'267', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1dzkq4k65usyu6ehqp28wemdjyj84jjzn0haq7l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'268', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'268', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16mam24ag695vh9tdfwsxeejg3wtg0ms3264kfz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'269', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'269', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ejtfvvpd268hg8xdjpxfagcnj7x52cepurftz8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'270', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 750000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'270', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1d3cul3elpugpu99p62gpu8ml9mx6zhdrqcl4ja",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'271', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'271', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15trkm623zm2r23j2hrqjsry636sckxcz7zzqgl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'272', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'272', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino196lwrtuwr2vf79r5jympkjugtsmxkgtwv5etr6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'273', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'273', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gaxcm3petj9z6kvp2w5kcr4usvdvq3hvf0xqn9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'274', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'274', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1tskv880tp95hrpqs7wrqxmp7wrmmr3lcwvjaj6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'275', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'275', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zddlpr6hjzjrunts8qdzkwfpx02nu274jv9dct",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'276', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'276', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18q6scezgt2646rzpc8fmw4jce5zmcvgvhzq7vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'277', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'277', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yws8zcjfsnfgq39c6chsgtm94mt9596m5pul58",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'278', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'278', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gyk9tf69huuc7lrrt6myuzufg4zv4tewyw9s72",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'279', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'279', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino160l526l8mkfjeacnhyv5ucvp6uekv9cchhzqdx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'280', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'280', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13hvsse9lhszwcktwyy74tgzzzmrqvjxk4nr00u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'281', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'281', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gxvvskyrpk7cjrd934rgmmxysqrvgqy76dcd28",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'282', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'282', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16g5l0fngqc9dlzvug7k6el6syey8r375ctthl3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'283', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'283', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qtnwfkkvwl5haylwl4ppy9tzkffmq560x3eth0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'284', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'284', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1j8ux8qvav9rv36zw6e5lkwcdupazruadewcdv4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 70000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'285', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 700000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'285', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ml9g8xcuemh3gly6pn90udkadtvqk49uu6x462",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'286', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'286', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mq4ruc3zgamspv94ej3ws8c35crqgwyxes6jl5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'287', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'287', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13ugty8yv3xn96kcet56kkvjx26m9e88vujvnln",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'288', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'288', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qajjjmwlnytjfe6l8jtqhev4helx9x47vgy8vh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1500000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'289', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 15000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'289', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hv5tlf84nxcqkvsdtnetfdyw3wfnvhl9zqjlpc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'290', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'290', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12l7dlgqkq3ue89vsckgw35vv5wpp7605s3kmh0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'291', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'291', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1j9nsdtrff2m9w97m7wsnxwyx7dvax2v2rhmlgw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'292', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'292', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12n9pnwrh2rqqp8a9kad6wadc2hc62ts7zpymmr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'293', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'293', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ypmdpy7tlep95za2nt9tx5a8tvjykxxstx2jf4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'294', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'294', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wgthf6t2m26sgfenejht7agnzm4wqa20ws3zwc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'295', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'295', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino14f5k9f27nwagph2f46xlcszqa8zq9zz76jdhvf",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'296', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'296', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hc9ffgdtgeznl4h08gckxncv8at744t9l20uyn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'297', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'297', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pvmnzwj7pdd4nec3kp0fgdf9w0hp9h6nfeaqek",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 115000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'298', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'298', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1teh54u7kjz4p36l63utcu3jcfkygxjp4sl4j9a",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'299', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'299', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cq4ge3ww6etrsa6t9695yyqmvgzus6l2056ufs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'300', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'300', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17ds4n2ukuj2nt46jtuep8z2gcv722ryajftwwk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-4hcbnsrf4wDYBpNHE74qd7JURAoty4Hsz",
+            "validatorDuration": 32745600,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'301', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'301', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jvtwr8mx0c6d6dx5x35s2rxlh8scpwnsg8mmz8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'302', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'302', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino165zf3m4ct6rsdkn49mpk5tlwla7hc9u86f6r96",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'303', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'303', Bucket:'14 Presale', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -6771,12 +6755,12 @@
             "depositDuration": 173448000,
             "timestampOffset": 5270400,
             "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "305"
+            "memo": "ID:'304', Bucket:'14 Presale'"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 5270400,
-            "memo": "305+"
+            "memo": "ID:'304', Bucket:'14 Presale', Type: 'unlocked incentive'"
           }
         ]
       }
@@ -6791,14 +6775,6 @@
         ],
         "threshold": 2,
         "memo": "101"
-      },
-      {
-        "alias": "X-camino16ukqv0wqy0hwkhe29zr5wfcapqfyf022ykzlx7",
-        "addresses": [
-          "X-camino1wu6aex7pj9ps0jfyj3jtyyhgjkjsaffpla0u70"
-        ],
-        "threshold": 1,
-        "memo": "107"
       },
       {
         "alias": "X-camino1ml9g8xcuemh3gly6pn90udkadtvqk49uu6x462",

--- a/genesis/genesis_camino.json
+++ b/genesis/genesis_camino.json
@@ -1,62 +1,96 @@
 {
   "networkID": 1000,
+  "allocations": null,
+  "startTime": 1166713120,
+  "initialStakeDuration": 0,
+  "initialStakeDurationOffset": 3600,
+  "initialStakedFunds": null,
+  "initialStakers": null,
   "camino": {
     "verifyNodeSignature": true,
     "lockModeBondDeposit": true,
-    "initialAdmin": "X-camino1m4nr983lhd4p4nfsqk3a6a9mejugnn73f83vuy",
+    "initialAdmin": "X-camino1t284hx6n73r2twagqvu8hmj3n7yh6vkgurea62",
     "depositOffers": [
       {
-        "memo": "presale3y",
         "interestRateNominator": 80000,
         "startOffset": 0,
-        "endOffset": 111585600,
+        "endOffset": 116856000,
         "minAmount": 1,
         "minDuration": 110376000,
         "maxDuration": 110376000,
         "unlockPeriodDuration": 31536000,
         "noRewardsPeriodDuration": 15768000,
+        "memo": "PreSale 3 Years 8%",
         "flags": {
           "locked": true
         }
       },
       {
-        "memo": "team5y",
-        "interestRateNominator": 0,
-        "startOffset": 0,
-        "endOffset": 158889600,
-        "minAmount": 1,
-        "minDuration": 157680000,
-        "maxDuration": 157680000,
-        "unlockPeriodDuration": 63072000,
-        "noRewardsPeriodDuration": 31536000,
-        "flags": {
-          "locked": true
-        }
-      },
-      {
-        "memo": "presale4y",
         "interestRateNominator": 90000,
         "startOffset": 0,
-        "endOffset": 143121600,
+        "endOffset": 148392000,
         "minAmount": 1,
         "minDuration": 141912000,
         "maxDuration": 141912000,
         "unlockPeriodDuration": 31536000,
         "noRewardsPeriodDuration": 15768000,
+        "memo": "PreSale 4 Years 9%",
         "flags": {
           "locked": true
         }
       },
       {
-        "memo": "presale5y",
         "interestRateNominator": 100000,
         "startOffset": 0,
-        "endOffset": 174657600,
+        "endOffset": 179928000,
         "minAmount": 1,
         "minDuration": 173448000,
         "maxDuration": 173448000,
         "unlockPeriodDuration": 31536000,
         "noRewardsPeriodDuration": 15768000,
+        "memo": "PreSale 5 Years 10%",
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "interestRateNominator": 0,
+        "startOffset": 0,
+        "endOffset": 179928000,
+        "minAmount": 1,
+        "minDuration": 157680000,
+        "maxDuration": 157680000,
+        "unlockPeriodDuration": 157680000,
+        "noRewardsPeriodDuration": 0,
+        "memo": "Undeposit 5 Years 0%",
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "interestRateNominator": 0,
+        "startOffset": 0,
+        "endOffset": 116856000,
+        "minAmount": 1,
+        "minDuration": 110376000,
+        "maxDuration": 110376000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 0,
+        "memo": "Seed 3 Years 0%",
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "interestRateNominator": 0,
+        "startOffset": 0,
+        "endOffset": 164160000,
+        "minAmount": 1,
+        "minDuration": 157680000,
+        "maxDuration": 157680000,
+        "unlockPeriodDuration": 63072000,
+        "noRewardsPeriodDuration": 0,
+        "memo": "Team 5 Years 0%",
         "flags": {
           "locked": true
         }
@@ -65,8 +99,23 @@
     "allocations": [
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-camino1m4nr983lhd4p4nfsqk3a6a9mejugnn73f83vuy",
-        "xAmount": 989998000000000000,
+        "avaxAddr": "X-camino1t284hx6n73r2twagqvu8hmj3n7yh6vkgurea62",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000,
+            "memo": "2+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13r5xljkdl7w4g9tcqynfafm4g89mx52ektkrju",
+        "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
           "kycVerified": true
@@ -74,22 +123,7556 @@
         "platformAllocations": [
           {
             "amount": 100000000000000,
-            "nodeID": "NodeID-PGHYeLVkU6ZVQEu8CuRBk6pQ2NJNAuzZ4",
-            "validatorDuration": 100000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "presale3y"
+            "nodeID": "NodeID-KumZcRwRSAE7CUkFE18ZLMnPsCVDpQXz8",
+            "validatorDuration": 63072000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "3"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lj38gmfuwhd9l3gcn0vavms64xe76ljpx5wu5f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-MUTNPmSqwWtchZhVvkWRfF8SUK8FtfnwP",
+            "validatorDuration": 63936000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "4"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19m2e8p6ce2yx9uf00rw5jm70l4w24x0s8gt55y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1150000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "5"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1udd7y4uv9kfyh2jsckfztz9crgfve3gcxjmtm7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "6"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15gmmr9we6yhgd7z45ryy886cyqgeuuxcsq4um7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "7"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ca5yhrucv5haavjsw4m8nwx28tzva6f8nafte3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 135000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "8"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12rxesrlk8qy6yydz9qegsx9rt9jj32gm8x80kw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "9"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jpsr4vqdek4kt79ccndunxscyq2n09ljpz5aen",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1207000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "10"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino146qrj047eaapww0mrv52zcg30ycljhhyel9x2x",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "11"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13tfvfqqacg79akws0l42lktgc00q6e7wckduh3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "12"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18q6scezgt2646rzpc8fmw4jce5zmcvgvhzq7vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "13"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vctr8ha7zna8fxdkazt5k6cnlj7fmg7eg4htx4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 215000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "14"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1emp8mkj8g24wmln7dskagu5a8r3p7qef4pkqpg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "15"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino10jsl9f669s9dn6zpxjgerv57pmhnaup5s88dax",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3000000000000000,
+            "nodeID": "NodeID-NyGcFbhSLRy5BHGc29v2h4kwUKMBqNtNq",
+            "validatorDuration": 32832000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "16"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1nzdp4qpj44dl7frlhfx2efh6mhq5c933644zgg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 36150000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "17"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino146qrj047eaapww0mrv52zcg30ycljhhyel9x2x",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 11550000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "18"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18q6scezgt2646rzpc8fmw4jce5zmcvgvhzq7vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2800000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "19"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rf43hs576l0jj72haq0h4yq06lmv2pk8wwzqfc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 11550000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "20"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jn87l4s3f0r2xa0kk3nw8n939pvkyjyzse22p5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2800000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "21"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ak489h9rs6e728wvrgpkx7rzuu9hf4kutfspm0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "22"
           },
+          {
+            "amount": 100000000000000,
+            "timestampOffset": 5270400,
+            "memo": "22+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1k6y2cfw4tv8n2p6lydj9vnj2kefcs4sfn2msfw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 9800000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "23"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17crk3v8k09p3hav0ekzvwqlc3kfrhreq279lks",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "24"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gcmdk8edz6jfg2lk72229xs5r3nxcwv6s93ldp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 13650000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "25"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1fp0gllrtxljv3gqwc2dq3vuq03vcrkrjdef2q9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
           {
             "amount": 10000000000000000,
             "depositDuration": 110376000,
-            "depositOfferMemo": "presale3y"
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "26"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino124te92fnfl94nqdxknw8w0juld4e8rgm8rsctf",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 6000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "27"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1396cw839aatmnf2f3nmuuh6p6zn2vesyquzuzm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "28"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "28+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1nqsk0mwued2l8zy7calqhnemxuzct89x4nlv0n",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "29"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "29+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vedj99e90uppeyza86qmhyyhfcfyhh054y30uh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "30"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "30+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ry0f50cfu670mxgj0nz6rz0d9jwqyg2kalk5vr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "31"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "31+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1tmq8ltmqrsud5ehqsd08lmg0vgxn57mkvm26yr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "32"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "32+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1k05g5q6alpm03ektp6w4y25uqz9nph7dzmnsqh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "33"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "33+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mcs8pk0f67p9s0mmtz9eyph26kp848rdsnpmh0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "34"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "34+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16ryrmg6csk09mmnswmnkdvtv2a7ug0777348qe",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "35"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "35+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1039z9rhr70sg02s2qysd0ydkxm4p5ljvj39sg5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 40000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "36"
+          },
+          {
+            "amount": 400000000000,
+            "timestampOffset": 5270400,
+            "memo": "36+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino14kmjrlcreau6duuh3a4r78p30rt9cauglprnzq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "37"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "37+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u3p0peu345nvsnh27jcqun2yq89le838ylxzq0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "38"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "38+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1r7mmvmcszwtzxjhpeu4zgj6arfztch6t80jay0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "39"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "39+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kje90w7g29xjwps75qwqyca84yvetp342xzt7c",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "40"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "40+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mp7f8rt2jd604ywnhetk2xq4mmj9qluvxf2d8w",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "41"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "41+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f4c73ufv6d9z93580jau6ugky9px22y0l6uxar",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "42"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "42+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12kjwnczd3vcjctjjjwu58qs2c76ak4c36w7f40",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "43"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "43+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jxlplag5299kcns2q86kzpp9jffvww3gfp2jx5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "44"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "44+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1uv72wn6ynluam4mmhf74vtfn7sq5xl9le4qvhr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "45"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "45+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1eyunyvyxfq8c9le0pc24xkdum2xehaums2ldxq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "46"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "46+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrdn5j3s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "47"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "47+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17qgahrsfwkkvqhpacf330w37edwt2fdy0pp7ze",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "nodeID": "NodeID-ADyRxZndN569FitkbBzpr8oSe6FnYCMUr",
+            "validatorDuration": 29980800,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "48"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "48+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18fwezlvf9knlalnevyj20lrk6459ypyyhggx2j",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "49"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "49+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1dukvf6l4k928t4ngpcd2w3h3zyvnd278rzcyc7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "50"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "50+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12eah23v9dcwcsjps267777klj8kkvwdyysdzzx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "51"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "51+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1t5ayje5edr2msh2dqtg4m6xp0fuv4k3qt4tdj9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 600000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "52"
+          },
+          {
+            "amount": 6000000000000,
+            "timestampOffset": 5270400,
+            "memo": "52+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ldpfsrvxh674jze42wxr7nwsrwatqpjnylu7vu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "53"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "53+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1heerqcl59yn3jtw99szd8l7q7a6jq24hpu380m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "54"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "54+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qy5zgzyxn7j22gtj5pd0r8gdgfrsduwrm8n7um",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "55"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "55+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12e08wmmlauses9u4z7sj306mlpycq0gz0egjz6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "56"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "56+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gqe0v4mamv5gxj9qh4hanftkhqvpnzecw2exme",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "57"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "57+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hmrn6czfq65kqwfeq537ktp8ygzxdx4qr5m554",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "58"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "58+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1su5tl8scmw4zwjnacaw48wkl8vlz0vkd72rdyt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "59"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "59+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1slw8htng4clqqwyk0nfvrydte2prmt2fdaf5ev",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "60"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "60+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1udazut0vnsnsj674sl7zngtguxh9ze4mpz0ae5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "61"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "61+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19fnu72sdpd0550h59g7gznlgrayzwulpc53chh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 60000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "62"
+          },
+          {
+            "amount": 600000000000,
+            "timestampOffset": 5270400,
+            "memo": "62+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hs88mzs5s37t8nueennxy7gxz2stdpjel09zeq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "63"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "63+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rklz6e8h8h4875pt55kgpwutd7gy3rps3q4hzt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "64"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "64+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kklwkxzvuefl4kvg4dkzw8hp5dq2marxdkfwz7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "65"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "65+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1277jph854ltpp9zxavp4fk2jjurprsd9jlusy0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "66"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "66+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1scefvccult0p9g9vvk2zp6qq7n44cmumnhm65q",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "67"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "67+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lgjzmekp359u28dkngdf98spe88050swhe9l5h",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "68"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "68+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1auylykzk6zqxsvrrx6gy2dc4v4l9fp3tsal6k8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "69"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "69+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1p6wvd9jd0dxueuseghgpnvgl979elus4xrl5vd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "70"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "70+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1t907jgamny9vqkl3ec7sfpdvskqf6wspezcy0m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "71"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "71+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino156x6huxhlqw28awt2cqd0q02qrfxne6hpsegmg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "72"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "72+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mxzvy5vpt7danrzvgkvvlw3x7wypea3lzdvd3s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "73"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "73+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qtdntjtqcqqnvfsx4c5gc2phtktmjca8q57tvt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "74"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "74+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f2ur6q69hstytk7002mgqsuvhr9psmewvf45x2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "75"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "75+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cvd8ardpsynhgfhdaapf7akhqv6sc7m99098vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "76"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "76+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xpj2lh6dzlx22pjuyaelf75g0vug44qghehc45",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "77"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "77+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1q50k78pse6vky5gwdsmuf7njcp8ahdlugw2ceu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "78"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "78+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15nnu9w2g3zj5sku9gl62gl5sdj6m5fdd2t8me7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "79"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "79+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19vvz56u2c7mstv88fmnmlm2kfa8vyp2ahl06e0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "80"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "80+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1avxc8uyqzf9hzwa9eacgg2x8y473j85sd2jwdt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "81"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "81+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zkny353z0srmc3yuajv2x2hjstkcun3aq3ww3u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-EPnVak5NCap1wdxJRWxKRQNaBfHi9MoVd",
+            "validatorDuration": 30412800,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "82"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "82+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ne69lm0mplfxcxmqlv3ls6wk5z8m3tc3dr3rpj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "83"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "83+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19hw2tjza5vuyjrgv0nlcle4mw573wxp507udyx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "84"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "84+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sey28879jhn9uy822u38vxw3uke8pazwsxlgr4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "85"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "85+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino124aw7ncdfefyqm4srujj9h3yxt9qzpsacsdk26",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "86"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "86+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ydmngswj235mczwktxz6d2zj64nh5cp8h5ht2r",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "87"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "87+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gyk9tf69huuc7lrrt6myuzufg4zv4tewyw9s72",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "88"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "88+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lc4qzvsqfzt2yy9k4596v394se6pg97lmjvgel",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "89"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "89+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lf62vgkt80dcgq0ljmjedvptrj8h93vnmej4xv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "90"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "90+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zc75guv3vwlhheq76egjesu23eccaa9kz097tn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "91"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "91+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cmtfkrzpeau8jy87cftmr87x5vs8vrg26lere9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "92"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "92+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino154ys5gaceac0m2sj0fskwzptr6tl77lwe3w3v7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "93"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "93+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1tvlzzcgfey8mc7z3mhwepk84kagutdwmw0m2ul",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "94"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "94+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17v6mxjg8t0w5lq9w6qx76k3p7ar7z8q2k532rl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "95"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "95+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yqgm4zkumgv5hf2afp798arjm59tat3ve9l4d8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "96"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "96+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sd7q4a5v0t3g3r86uzwzkmxdf5mqs6unerwxa4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "97"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "97+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pvpjqg5p8xwqgcjeqv5vzdlmzlmpw06whegrvm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "98"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "98+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ldtg0fl6reuf9w27w6xt9hvqfjal7lggkq3x33",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "99"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "99+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yfpzkqaqgqrs4z4ta9stwht4cgmfqeae7dyjnz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "100"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "100+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xfj26sj8yjtzu632hwryw6k5k8q4t4a8h3jt65",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "101"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "101+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jp56myed7nwy3sre4u445mepkpe79ymmzfr905",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "102"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "102+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17z889qchneqk94x9mjxw0m0xgcgls9d53s7dvg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "103"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "103+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1a3l20l8nwejvkfszggzjeac8lepymh6e3pzm2u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "104"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "104+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino174v5ghmdy20xtmyjnqsmnn6yv99jcxtmcsmhkg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "105"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "105+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13yjkkxgkg0mk7k727f30hwy78zukld6zwfdxy9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "106"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "106+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1edf9wnssqddknydsdym28al5axq7dum75da6fl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "107"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "107+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kfapm9d2r8n5rmjvvv5284qp2rdr7t69nul5j8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "108"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "108+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16l5nmctdj4qqk4zqmy8zlkmsaypjzkw4ehfpkp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "109"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "109+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15tt8kvkah5qcs8r24d9v7w2eymg4hq2nk77gfu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2000000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "110"
+          },
+          {
+            "amount": 20000000000000,
+            "timestampOffset": 5270400,
+            "memo": "110+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vwlkq9xandunkreu49gwkql8vtnxa0ltslq8k5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "111"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "111+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sjsdrw4avghcnvm4rkvsd5clhcujgm8dp292ke",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "112"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "112+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pfl4x5q63wl6e76m2jrncxchsh4eruw32kqmlu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "113"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "113+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16g8j2vrcywjskaygezkm5rl40df6m063df2e8g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "114"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "114+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1am4366ap64h8gftnfd5xcx6gspk237y8vrnd97",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "115"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "115+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1258ga93qdkk7x58rrfp88zt5y9w64sr6p38kc9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "116"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "116+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u8cuvpxmq807q95newex63za3kpw3nqwyj4g7e",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "117"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "117+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ezjkht68k5rz69c5xeetn59vs3wmw6ffa4x5ze",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "118"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "118+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vw4u7j0dwzampvvmyt65rckvfjyykkkgcrf04h",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "119"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "119+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ku4xvfreup02ugju8ls6npyfeu2d0vp2n7c4d9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "120"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16g8j2vrcywjskaygezkm5rl40df6m063df2e8g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "121"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16dkxe6puk3y4qm7hjfvg2lwl8r92e27sj70dxt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "122"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ty3unkry6cqhyyrv4hl6zuhx0k6z59xyezf726",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "123"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1s5nvfwlytnphhzjqm7ep9w7xe25zrep9vm4ua3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "124"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16kqqmrpa92upyxy63z02zjyuvdwjtlhzlsm92c",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "125"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yz03v8cyvgglekensauc8f40vn9mxdnt2xvkef",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "126"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1k6z0skaz3333445zz6vgl9nsmzkm2a89xskxqs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "127"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "127+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qh9nzgm6q5cfa2mpshwu9guzahf5se7furw6fa",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 600000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "128"
+          },
+          {
+            "amount": 6000000000000,
+            "timestampOffset": 5270400,
+            "memo": "128+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13kzrxg5y4qs97qzf4zdqw9m4z9ydkku6xudkk9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "129"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "129+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jm8694tdqc6q27my8wnwhe7mmpl93scy3rgrvm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "130"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "130+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gqj0qsm8dhyer2alw57rwvt0wqp8hhvk83lk9p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "131"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "131+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1els93ysuw4ansfqxe55wlf7ca2rzl0xhhe97pc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "132"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "132+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1e9kkysfkfq5xr93qyyxsfz0mg43x2fgdl49e5v",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "133"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "133+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1nsh2rw3sjvylgd9gk3jpmfx4dlfgm92ylwms58",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "134"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "134+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1uxp2phhpxh7q2zrfmy8pnzt4q9ytg084rpzasv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "135"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "135+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1nkjv6uvpn0u7qg5g24yaey0ch3upjgcycp3rne",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "136"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "136+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino124qh486fhjst6c2zysxgvusz0vlu867qn3lxxy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "137"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "137+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pg3wvrpe3efjt8phj5pf5ftmrk66jr5lzm2jge",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "138"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "138+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1whhfteexl2x4sdl0jfs4nqvdvyh0qx7hvgvvcs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-nj5YW9BXAYQSWunEV5sUqS68vHdnU2Aw",
+            "validatorDuration": 34128000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "139"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "139+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rn52cw296jemvujuv6h9824aezv3w2p4fkldf0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "140"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "140+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f3jtdegkvq8m8avdfqs478hg94xu097hmknwyy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "141"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "141+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yyrg823l0pjxvtle9d4hjqgegttharh4kzh79k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "142"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "142+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1txd4zzds5w07vw7hk9cwmuq3fv0e42uerghsar",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "143"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "143+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zqt6l7yyks097mf4errxd2wjcz6mxd96gjtaxm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "144"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "144+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19jfth3scmug3640fq5zhpye5cw88yqryzz2s32",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "145"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "145+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kpd227tfx0x9mfcg4m62tl2mm9d7eag0mwp4kw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "146"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "146+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ga0ut4yez75rp8077g77uycgchnxyg28gu4w3r",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "147"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "147+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sjxkh9rcjjt4n3nj907rhh5ejey4wa022hl26f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "148"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "148+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1j2kypzc2t4l9qd57qh8ql3ujng65cr33mhzv8s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "149"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "149+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u5s70nmxd7pydjtt70kp842h9pjn3sfu6ky6s4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "150"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "150+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qcjys29pzv8m75fdt9nszl0llkhjv4n9q5ldwc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "151"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "151+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gxw932wm6g0up8pt76af60y4racuuged6j7kgx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "152"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "152+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1k0lnzgar08aa95daf5k066kvuvj0fscxgemrmj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "153"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "153+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yfq50nt44nvf8nt03cqdtwazpw6lthnk4sjur6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "154"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "154+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1scyvhvrepne0fekev9kw6w0u4caq5dyst3upk0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "155"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "155+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jjrm4p75euylsy70jxr9p6dsjnnec3qm4gvq3d",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "156"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "156+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f2cy4rqyg76q8l8e7xpagj4qgx7nzjdcpx98m0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "157"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "157+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15nanl7nh4p8f0w7d35xy9z0zg2e6cagqwjssly",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "158"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "158+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1la56pfek0mpc0x476k40h97kwkh0g73jram8he",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "159"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "159+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1aytql7x689t96yvf5ctdr23d2gx646lv2jfd4l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "160"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "160+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1y30tmzcz0na4nu0uqdh4460dute9nwhvymyuxr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "161"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "161+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vpqxc97jyqecl0arr7t0je08z06nljv0ytqq9y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "162"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "162+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1whe7zklwmyxw4ct0x2wsex0ztcfd0dyyhx365g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "163"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "163+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1k8ahvt0k5uyycvtzs94cavjk26ratnhuw3c07f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "164"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "164+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvng9gkd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "165"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "165+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19ayweyate24cq9enm97mys6yvpj4hg0tp8kx5j",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "166"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "166+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wtjqyemv7ud2t8mzr9m5p25sruukkvq59qqhv0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "167"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "167+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1dzkq4k65usyu6ehqp28wemdjyj84jjzn0haq7l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "168"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "168+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hu4fnqlfze3kedxy8dgg9d2g9uhr9zwgp9lew0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "169"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "169+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16mam24ag695vh9tdfwsxeejg3wtg0ms3264kfz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "170"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "170+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1sgctncsl8zaryp5w62xp25qqjhskzqr7w6qfg9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "171"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "171+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19gk9fzxx52u2lshxvpsp76vamj4q265cvta7j4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "172"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "172+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1shlcs8lgwxcnsc66gs2yn0k0qqft77hpzd9ak4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2000000000000000,
+            "nodeID": "NodeID-2me9yUEwfwQCC53Zod1d52M2LKmJPJHVd",
+            "validatorDuration": 30672000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "173"
+          },
+          {
+            "amount": 20000000000000,
+            "timestampOffset": 5270400,
+            "memo": "173+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16273wcdf2jvytsauu7jd78sjp4fh2j8qkv9j2y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "174"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "174+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15esv7xd09h2y0fltt83zxgqtzw9xxprkfu0u3m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "175"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "175+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18har8esnq6gww24qhgsq39g390mn8p7kmphn7e",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "176"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "176+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ty8y07xy43el4w8awz7srwqc8had8ndyukfl9f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "nodeID": "NodeID-8UfSECBBuFwPAupRQHYFZLUZaQvbpmAoB",
+            "validatorDuration": 30758400,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "177"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "177+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1c3kd4e02r5mzg83ezs7yxhwrvyfstqnj6jj879",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "178"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "178+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1m56g7kzpyvwlcc3mzz9rs5x4u3xuqasqu4y73k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "179"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "179+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1dxd66ecwj99xyezr4p5fq7cfwcqqhj29hapxad",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "180"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "180+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ejtfvvpd268hg8xdjpxfagcnj7x52cepurftz8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "181"
+          },
+          {
+            "amount": 750000000000,
+            "timestampOffset": 5270400,
+            "memo": "181+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ml9g8xcuemh3gly6pn90udkadtvqk49uu6x462",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "182"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "182+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12ymv8mufsrdal5ej3ce9cyjwwmu7kclgag4v7m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "183"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "183+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13384dvk54kl83cdcapcl6nzxq35nxlweawk38q",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "184"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "184+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1d4326e6qataqhz5zpfjtsvg0325pqpd67nhuqg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "185"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "185+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16wusq5lzn8ngtea7ff4e3v9thzxlac70twp4hz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "186"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "186+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1a28tjjxyplz3uq0737tgwv7k29e8dj24azfrlk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "187"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "187+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1d3cul3elpugpu99p62gpu8ml9mx6zhdrqcl4ja",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "188"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "188+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xwerkdrpkuhq0u9uprvp0dms6tc7y5angf654p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "189"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "189+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1muy0sy676mc383d566he9lw5a32dkslfdgxzat",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "190"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "190+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15trkm623zm2r23j2hrqjsry636sckxcz7zzqgl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "191"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "191+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yatmadtt3qpn7em0r2vmd6ncavdqjlf7jg5nve",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "192"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "192+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino10thamqpnlvawz4zqayvj7t9s0x6uzwz6hm5kv6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "193"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "193+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino196lwrtuwr2vf79r5jympkjugtsmxkgtwv5etr6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "194"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "194+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1y7mc7hekqxxhuerst0ukpeq9k63zy3783ga4vr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "195"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "195+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino153ejpsghh0tzamey70clpcd7g0y9r6g699ctgk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "196"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "196+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lx0paymqrp528j5t9hjks6auapgfq49vzqj8ky",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "197"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "197+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1fxsxvek9w0u6q2dy5zkcqxqqlf0kje67t9afx5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "198"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "198+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zl5pd3x9h2tj47v7nfwusue3t3lu967znpzfa9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "199"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "199+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qmgvg3qw95ft4sww5lkk0vkypjs737fds808k7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "200"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "200+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1anj83lc0h839vmvltws0a6h7k5znlyq8wvl768",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "201"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "201+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gaxcm3petj9z6kvp2w5kcr4usvdvq3hvf0xqn9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "202"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "202+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvng9gkd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "203"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "203+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1tskv880tp95hrpqs7wrqxmp7wrmmr3lcwvjaj6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "204"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "204+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qwu3jm84hr3sh9kpst3gxlakd22r5vjad4v5x9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "205"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "205+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ysa48z2anf29ckcmg8rak384s0k8uwd2ra5wsa",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "206"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "206+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zddlpr6hjzjrunts8qdzkwfpx02nu274jv9dct",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "207"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "207+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18q6scezgt2646rzpc8fmw4jce5zmcvgvhzq7vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "208"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "208+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yws8zcjfsnfgq39c6chsgtm94mt9596m5pul58",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "209"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "209+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18eqxyetaqt8kym2nqhat532gxtewfsvk2zpq4m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "210"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "210+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kklwkxzvuefl4kvg4dkzw8hp5dq2marxdkfwz7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "211"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "211+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gyk9tf69huuc7lrrt6myuzufg4zv4tewyw9s72",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "212"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "212+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtakqwzx3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "213"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "213+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino160l526l8mkfjeacnhyv5ucvp6uekv9cchhzqdx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "214"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "214+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13hvsse9lhszwcktwyy74tgzzzmrqvjxk4nr00u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "215"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "215+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1gxvvskyrpk7cjrd934rgmmxysqrvgqy76dcd28",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "216"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "216+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wgepplh320jtxdfwpnlr3pqpt4sj3xctemynt4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "nodeID": "NodeID-4EQFrUN4H512882gcc4UPkwDueQwM49bx",
+            "validatorDuration": 31795200,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "217"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "217+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jl4gs84hu6s2k24kxrj7549seyczw5cr0xwe8q",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "218"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "218+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16g5l0fngqc9dlzvug7k6el6syey8r375ctthl3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "219"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "219+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1c78g2twqemmav8dr0u6cncuvn9nf9zm30r4jeu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "220"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "220+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1td7w8a2ktccxktvh72275txv4dpzcn5y9u2xgp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "221"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "221+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino14u3mjp2zwrm7l8v5x7yxn4ed5t29gu0y5zhtng",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "222"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "222+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qtnwfkkvwl5haylwl4ppy9tzkffmq560x3eth0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "223"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "223+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1t7hagl6tr9hj7hvt66xv73au3edt8fj0xxk2ha",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "224"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "224+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1p4xp6m8qgt202aqklwcnhfqx5rg9c2hurcv6py",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "225"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "225+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1236v9648strvh8xmvl3g7hcmxmn5q7366dfmxx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "226"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "226+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cdr7whau0kjreg2u6awc4k04jx2yp2sw06yqmh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "227"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "227+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15xxam9nwdz53wdl9zsewqpnjel0arf0wmhpwku",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "228"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "228+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1smeeegnxaaamfazx98d0qpnrkkx5qrwkhz08r4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "229"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "229+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1537zcugeec0243matenf36nc90qg0rhh2jkvc3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "230"
+          },
+          {
+            "amount": 3000000000000,
+            "timestampOffset": 5270400,
+            "memo": "230+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1j8ux8qvav9rv36zw6e5lkwcdupazruadewcdv4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 70000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "231"
+          },
+          {
+            "amount": 700000000000,
+            "timestampOffset": 5270400,
+            "memo": "231+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rdh6676x0fdevchtu2xjxpm0pf9xun4khtwudn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "232"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "232+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cvt8hhmkysu5rdjzvdvvp70tq5u7ae4pmug2yc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "233"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "233+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ml9g8xcuemh3gly6pn90udkadtvqk49uu6x462",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "234"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "234+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15dw76k56hd7x2s7k9rnvkzsv56sam5uj4sh9w8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "235"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "235+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mq4ruc3zgamspv94ej3ws8c35crqgwyxes6jl5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "236"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "236+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cvd8ardpsynhgfhdaapf7akhqv6sc7m99098vy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "237"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "237+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ylvqqfp9fyyr52rnpl4faghh5fmzm5fhwga6fk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "238"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "238+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1upeztlw8cktcf8w78ayt72g65z05egnxnsyxyh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "239"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "239+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13ugty8yv3xn96kcet56kkvjx26m9e88vujvnln",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "240"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "240+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1vntz0u4d88yjxsfm9rmpczrx7295wu9ga396pc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "241"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "241+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xp9tyghuh7j7a8exqk9uqpmyath7pklefm93zv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "242"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "242+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1uaasrym74ld4esmdz6wjxse69zpjkmml85c36t",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "243"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "243+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qajjjmwlnytjfe6l8jtqhev4helx9x47vgy8vh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1500000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "244"
+          },
+          {
+            "amount": 15000000000000,
+            "timestampOffset": 5270400,
+            "memo": "244+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hv5tlf84nxcqkvsdtnetfdyw3wfnvhl9zqjlpc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "245"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "245+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12l7dlgqkq3ue89vsckgw35vv5wpp7605s3kmh0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "246"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "246+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1enn02mahvwyrjdca5htg9rydqrnksscmtffz5m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "247"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "247+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1j9nsdtrff2m9w97m7wsnxwyx7dvax2v2rhmlgw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "248"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "248+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13m4yh7ztmps4hjsnyhwy0rxyh6w7ufj6dn7jc5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "249"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "249+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12n9pnwrh2rqqp8a9kad6wadc2hc62ts7zpymmr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "250"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "250+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1d68vs6523kp60s8ls67pexr5wmx539naur9pxw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "251"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "251+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1z0hl0jpetf53mxj8d7n9mt70l0l99ng95vc533",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "252"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "252+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1zpkv5m338vccu9d5fln6wysjdhl05wp2m96tk3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "253"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "253+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino18n7y8k9yfv9ah4knxhll9hhuaf0r0hgr2ma40g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "254"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "254+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ypmdpy7tlep95za2nt9tx5a8tvjykxxstx2jf4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "255"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "255+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1wgthf6t2m26sgfenejht7agnzm4wqa20ws3zwc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "256"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "256+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1rpp52fc6d9gwr2pcshlk3565nqazqym4kyhev2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "257"
+          },
+          {
+            "amount": 25000000000000,
+            "timestampOffset": 5270400,
+            "memo": "257+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino14f5k9f27nwagph2f46xlcszqa8zq9zz76jdhvf",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "258"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "258+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1h7u9p4pa9faxj3zezs9udxvj8quuqymraqddam",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "259"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "259+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1kfnsy5p7pfsqh76k5zzmj2kd5svaf0qwcfpt20",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-Ka4EiYpFwSdUXVji39DqNjtjJ2n3jiBki",
+            "validatorDuration": 32400000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "260"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "260+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hc9ffgdtgeznl4h08gckxncv8at744t9l20uyn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "261"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "261+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1qql75cyftxtf923vny3qr9hkmdayyny6ltw4v3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "262"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "262+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1pvmnzwj7pdd4nec3kp0fgdf9w0hp9h6nfeaqek",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 115000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "263"
+          },
+          {
+            "amount": 1150000000000,
+            "timestampOffset": 5270400,
+            "memo": "263+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino133alnuggsul62aajwhynp7uhsvc8val6j7rd3j",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "264"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "264+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1swq7jndpq8seupaehfhpwc8tjy8z6j7zpn666f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "nodeID": "NodeID-4NTFqo7zYHmupX3j8em6qnw3cKrXEYu8v",
+            "validatorDuration": 32659200,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "265"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "265+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1lsgwstc8edestl9v9t65kcfwjcy4gh8qhpvdej",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "266"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "266+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jgvgunr3jck6tn7xkzdrrj7khlge7rkvlzd9c6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "267"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "267+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ztkd0srlqersv4c53kfg3cc5kg03ww7946a2e6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "nodeID": "NodeID-9pygZskxbgi5ZKicwu5ES2ZwteTK6MnMH",
+            "validatorDuration": 31104000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "268"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "268+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15r9s9pctuhf4as2h67naa7ct58fnpn4sapnzl5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "269"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "269+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino104gqfegwvksn3kfu95dn6upy48vtpuxcg6l8lz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "270"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "270+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1teh54u7kjz4p36l63utcu3jcfkygxjp4sl4j9a",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "271"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "271+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1czgaf8lqfu8cfa74gyuh8ngtfysqlm0xxn593l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "272"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "272+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino12neqhcynnfy82lxcdcgj0lmqazr4yn77yq68vt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "273"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "273+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1cq4ge3ww6etrsa6t9695yyqmvgzus6l2056ufs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "274"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "274+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino120jls24pylcuf8jpu55a0nle9r776reja8lz06",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "275"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "275+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15mzhyljgn57752z877zwshx2kfm4qp4a3z5x6p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "276"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "276+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1f9z05t8uweh6e3e7q75xf7p4745hm5c8059ga8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "277"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino17ds4n2ukuj2nt46jtuep8z2gcv722ryajftwwk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "nodeID": "NodeID-4hcbnsrf4wDYBpNHE74qd7JURAoty4Hsz",
+            "validatorDuration": 32745600,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "278"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "278+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1253vr70qkvynz4nyj6retgftjw8zu7zts4f49n",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "279"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "279+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino14jw3xrysalfq33n22e4wgmfwnumjkt4ukn4wd0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15200000000000000,
+            "memo": "280+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino14jw3xrysalfq33n22e4wgmfwnumjkt4ukn4wd0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 40000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "281"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino123q64vzr4kdsgxfntwujjhxapdakz4xs2cwec2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1500000000000000,
+            "memo": "282+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino123q64vzr4kdsgxfntwujjhxapdakz4xs2cwec2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 18600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "283"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u3fe3uet9s08d0aja5zme7dy9yx23n8d7tweuz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000000,
+            "memo": "284+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1u3fe3uet9s08d0aja5zme7dy9yx23n8d7tweuz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 45000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "285"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000000,
+            "memo": "286+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "287"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "288"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xsww8kttcufckh84x49287u8wprz89rfhextn6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000000,
+            "memo": "289+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1xsww8kttcufckh84x49287u8wprz89rfhextn6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "290"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1s43aum9ctvdyxgdfnyapqdfvy7ddjmc58ptrqm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000000,
+            "memo": "291+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1ext8a4n2ufqvgfhunzq8cvlexz9w8xhxrqz0hq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 240567110000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "292"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1hhqspfn3chrr8f23kdekcwl26a66nw7wdvp8qa",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "nodeID": "NodeID-5APqagKQK2d9cMrtgR2h3bsC4GrU3UkNr",
+            "validatorDuration": 31276800,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "293"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino13r5xljkdl7w4g9tcqynfafm4g89mx52ektkrju",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000,
+            "memo": "294+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1eysxq4a0utnrzmjcfnzx227ahlcymd5shfcc47",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000,
+            "memo": "295+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1crv6z0h3zdzj2mwjacelywa9twyg7wj9ud4jah",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "296"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1yqn8cjps7szj8pl2sj425fg2v7tjyz4rsdh0wx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "297"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino153uxhwgdunhyzmaq6t2azlp77aqpnlkpqk8ms6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "298"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino15cxxvhc3v23z86duy7ryuaraqjgnzjfcq0es6k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "299"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1jvtwr8mx0c6d6dx5x35s2rxlh8scpwnsg8mmz8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "300"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "300+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino16ukqv0wqy0hwkhe29zr5wfcapqfyf022ykzlx7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "timestampOffset": 5270400,
+            "memo": "301+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1urux0644x3gdp7n40z5qfj0zxd2wzheg4fl9z7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "302"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "302+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino165zf3m4ct6rsdkn49mpk5tlwla7hc9u86f6r96",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "303"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "303+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino1n4c9txy82r8kklpvrf4m5fk5q3n3cj63zpfu46",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "304"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "304+"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-camino19kqmnj2w4ypdw33zltukr9dgtwur56yd6wea4k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "305"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "305+"
           }
         ]
       }
+    ],
+    "initialMultisigAddresses": [
+      {
+        "alias": "X-camino124te92fnfl94nqdxknw8w0juld4e8rgm8rsctf",
+        "addresses": [
+          "X-camino1yygtqe5az7cu34z6xqs0007wnccw7y38sw4dtj",
+          "X-camino1tr0q3nv8d6hgh4777dj5trqqpp7netsp3rqgvz",
+          "X-camino16dkxe6puk3y4qm7hjfvg2lwl8r92e27sj70dxt"
+        ],
+        "threshold": 2,
+        "memo": "101"
+      },
+      {
+        "alias": "X-camino16ukqv0wqy0hwkhe29zr5wfcapqfyf022ykzlx7",
+        "addresses": [
+          "X-camino1wu6aex7pj9ps0jfyj3jtyyhgjkjsaffpla0u70"
+        ],
+        "threshold": 1,
+        "memo": "107"
+      },
+      {
+        "alias": "X-camino1ml9g8xcuemh3gly6pn90udkadtvqk49uu6x462",
+        "addresses": [
+          "X-camino105juj7nnwlr43jju46ll3w0hk2jhh8qxz8qt30",
+          "X-camino15us5xx6cqyqke700r7zzrttkc8f8kkmz3qlp6g",
+          "X-camino1chgzlvlsuv24ul0lc2pe3s3u3kg2nth6tfp8gz",
+          "X-camino1lw0tt6jc6wtstw985dezs9slux395jucpfx00a"
+        ],
+        "threshold": 2,
+        "memo": "108"
+      },
+      {
+        "alias": "X-camino1rdh6676x0fdevchtu2xjxpm0pf9xun4khtwudn",
+        "addresses": [
+          "X-camino1y927svmcmp4qrm6sa353heyaugv2m6q0fskura",
+          "X-camino178k05na3e3yvh43lwgn93xavgzd9g9uwex8hau"
+        ],
+        "threshold": 1,
+        "memo": "114"
+      },
+      {
+        "alias": "X-camino1k6y2cfw4tv8n2p6lydj9vnj2kefcs4sfn2msfw",
+        "addresses": [
+          "X-camino1p5vqs0aedzx8fmy3nejk6hdm2rtulafyrjnp58",
+          "X-camino1rq99jnlyu6pz7yn40sm7g3gpw7zg96pfkey432",
+          "X-camino1ggdq6ynh8svx2w4ahww9y605weaejkcq28p4sa",
+          "X-camino1f2tqt7uc6ltp3u5twmkclkz8wrudwxjyfv8npz",
+          "X-camino1vykttsktmmzqx27feaqp8d3tsgyxmwf6nqexg2",
+          "X-camino1wwzwaztw5720s3yt2awj0yg0ekdt64vjw8p8jd",
+          "X-camino10mc35x5vhq3dg9vny3hhf3f8c43sdrert7qxrj",
+          "X-camino1uzuch26fsrf0klj0xf6k8ngfvahjz2dc3qu8np"
+        ],
+        "threshold": 3,
+        "memo": "122"
+      },
+      {
+        "alias": "X-camino1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrdn5j3s",
+        "addresses": [
+          "X-camino1xhgfdj0zwqyntv2a43xftcpdqgtzhyycp0kf6j",
+          "X-camino1ggm6nly7q96mqxkjwc7yed0pzya7y9vz7hzsse",
+          "X-camino1mavgenegtk3elk07l4vzfxcyrvx2fsnvxhn9na"
+        ],
+        "threshold": 2,
+        "memo": "123"
+      },
+      {
+        "alias": "X-camino1hhqspfn3chrr8f23kdekcwl26a66nw7wdvp8qa",
+        "addresses": [
+          "X-camino1rq99jnlyu6pz7yn40sm7g3gpw7zg96pfkey432",
+          "X-camino1reelwcfs8hf8mlh2pwtp58jum78fhlphucn6vm",
+          "X-camino1f2tqt7uc6ltp3u5twmkclkz8wrudwxjyfv8npz",
+          "X-camino16kqqmrpa92upyxy63z02zjyuvdwjtlhzlsm92c"
+        ],
+        "threshold": 2,
+        "memo": "124"
+      },
+      {
+        "alias": "X-camino133alnuggsul62aajwhynp7uhsvc8val6j7rd3j",
+        "addresses": [
+          "X-camino1ay6pzxyv9tqstnwnlqv25zes2w90jej7mqxk8s"
+        ],
+        "threshold": 1,
+        "memo": "147"
+      },
+      {
+        "alias": "X-camino1j9nsdtrff2m9w97m7wsnxwyx7dvax2v2rhmlgw",
+        "addresses": [
+          "X-camino14jdzccn3vx9q7qxnr8pxt4tachwdwyd9yehl6m"
+        ],
+        "threshold": 1,
+        "memo": "153"
+      },
+      {
+        "alias": "X-camino10jsl9f669s9dn6zpxjgerv57pmhnaup5s88dax",
+        "addresses": [
+          "X-camino17tldvcdnq52a29y5vplw5l4pys80jnlprzh7qq"
+        ],
+        "threshold": 1,
+        "memo": "155"
+      },
+      {
+        "alias": "X-camino18q6scezgt2646rzpc8fmw4jce5zmcvgvhzq7vy",
+        "addresses": [
+          "X-camino1pzdrxqdnkuxa427gmuc8fg2gnj4hv3w0dsq5tg",
+          "X-camino1teeklahjnuwwfna5tvudvrswxerm2fdtsk3mt3",
+          "X-camino1h87ampd07hwtnqywpsagrxm9ygkmcr34z3zmvs",
+          "X-camino1at9hu5wd4xpfagvqs4t47yd4p6jx87gpp9enpp"
+        ],
+        "threshold": 2,
+        "memo": "156"
+      },
+      {
+        "alias": "X-camino146qrj047eaapww0mrv52zcg30ycljhhyel9x2x",
+        "addresses": [
+          "X-camino1pjm87e2aklx5dj0qjpzdxe545lmz2kjw7yrzzt",
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino1308ufc2ekfqmynl3ul6khwrjkc7w3jw9akc8kc"
+        ],
+        "threshold": 2,
+        "memo": "157"
+      },
+      {
+        "alias": "X-camino19m2e8p6ce2yx9uf00rw5jm70l4w24x0s8gt55y",
+        "addresses": [
+          "X-camino19s08wlh8a79h32upup8xz5lqrne6ps6vaptdaj",
+          "X-camino1w04tgtwve7er76ffz8taygd07d3kxjwcmsn50c",
+          "X-camino14n7xd94q07gzsxlumhwtvydt9vmnh9ejkvxgdl",
+          "X-camino17mmty08pa2ad43e53055a9ujdr5s9p3sjxv99m"
+        ],
+        "threshold": 2,
+        "memo": "158"
+      },
+      {
+        "alias": "X-camino1smeeegnxaaamfazx98d0qpnrkkx5qrwkhz08r4",
+        "addresses": [
+          "X-camino1z3lfk4q88hfv5f8dlde7vrxqd9pta60a248ue8",
+          "X-camino1x3dwax0xcrsvwudlcnwjvr6clu9jzyhlehmd2c",
+          "X-camino16a8rqzehm6httxzcx0aj2rq8z4h7ntmz3qyfzz"
+        ],
+        "threshold": 1,
+        "memo": "168"
+      },
+      {
+        "alias": "X-camino160l526l8mkfjeacnhyv5ucvp6uekv9cchhzqdx",
+        "addresses": [
+          "X-camino1mvvz30r2ygmwyk9dc6y69ff9vqfxqdh90hskgn"
+        ],
+        "threshold": 1,
+        "memo": "169"
+      },
+      {
+        "alias": "X-camino1wgepplh320jtxdfwpnlr3pqpt4sj3xctemynt4",
+        "addresses": [
+          "X-camino1msjywfc88xkqm3vdmhyat6x0ar9galgjkrncxl",
+          "X-camino17j8tn7asys029zjxj5834zrp50nrl2jzccp7wm"
+        ],
+        "threshold": 2,
+        "memo": "175"
+      },
+      {
+        "alias": "X-camino12neqhcynnfy82lxcdcgj0lmqazr4yn77yq68vt",
+        "addresses": [
+          "X-camino1806h6nxlqlmw69wj4anh604navdancnad83v0s"
+        ],
+        "threshold": 1,
+        "memo": "201"
+      },
+      {
+        "alias": "X-camino1h7u9p4pa9faxj3zezs9udxvj8quuqymraqddam",
+        "addresses": [
+          "X-camino1pk3rmmvchm6jyv5c5mnmwfgaznlecnewhyslnp",
+          "X-camino1pechqrj6s47ltdgdj6z9m25hqvuqup5el8qrxp",
+          "X-camino1tsxnuvztsledksd2vwa5s2cqxcesqsgt63x9gf",
+          "X-camino1mq0f3xg4v7klgshy0vc6mpmpuhz2l6zwjs609z",
+          "X-camino17x4yq0rau70urx2mj50ajmalr9uxhnu7zx9j4c"
+        ],
+        "threshold": 2,
+        "memo": "204"
+      },
+      {
+        "alias": "X-camino1vedj99e90uppeyza86qmhyyhfcfyhh054y30uh",
+        "addresses": [
+          "X-camino1g3wnnvsknstw9utt02zg9s0z9vlkll5zkjfh6l"
+        ],
+        "threshold": 1,
+        "memo": "228"
+      },
+      {
+        "alias": "X-camino1ztkd0srlqersv4c53kfg3cc5kg03ww7946a2e6",
+        "addresses": [
+          "X-camino19l54f9nfxhap647smkh8f7d64t42yyn8rtzuar"
+        ],
+        "threshold": 1,
+        "memo": "252"
+      },
+      {
+        "alias": "X-camino1fxsxvek9w0u6q2dy5zkcqxqqlf0kje67t9afx5",
+        "addresses": [
+          "X-camino1vm5c7snzm7tfd60lnszr6rh220ehaaehp6y3af",
+          "X-camino1ntwu2g45zl9trt4ptf9z458y4fkjk3s8nmccjk"
+        ],
+        "threshold": 1,
+        "memo": "265"
+      },
+      {
+        "alias": "X-camino13m4yh7ztmps4hjsnyhwy0rxyh6w7ufj6dn7jc5",
+        "addresses": [
+          "X-camino1pvjh956nk5pfvs4cxj393srggtuttc0wef7nth",
+          "X-camino1yl7sslel748vc2k9jzzuccqh6c4z5pws2j45qm",
+          "X-camino1g4x9jncqa4qmvsups4n58xecpnfgukxymf05um",
+          "X-camino1javf0x8m5syvy4c324kf5u8h4ucmktty3zw7sv"
+        ],
+        "threshold": 2,
+        "memo": "267"
+      },
+      {
+        "alias": "X-camino1qmgvg3qw95ft4sww5lkk0vkypjs737fds808k7",
+        "addresses": [
+          "X-camino1tue3f8kqn43l7548q35n5l8t6fyhw7a8mm2f6g",
+          "X-camino1cdqr442s4jvjs9r8twpmz86j5c9ml8w8h8fz0p"
+        ],
+        "threshold": 1,
+        "memo": "294"
+      },
+      {
+        "alias": "X-camino1z0hl0jpetf53mxj8d7n9mt70l0l99ng95vc533",
+        "addresses": [
+          "X-camino1ylygwv9shf7h98hx439jmuyp6adrgl544ztc5e"
+        ],
+        "threshold": 1,
+        "memo": "297"
+      },
+      {
+        "alias": "X-camino1jgvgunr3jck6tn7xkzdrrj7khlge7rkvlzd9c6",
+        "addresses": [
+          "X-camino19us5zgu4g3pqx4n0r9yfm67ngvp5c6hmqp7q43"
+        ],
+        "threshold": 1,
+        "memo": "304"
+      },
+      {
+        "alias": "X-camino1yws8zcjfsnfgq39c6chsgtm94mt9596m5pul58",
+        "addresses": [
+          "X-camino1fkumksdh3cc3tjq6lauj4fgw0302s58t9rtsac",
+          "X-camino1ss45guv0dvndhqen29nqvj2z7uqcxse2d4m0t5",
+          "X-camino164ga3vuv2wr0ynrtfzhcw54mdz9appxp3sy540"
+        ],
+        "threshold": 2,
+        "memo": "348"
+      },
+      {
+        "alias": "X-camino1ypmdpy7tlep95za2nt9tx5a8tvjykxxstx2jf4",
+        "addresses": [
+          "X-camino1l7lqt7nvn5fxcua7qtrpu35t6gyayvmwccemwl"
+        ],
+        "threshold": 1,
+        "memo": "361"
+      },
+      {
+        "alias": "X-camino12n9pnwrh2rqqp8a9kad6wadc2hc62ts7zpymmr",
+        "addresses": [
+          "X-camino100g8eeflkae5z2xthem8kvph4mplzmr0vgvaqk",
+          "X-camino17jud7x574ejxvr59uter92kq5jy63xqqgu36tt"
+        ],
+        "threshold": 1,
+        "memo": "369"
+      },
+      {
+        "alias": "X-camino1td7w8a2ktccxktvh72275txv4dpzcn5y9u2xgp",
+        "addresses": [
+          "X-camino1nnj4786z985qx6qamvra4zyh6h3v7kxecc0qj3",
+          "X-camino1aypxtwfkzjy02vtyl05z2g3cqrfnml2dvljtcg"
+        ],
+        "threshold": 2,
+        "memo": "382"
+      },
+      {
+        "alias": "X-camino1m56g7kzpyvwlcc3mzz9rs5x4u3xuqasqu4y73k",
+        "addresses": [
+          "X-camino1e4spjn6qc5ga3g0vmf5ad95e4cssypxs4dyqj2",
+          "X-camino1uacvp9lkcdqr85myw4hyqg2wt9e3vf3vxjg9rf"
+        ],
+        "threshold": 1,
+        "memo": "388"
+      },
+      {
+        "alias": "X-camino15tt8kvkah5qcs8r24d9v7w2eymg4hq2nk77gfu",
+        "addresses": [
+          "X-camino1k565fpq39tw3x9n9kaaexewnrjdtejej0vhm5w"
+        ],
+        "threshold": 1,
+        "memo": "394"
+      },
+      {
+        "alias": "X-camino1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtakqwzx3",
+        "addresses": [
+          "X-camino1gye293pwk9af9s9ws826wetzr6l4phz36u6cp9"
+        ],
+        "threshold": 1,
+        "memo": "402"
+      },
+      {
+        "alias": "X-camino1k6z0skaz3333445zz6vgl9nsmzkm2a89xskxqs",
+        "addresses": [
+          "X-camino1r9hyse7qqge3ckwcy7vxtks7ejythgfn78vhcl"
+        ],
+        "threshold": 1,
+        "memo": "421"
+      },
+      {
+        "alias": "X-camino13kzrxg5y4qs97qzf4zdqw9m4z9ydkku6xudkk9",
+        "addresses": [
+          "X-camino1vs5nw0t5rq3rnq6ehzeu6eptka05kclzhzefva",
+          "X-camino16rvf78jypp5c5tf7zw20awnjqk2r78xsfcsxgq",
+          "X-camino1udmhtchhzknfrc674765p7haalzp5nthavtxhk"
+        ],
+        "threshold": 2,
+        "memo": "422"
+      },
+      {
+        "alias": "X-camino1jm8694tdqc6q27my8wnwhe7mmpl93scy3rgrvm",
+        "addresses": [
+          "X-camino1tyhaxdvp2kdtcylmjjjk3au2sdvsfj9krawh5d",
+          "X-camino1vc6tq3tn3fz49y532q7tdg6w7at2dx3r0xkflf"
+        ],
+        "threshold": 1,
+        "memo": "423"
+      },
+      {
+        "alias": "X-camino1gqj0qsm8dhyer2alw57rwvt0wqp8hhvk83lk9p",
+        "addresses": [
+          "X-camino1202mhjj7zxsc6d57x382m97mtw68kdw3r0tunk",
+          "X-camino1vk90lszrs4kcpdu3zpqp3zapyvxrp8yhldc275",
+          "X-camino1d0el2szhu3azftp7z8w7vgp5gm2rcfcv6sz2sa",
+          "X-camino15jrtmg8qf328qkasy892hf2n5hghh8xdntc3g6",
+          "X-camino1ajp9ctl6wczhk45yz2s66klhlf3czhvxrnx2vm"
+        ],
+        "threshold": 2,
+        "memo": "424"
+      },
+      {
+        "alias": "X-camino1zpkv5m338vccu9d5fln6wysjdhl05wp2m96tk3",
+        "addresses": [
+          "X-camino1xzqavra5hmuy0lu34hd68uadruaq2vjz3skadt",
+          "X-camino1hapvmtn2ckxhhr4xteuytgyfjal8suz4frmt8l"
+        ],
+        "threshold": 1,
+        "memo": "439"
+      },
+      {
+        "alias": "X-camino1ylvqqfp9fyyr52rnpl4faghh5fmzm5fhwga6fk",
+        "addresses": [
+          "X-camino18asarasfkentje83r49h2s98aavyh06md8tf7h",
+          "X-camino1kmvh5fuzkgsghdd4ffjnum6vydtdg7lglu9k6u"
+        ],
+        "threshold": 1,
+        "memo": "441"
+      },
+      {
+        "alias": "X-camino1fp0gllrtxljv3gqwc2dq3vuq03vcrkrjdef2q9",
+        "addresses": [
+          "X-camino1rng8zue68t0ckhe34vj80mrcz5s0l6xq8q5fmr",
+          "X-camino1de7r6jwww9npznc60a463vll9te5g7888ryg8s",
+          "X-camino1jrnmlnxcysgsmamjn66zzl6tc6rrwh5nw3kmtc"
+        ],
+        "threshold": 2,
+        "memo": "444"
+      },
+      {
+        "alias": "X-camino15gmmr9we6yhgd7z45ryy886cyqgeuuxcsq4um7",
+        "addresses": [
+          "X-camino196w4wzzzgc5vu38jywtr0na3uh9ml8vqrw34ws"
+        ],
+        "threshold": 1,
+        "memo": "445"
+      },
+      {
+        "alias": "X-camino1qql75cyftxtf923vny3qr9hkmdayyny6ltw4v3",
+        "addresses": [
+          "X-camino1hwqs0fkuartuzv9px5fae0vw74lp8rz22mfvvt"
+        ],
+        "threshold": 1,
+        "memo": "461"
+      },
+      {
+        "alias": "X-camino1qh9nzgm6q5cfa2mpshwu9guzahf5se7furw6fa",
+        "addresses": [
+          "X-camino1zt7qczfecjda0qzn9zq9lvu24pv90ts6whc629",
+          "X-camino1zuhfsllesh4k54rxwkmxcwyn6jkpakr08phjay",
+          "X-camino1l9d26hr08w7d57hcepfz2hl8n66jzjgaxg3043"
+        ],
+        "threshold": 2,
+        "memo": "492"
+      },
+      {
+        "alias": "X-camino1d68vs6523kp60s8ls67pexr5wmx539naur9pxw",
+        "addresses": [
+          "X-camino1qa88y6j2gd065pgtsmls2kwmzppllvxxq9s2rv"
+        ],
+        "threshold": 1,
+        "memo": "510"
+      },
+      {
+        "alias": "X-camino14f5k9f27nwagph2f46xlcszqa8zq9zz76jdhvf",
+        "addresses": [
+          "X-camino1qhrydqys7fhugrvfeh0mnp2nrr65m43phhu3sz",
+          "X-camino1x2fv48xd6m5au3hxp90mss7ptw3mayxv2q3dln"
+        ],
+        "threshold": 1,
+        "memo": "515"
+      },
+      {
+        "alias": "X-camino15r9s9pctuhf4as2h67naa7ct58fnpn4sapnzl5",
+        "addresses": [
+          "X-camino17krhudwn3m57xrqn0kqmffwfxl4rgzzauw3m78"
+        ],
+        "threshold": 1,
+        "memo": "528"
+      },
+      {
+        "alias": "X-camino15mzhyljgn57752z877zwshx2kfm4qp4a3z5x6p",
+        "addresses": [
+          "X-camino1009vem499gs6xnjr0rylcpmhksqhrgunxnxq89",
+          "X-camino14wjmzwz72wpf9j6tgh9xhq7z9j2epwmjpa6t97"
+        ],
+        "threshold": 1,
+        "memo": "549"
+      },
+      {
+        "alias": "X-camino1txd4zzds5w07vw7hk9cwmuq3fv0e42uerghsar",
+        "addresses": [
+          "X-camino1t326mc4mxzgv2zk4xw6wql7ld4rmgg7cdtjly8",
+          "X-camino1tk2dxqsf3ldkdlr0mtdrxsa63q3ualzv58z356",
+          "X-camino1cgzgtnk6gj9pnws9w6ecya0jqqckc2sm0a8zjl",
+          "X-camino1c5gfpcuvdq378ex8crll8mgkae6hdylns3v5jg",
+          "X-camino1u7mucmymjh7w6ffjh7gp4fd68uuaqd6nrqzyhw",
+          "X-camino1lsr42pxckzvmkd5y9rm2nvnty3ju5gjh8ka2ve"
+        ],
+        "threshold": 3,
+        "memo": "568"
+      },
+      {
+        "alias": "X-camino1zqt6l7yyks097mf4errxd2wjcz6mxd96gjtaxm",
+        "addresses": [
+          "X-camino1qr8x6ksnm0suzluxlvx6a9llxxlkttecwzqm3p",
+          "X-camino1g0h99yx8cmklsr223fvuqpx0cyfd6rr2nel779",
+          "X-camino10hc036xkd376v689m83cvjackv3udekeuj5ddu"
+        ],
+        "threshold": 2,
+        "memo": "569"
+      },
+      {
+        "alias": "X-camino1dxd66ecwj99xyezr4p5fq7cfwcqqhj29hapxad",
+        "addresses": [
+          "X-camino1rwek7nheyyg6vjp4hy67lfr76c3gpq8920fgpj",
+          "X-camino1d6qztaunws956zdwv7u7csqhysgz7yu6n9nvfu",
+          "X-camino1u0ywjglrprcutlnkcnk5qtzcgggj4ksutq3n83"
+        ],
+        "threshold": 2,
+        "memo": "576"
+      },
+      {
+        "alias": "X-camino1c3kd4e02r5mzg83ezs7yxhwrvyfstqnj6jj879",
+        "addresses": [
+          "X-camino1tc85rxtwjxn46uen44rqwfdrry24ha9rujkvhq"
+        ],
+        "threshold": 1,
+        "memo": "602"
+      },
+      {
+        "alias": "X-camino1enn02mahvwyrjdca5htg9rydqrnksscmtffz5m",
+        "addresses": [
+          "X-camino1vja8yrr2yvjtmgpw0cap9r240p0kxu8mslzcvd"
+        ],
+        "threshold": 1,
+        "memo": "607"
+      },
+      {
+        "alias": "X-camino15esv7xd09h2y0fltt83zxgqtzw9xxprkfu0u3m",
+        "addresses": [
+          "X-camino10ug0cakympud639d736slusv5smyfc56surzfn"
+        ],
+        "threshold": 1,
+        "memo": "608"
+      },
+      {
+        "alias": "X-camino16273wcdf2jvytsauu7jd78sjp4fh2j8qkv9j2y",
+        "addresses": [
+          "X-camino18majy9d7c0zuwpz8r6spzr927xgj9mf7nh9t0x"
+        ],
+        "threshold": 1,
+        "memo": "609"
+      },
+      {
+        "alias": "X-camino1whhfteexl2x4sdl0jfs4nqvdvyh0qx7hvgvvcs",
+        "addresses": [
+          "X-camino1pt4aqevy3n3lpjvy6y3e8dnyqnrmzu02wue3gp"
+        ],
+        "threshold": 1,
+        "memo": "610"
+      },
+      {
+        "alias": "X-camino1qajjjmwlnytjfe6l8jtqhev4helx9x47vgy8vh",
+        "addresses": [
+          "X-camino1j5uwju5lqmm7ja3atkayclj3fyemk4m4gahalm"
+        ],
+        "threshold": 1,
+        "memo": "611"
+      },
+      {
+        "alias": "X-camino1258ga93qdkk7x58rrfp88zt5y9w64sr6p38kc9",
+        "addresses": [
+          "X-camino1qarpkac6r00v4cwdldc099nrypg4mjemsvm30x"
+        ],
+        "threshold": 1,
+        "memo": "612"
+      },
+      {
+        "alias": "X-camino174v5ghmdy20xtmyjnqsmnn6yv99jcxtmcsmhkg",
+        "addresses": [
+          "X-camino1xsznkqapgemyrm5mm6whkxsd6tjqhx6ah2wdwr"
+        ],
+        "threshold": 1,
+        "memo": "613"
+      },
+      {
+        "alias": "X-camino1a3l20l8nwejvkfszggzjeac8lepymh6e3pzm2u",
+        "addresses": [
+          "X-camino16qy2kwmv6xc9wdqpugv9h0udvrmkml5p6ltjkh"
+        ],
+        "threshold": 1,
+        "memo": "614"
+      },
+      {
+        "alias": "X-camino1avxc8uyqzf9hzwa9eacgg2x8y473j85sd2jwdt",
+        "addresses": [
+          "X-camino1xz37ugnp0aaedt2ur6j7qh6mljvksn00w5c2ru"
+        ],
+        "threshold": 1,
+        "memo": "615"
+      },
+      {
+        "alias": "X-camino15nnu9w2g3zj5sku9gl62gl5sdj6m5fdd2t8me7",
+        "addresses": [
+          "X-camino1ctxkgndq8vz082c9r7ef88u295pd2uux8nljez"
+        ],
+        "threshold": 1,
+        "memo": "616"
+      },
+      {
+        "alias": "X-camino17qgahrsfwkkvqhpacf330w37edwt2fdy0pp7ze",
+        "addresses": [
+          "X-camino1y4044a9ltvz6weh7qvm930x685fa9fap3avnq5"
+        ],
+        "threshold": 1,
+        "memo": "617"
+      },
+      {
+        "alias": "X-camino1uv72wn6ynluam4mmhf74vtfn7sq5xl9le4qvhr",
+        "addresses": [
+          "X-camino1eqqw5kc58pfw8p63r4grdwwh2u4u4rgfh0aazy"
+        ],
+        "threshold": 1,
+        "memo": "618"
+      },
+      {
+        "alias": "X-camino17ds4n2ukuj2nt46jtuep8z2gcv722ryajftwwk",
+        "addresses": [
+          "X-camino134sgvmyxja3gxgc7u73euespk7de0sfgzf060e"
+        ],
+        "threshold": 1,
+        "memo": "642"
+      },
+      {
+        "alias": "X-camino1zkny353z0srmc3yuajv2x2hjstkcun3aq3ww3u",
+        "addresses": [
+          "X-camino16jspkntmcazg5gal5r3sxmcuhnga990lx0ceda"
+        ],
+        "threshold": 1,
+        "memo": "674"
+      },
+      {
+        "alias": "X-camino1xp9tyghuh7j7a8exqk9uqpmyath7pklefm93zv",
+        "addresses": [
+          "X-camino1ytsp00yv55dg72xjlsh3l444a7xczmn20dhulf",
+          "X-camino1wte3r2tahcgewrluxtvdtm5zj3850mlumq7e7g",
+          "X-camino1n3tufnv7a7lvflwfp8zqx08pcnd5raeu0sa3yw"
+        ],
+        "threshold": 2,
+        "memo": "675"
+      },
+      {
+        "alias": "X-camino1xfj26sj8yjtzu632hwryw6k5k8q4t4a8h3jt65",
+        "addresses": [
+          "X-camino1df0n4cyl5gau4lvrhwn6q5wrn35yazj6lv9lfs"
+        ],
+        "threshold": 1,
+        "memo": "685"
+      },
+      {
+        "alias": "X-camino1swq7jndpq8seupaehfhpwc8tjy8z6j7zpn666f",
+        "addresses": [
+          "X-camino1zxq4yv5pdv0jt8xjjtfk0g3nejzqvvhlt22cgh",
+          "X-camino1ya0kfa4ydz5z74xd08u6mgrhzgskaxx5hlr6mu",
+          "X-camino187rxltxpmd6mnqjrhyhy3awxc28qr69j6ft74d",
+          "X-camino14xhnmly36ygyxynhshql7v280y3uvq03k5w62p",
+          "X-camino173ne9hrnyw9kzr9jkwhyn6x6tmpv7w3r043k80"
+        ],
+        "threshold": 3,
+        "memo": "711"
+      },
+      {
+        "alias": "X-camino1kfnsy5p7pfsqh76k5zzmj2kd5svaf0qwcfpt20",
+        "addresses": [
+          "X-camino1sejgq4uhcpwc66l7qetwhtd3qjst3ztrg5kvx8"
+        ],
+        "threshold": 1,
+        "memo": "723"
+      },
+      {
+        "alias": "X-camino1uaasrym74ld4esmdz6wjxse69zpjkmml85c36t",
+        "addresses": [
+          "X-camino1fxr6wspsapcykv4frwepq3pa9zkpqr3kgvcc6x",
+          "X-camino1dy2zwpxhdmcsujsu5culd5fw53enx3462yh7jt"
+        ],
+        "threshold": 2,
+        "memo": "728"
+      },
+      {
+        "alias": "X-camino1537zcugeec0243matenf36nc90qg0rhh2jkvc3",
+        "addresses": [
+          "X-camino1qfwkgqzmrmr9qvhr0l0ytchc9je045ptknxcw8",
+          "X-camino1yqg7wdnmgdr5230dspa9fc8x0lq6che752nuue"
+        ],
+        "threshold": 1,
+        "memo": "730"
+      },
+      {
+        "alias": "X-camino19hw2tjza5vuyjrgv0nlcle4mw573wxp507udyx",
+        "addresses": [
+          "X-camino1v9n5mvtwe4t2fdk0qu3n8akysct6s7wvu8spxz",
+          "X-camino1vhluqqdmlt0kr0crxxyqufuazd0zhqz7cu7uac"
+        ],
+        "threshold": 1,
+        "memo": "736"
+      },
+      {
+        "alias": "X-camino104gqfegwvksn3kfu95dn6upy48vtpuxcg6l8lz",
+        "addresses": [
+          "X-camino1zw2s64syjumgf7w4hqd5wj6dznevhvpq8uv254",
+          "X-camino13aj3nfpmjw3wrt45tsjtl5ekdtwqm2nz33tc9e",
+          "X-camino1m8nwlxcxu4rn4p8cck482j57zmc2knh0kjn8ag"
+        ],
+        "threshold": 2,
+        "memo": "745"
+      },
+      {
+        "alias": "X-camino18har8esnq6gww24qhgsq39g390mn8p7kmphn7e",
+        "addresses": [
+          "X-camino1qyp3dqghf3nmyhectuq09peyd4asqgntrpzfrw",
+          "X-camino15r60f5ehfs225n69vwnpuwk43s9zzwed222wym"
+        ],
+        "threshold": 1,
+        "memo": "757"
+      },
+      {
+        "alias": "X-camino1teh54u7kjz4p36l63utcu3jcfkygxjp4sl4j9a",
+        "addresses": [
+          "X-camino17lwvng3sjywe92qhdqdku3gazz57m0m0pxlyrd"
+        ],
+        "threshold": 1,
+        "memo": "766"
+      },
+      {
+        "alias": "X-camino1rpp52fc6d9gwr2pcshlk3565nqazqym4kyhev2",
+        "addresses": [
+          "X-camino1t0yu2fp26xwdw052m4v4549hw0cnehvn3gydn3",
+          "X-camino1t68x78yd5f0sujvn8mj05463mg9pycrls3g474",
+          "X-camino1ceyz5f8s5wagsnumj9d7felq03s0nrar83phej"
+        ],
+        "threshold": 2,
+        "memo": "777"
+      },
+      {
+        "alias": "X-camino17crk3v8k09p3hav0ekzvwqlc3kfrhreq279lks",
+        "addresses": [
+          "X-camino13pkc4gy9ver33wdgklxmq2e7zg5455nt7u08d3",
+          "X-camino1hygzrvnqflj397886wu6d6xvq6e6yx42nt7759",
+          "X-camino1lgu6sxcesryex7dvgrgsvljzu8sgll5z69hz6h"
+        ],
+        "threshold": 2,
+        "memo": "780"
+      },
+      {
+        "alias": "X-camino1d3cul3elpugpu99p62gpu8ml9mx6zhdrqcl4ja",
+        "addresses": [
+          "X-camino18qm3s0xd0tnm4jwj8ktkrzcvm76tql3dv6jsws"
+        ],
+        "threshold": 1,
+        "memo": "781"
+      },
+      {
+        "alias": "X-camino1cq4ge3ww6etrsa6t9695yyqmvgzus6l2056ufs",
+        "addresses": [
+          "X-camino1vtgvpxjplj3hw9s27gs9v7nh9pxtdp09qjjayy"
+        ],
+        "threshold": 1,
+        "memo": "815"
+      },
+      {
+        "alias": "X-camino1shlcs8lgwxcnsc66gs2yn0k0qqft77hpzd9ak4",
+        "addresses": [
+          "X-camino18nxlt5qepw236229nzpvhlgr9l7w9r6qrs23g0",
+          "X-camino1jwg48rzfv2fsykyyh3ypccv670c094vycj3kxg",
+          "X-camino1kgcurud2zcf2qczrnx74dd2zp73swfjmlh4nw0"
+        ],
+        "threshold": 2,
+        "memo": "818"
+      },
+      {
+        "alias": "X-camino1pvmnzwj7pdd4nec3kp0fgdf9w0hp9h6nfeaqek",
+        "addresses": [
+          "X-camino1qkte80a6czr976azxzquq4wp4pszw5l4u4f43e",
+          "X-camino17p9xatlue36mr0e805ff5ax88qzzt3vxxyzz2y",
+          "X-camino17d7y79mhq73hwwmq9rzet2m7hw4675ljxytsdc"
+        ],
+        "threshold": 2,
+        "memo": "833"
+      },
+      {
+        "alias": "X-camino12l7dlgqkq3ue89vsckgw35vv5wpp7605s3kmh0",
+        "addresses": [
+          "X-camino1nm89peu4d7m3g79pfrfnw4tn5qgzzyzk0hm67l",
+          "X-camino154vpf9x2m7fvm8lktqhe4hwka3n3jnvrptkvy7"
+        ],
+        "threshold": 1,
+        "memo": "862"
+      },
+      {
+        "alias": "X-camino1nzdp4qpj44dl7frlhfx2efh6mhq5c933644zgg",
+        "addresses": [
+          "X-camino1g85mkrpyuf5ns4vrl8hxeww8alqk2cq2ct35m5",
+          "X-camino12dudfc9wd528h27vc0uw7cm7ck0k6fgn0c6mwx",
+          "X-camino1ud5pmnj78wz0g3psfjg2cqpc8k37enfdrtxa6t"
+        ],
+        "threshold": 2,
+        "memo": "888"
+      },
+      {
+        "alias": "X-camino1ty8y07xy43el4w8awz7srwqc8had8ndyukfl9f",
+        "addresses": [
+          "X-camino1z5xllk949xjtaf3jyezq4tlu33ag2290ulg3vy"
+        ],
+        "threshold": 1,
+        "memo": "914"
+      },
+      {
+        "alias": "X-camino1n4c9txy82r8kklpvrf4m5fk5q3n3cj63zpfu46",
+        "addresses": [
+          "X-camino1z5xllk949xjtaf3jyezq4tlu33ag2290ulg3vy"
+        ],
+        "threshold": 1,
+        "memo": "915"
+      },
+      {
+        "alias": "X-camino1253vr70qkvynz4nyj6retgftjw8zu7zts4f49n",
+        "addresses": [
+          "X-camino18n04s6gakwehehtcwhj8gypse5y5lujfnvzqwe"
+        ],
+        "threshold": 1,
+        "memo": "916"
+      },
+      {
+        "alias": "X-camino14jw3xrysalfq33n22e4wgmfwnumjkt4ukn4wd0",
+        "addresses": [
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino15cn5qxxfs7ksulm22ra4gl0v76juct92z9khlw",
+          "X-camino1kxjatd557dtaflnpu8ulnh6hhq9hhll65eskqe"
+        ],
+        "threshold": 2,
+        "memo": "940"
+      },
+      {
+        "alias": "X-camino123q64vzr4kdsgxfntwujjhxapdakz4xs2cwec2",
+        "addresses": [
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino15cn5qxxfs7ksulm22ra4gl0v76juct92z9khlw",
+          "X-camino1kxjatd557dtaflnpu8ulnh6hhq9hhll65eskqe"
+        ],
+        "threshold": 2,
+        "memo": "941"
+      },
+      {
+        "alias": "X-camino1u3fe3uet9s08d0aja5zme7dy9yx23n8d7tweuz",
+        "addresses": [
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino15cn5qxxfs7ksulm22ra4gl0v76juct92z9khlw",
+          "X-camino1kxjatd557dtaflnpu8ulnh6hhq9hhll65eskqe"
+        ],
+        "threshold": 2,
+        "memo": "942"
+      },
+      {
+        "alias": "X-camino1mj0yc9kcxl22kj820dz8ktsmf8azkru0rfs602",
+        "addresses": [
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino15cn5qxxfs7ksulm22ra4gl0v76juct92z9khlw",
+          "X-camino1kxjatd557dtaflnpu8ulnh6hhq9hhll65eskqe"
+        ],
+        "threshold": 2,
+        "memo": "943"
+      },
+      {
+        "alias": "X-camino1xsww8kttcufckh84x49287u8wprz89rfhextn6",
+        "addresses": [
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino15cn5qxxfs7ksulm22ra4gl0v76juct92z9khlw",
+          "X-camino1kxjatd557dtaflnpu8ulnh6hhq9hhll65eskqe"
+        ],
+        "threshold": 2,
+        "memo": "944"
+      },
+      {
+        "alias": "X-camino1s43aum9ctvdyxgdfnyapqdfvy7ddjmc58ptrqm",
+        "addresses": [
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino15cn5qxxfs7ksulm22ra4gl0v76juct92z9khlw",
+          "X-camino1kxjatd557dtaflnpu8ulnh6hhq9hhll65eskqe"
+        ],
+        "threshold": 2,
+        "memo": "945"
+      },
+      {
+        "alias": "X-camino1ext8a4n2ufqvgfhunzq8cvlexz9w8xhxrqz0hq",
+        "addresses": [
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino15cn5qxxfs7ksulm22ra4gl0v76juct92z9khlw",
+          "X-camino1kxjatd557dtaflnpu8ulnh6hhq9hhll65eskqe"
+        ],
+        "threshold": 2,
+        "memo": "946"
+      },
+      {
+        "alias": "X-camino13r5xljkdl7w4g9tcqynfafm4g89mx52ektkrju",
+        "addresses": [
+          "X-camino1teeklahjnuwwfna5tvudvrswxerm2fdtsk3mt3",
+          "X-camino1jn87l4s3f0r2xa0kk3nw8n939pvkyjyzse22p5",
+          "X-camino1udd7y4uv9kfyh2jsckfztz9crgfve3gcxjmtm7"
+        ],
+        "threshold": 2,
+        "memo": "947"
+      },
+      {
+        "alias": "X-camino1eysxq4a0utnrzmjcfnzx227ahlcymd5shfcc47",
+        "addresses": [
+          "X-camino196w4wzzzgc5vu38jywtr0na3uh9ml8vqrw34ws",
+          "X-camino18pry238vq8uzzpar32wa4x4p2rkyc7wxmur7sd",
+          "X-camino1jpsr4vqdek4kt79ccndunxscyq2n09ljpz5aen",
+          "X-camino1k8k9cj9cvnky0zy8c7mqd9h63swxesd9x34l37"
+        ],
+        "threshold": 2,
+        "memo": "948"
+      },
+      {
+        "alias": "X-camino1lj38gmfuwhd9l3gcn0vavms64xe76ljpx5wu5f",
+        "addresses": [
+          "X-camino1s4wlx4rfsk6shfrtrw0kxunefy7we5nfmkc3h2",
+          "X-camino15cn5qxxfs7ksulm22ra4gl0v76juct92z9khlw",
+          "X-camino1kxjatd557dtaflnpu8ulnh6hhq9hhll65eskqe"
+        ],
+        "threshold": 2,
+        "memo": "949"
+      },
+      {
+        "alias": "X-camino1lsgwstc8edestl9v9t65kcfwjcy4gh8qhpvdej",
+        "addresses": [
+          "X-camino1ejmjsgslx2e2zqfu24xlthdnn5zt8255lt3dv0"
+        ],
+        "threshold": 1,
+        "memo": "957"
+      },
+      {
+        "alias": "X-camino14u3mjp2zwrm7l8v5x7yxn4ed5t29gu0y5zhtng",
+        "addresses": [
+          "X-camino1f90eqfg60h6mp79h332gf555xj8aq46m4ctk2v",
+          "X-camino10ucmxrt0wadn2fjxtkem8el9nwn29s3h22xru3",
+          "X-camino1sayrny8ynef94v4dhz849jf05n689cam3956f3"
+        ],
+        "threshold": 2,
+        "memo": "975"
+      }
     ]
   },
-  "startTime": 1670956381,
-  "initialStakeDurationOffset": 5400,
-  "cChainGenesis": "{\"config\":{\"chainId\":500,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
-  "message": "Travel around the world!"
+  "cChainGenesis": "{\"config\":{\"chainId\":500},\"initialAdmin\":\"0xa3ddc397f6b3022db33e1dc7897ab9d41db42492\", \"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
+  "message": "Bon voyage!"
 }

--- a/genesis/genesis_columbus.json
+++ b/genesis/genesis_columbus.json
@@ -14,7 +14,7 @@
       {
         "interestRateNominator": 80000,
         "startOffset": 0,
-        "endOffset": 114177600,
+        "endOffset": 116856000,
         "minAmount": 1,
         "minDuration": 110376000,
         "maxDuration": 110376000,
@@ -28,7 +28,7 @@
       {
         "interestRateNominator": 90000,
         "startOffset": 0,
-        "endOffset": 145713600,
+        "endOffset": 148392000,
         "minAmount": 1,
         "minDuration": 141912000,
         "maxDuration": 141912000,
@@ -42,7 +42,7 @@
       {
         "interestRateNominator": 100000,
         "startOffset": 0,
-        "endOffset": 177249600,
+        "endOffset": 179928000,
         "minAmount": 1,
         "minDuration": 173448000,
         "maxDuration": 173448000,
@@ -56,7 +56,7 @@
       {
         "interestRateNominator": 0,
         "startOffset": 0,
-        "endOffset": 177249600,
+        "endOffset": 179928000,
         "minAmount": 1,
         "minDuration": 157680000,
         "maxDuration": 157680000,
@@ -70,7 +70,7 @@
       {
         "interestRateNominator": 0,
         "startOffset": 0,
-        "endOffset": 114177600,
+        "endOffset": 116856000,
         "minAmount": 1,
         "minDuration": 110376000,
         "maxDuration": 110376000,
@@ -84,7 +84,7 @@
       {
         "interestRateNominator": 0,
         "startOffset": 0,
-        "endOffset": 161481600,
+        "endOffset": 164160000,
         "minAmount": 1,
         "minDuration": 157680000,
         "maxDuration": 157680000,
@@ -98,7 +98,7 @@
       {
         "interestRateNominator": 90000,
         "startOffset": 0,
-        "endOffset": 34128000,
+        "endOffset": 36806400,
         "minAmount": 1,
         "minDuration": 31536000,
         "maxDuration": 31536000,
@@ -112,7 +112,7 @@
       {
         "interestRateNominator": 110000,
         "startOffset": 0,
-        "endOffset": 65664000,
+        "endOffset": 68342400,
         "minAmount": 1,
         "minDuration": 60,
         "maxDuration": 31536000,
@@ -126,7 +126,7 @@
       {
         "interestRateNominator": 210000,
         "startOffset": 0,
-        "endOffset": 65664000,
+        "endOffset": 68342400,
         "minAmount": 1,
         "minDuration": 86400,
         "maxDuration": 31536000,
@@ -151,7 +151,6723 @@
           {
             "amount": 10000000000000,
             "timestampOffset": 3600,
-            "memo": "2+"
+            "memo": "ID:'2', Bucket:'01 ADMIN', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1nzdp4qpj44dl7frlhfx2efh6mhq5c933pwtxfq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 36150000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'3', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus146qrj047eaapww0mrv52zcg30ycljhhyzymztw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 11550000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'4', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18q6scezgt2646rzpc8fmw4jce5zmcvgvve76dv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2800000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'5', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1rf43hs576l0jj72haq0h4yq06lmv2pk844uygs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 11550000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'6', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jn87l4s3f0r2xa0kk3nw8n939pvkyjyztz5wqu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2800000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'7', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1crv6z0h3zdzj2mwjacelywa9twyg7wj98ktkul",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'8', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yqn8cjps7szj8pl2sj425fg2v7tjyz4rtkft0w",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'9', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus153uxhwgdunhyzmaq6t2azlp77aqpnlkpmdel3j",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'10', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15cxxvhc3v23z86duy7ryuaraqjgnzjfcm585m7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'11', Bucket:'02 Founders'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1k6y2cfw4tv8n2p6lydj9vnj2kefcs4sfg395gx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 9800000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "ID:'12', Bucket:'03 Seed'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus17crk3v8k09p3hav0ekzvwqlc3kfrhreq39mmhc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "ID:'13', Bucket:'03 Seed'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1gcmdk8edz6jfg2lk72229xs5r3nxcwv6t70mvf",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 13650000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "ID:'14', Bucket:'03 Seed'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1fp0gllrtxljv3gqwc2dq3vuq03vcrkrjkzhwpd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "ID:'15', Bucket:'03 Seed'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus124te92fnfl94nqdxknw8w0juld4e8rgmucwu2p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 6000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "ID:'16', Bucket:'03 Seed'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1hhqspfn3chrr8f23kdekcwl26a66nw7wkhlrp4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "Seed 3 Years 0%",
+            "memo": "ID:'17', Bucket:'03 Seed'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus19m2e8p6ce2yx9uf00rw5jm70l4w24x0sun4s4v",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1150000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'18', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1udd7y4uv9kfyh2jsckfztz9crgfve3gcaf906k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'19', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15gmmr9we6yhgd7z45ryy886cyqgeuuxctmtc6k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'20', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ca5yhrucv5haavjsw4m8nwx28tzva6f8gxh0ce",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 135000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'21', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12rxesrlk8qy6yydz9qegsx9rt9jj32gmuaethx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'22', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jpsr4vqdek4kt79ccndunxscyq2n09lj6e2ecm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1207000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'23', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus146qrj047eaapww0mrv52zcg30ycljhhyzymztw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'24', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13tfvfqqacg79akws0l42lktgc00q6e7wrdncke",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'25', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18q6scezgt2646rzpc8fmw4jce5zmcvgvve76dv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'26', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1vctr8ha7zna8fxdkazt5k6cnlj7fmg7enwf08a",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 215000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'27', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1emp8mkj8g24wmln7dskagu5a8r3p7qefw6gyqq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'28', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus10jsl9f669s9dn6zpxjgerv57pmhnaup5tuefuw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 3000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'29', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1f9z05t8uweh6e3e7q75xf7p4745hm5c850mvu0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'30', Bucket:'04 Team'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ku4xvfreup02ugju8ls6npyfeu2d0vp2g9x3vd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'31', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16g8j2vrcywjskaygezkm5rl40df6m063kj5axq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'32', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16dkxe6puk3y4qm7hjfvg2lwl8r92e27sf93f8r",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'33', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ty3unkry6cqhyyrv4hl6zuhx0k6z59xyzeh6tj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": false
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'34', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1s5nvfwlytnphhzjqm7ep9w7xe25zrep9hqtcue",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'35', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16kqqmrpa92upyxy63z02zjyuvdwjtlhzyt9pts",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'36', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yz03v8cyvgglekensauc8f40vn9mxdnt3ajjcp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'37', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus123q64vzr4kdsgxfntwujjhxapdakz4xs3rsaez",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 18600000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'38', Bucket:'05 Advisor'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus123q64vzr4kdsgxfntwujjhxapdakz4xs3rsaez",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1500000000000000,
+            "memo": "ID:'39', Bucket:'05 Advisor', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1mj0yc9kcxl22kj820dz8ktsmf8azkru0cjw7wz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'40', Bucket:'06 dApp Incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1mj0yc9kcxl22kj820dz8ktsmf8azkru0cjw7wz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'41', Bucket:'06 dApp Incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1mj0yc9kcxl22kj820dz8ktsmf8azkru0cjw7wz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000000,
+            "memo": "ID:'42', Bucket:'06 dApp Incentive', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1u3fe3uet9s08d0aja5zme7dy9yx23n8d9ssaa2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 45000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'43', Bucket:'07 IEO'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1u3fe3uet9s08d0aja5zme7dy9yx23n8d9ssaa2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000000,
+            "memo": "ID:'44', Bucket:'07 IEO', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xsww8kttcufckh84x49287u8wprz89rfvzc0jj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'45', Bucket:'08 Marketing'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xsww8kttcufckh84x49287u8wprz89rfvzc0jj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000000,
+            "memo": "ID:'46', Bucket:'08 Marketing', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ext8a4n2ufqvgfhunzq8cvlexz9w8xhxcmutkg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'47', Bucket:'09 Reserve'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13r5xljkdl7w4g9tcqynfafm4g89mx52edsg8n5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000,
+            "memo": "ID:'48', Bucket:'09 Reserve', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1eysxq4a0utnrzmjcfnzx227ahlcymd5svjxu5k",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000,
+            "memo": "ID:'49', Bucket:'09 Reserve', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13r5xljkdl7w4g9tcqynfafm4g89mx52edsg8n5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'50', Bucket:'10 Chain4Travel AG Initial Validator'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1lj38gmfuwhd9l3gcn0vavms64xe76ljpa0sc4p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'51', Bucket:'11 Camino Network Foundation Initial Validator'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1s43aum9ctvdyxgdfnyapqdfvy7ddjmc5u648pn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000000,
+            "memo": "ID:'52', Bucket:'12 SecondSale', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus14jw3xrysalfq33n22e4wgmfwnumjkt4udgt2v8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 40000000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'53', Bucket:'13 Team '"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus14jw3xrysalfq33n22e4wgmfwnumjkt4udgt2v8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15200000000000000,
+            "memo": "ID:'54', Bucket:'13 Team ', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1vedj99e90uppeyza86qmhyyhfcfyhh05wl0tal",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'55', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'55', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1tmq8ltmqrsud5ehqsd08lmg0vgxn57mkhq579t",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'56', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'56', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1k05g5q6alpm03ektp6w4y25uqz9nph7deqd5pl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'57', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'57', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1039z9rhr70sg02s2qysd0ydkxm4p5ljvf2m5fu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 40000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'58', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 400000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'58', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1r7mmvmcszwtzxjhpeu4zgj6arfztch6tu5ve98",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'59', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'59', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1f4c73ufv6d9z93580jau6ugky9px22y0ypzzut",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'60', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'60', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12kjwnczd3vcjctjjjwu58qs2c76ak4c3p4qd58",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'61', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'61', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jxlplag5299kcns2q86kzpp9jffvww3gj65k8u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'62', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'62', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1uv72wn6ynluam4mmhf74vtfn7sq5xl9lzw7gkt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'63', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'63', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1eyunyvyxfq8c9le0pc24xkdum2xehaumt3pf8g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'64', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'64', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrkg2ksc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'65', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'65', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus17qgahrsfwkkvqhpacf330w37edwt2fdy56l6r3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'66', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'66', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12e08wmmlauses9u4z7sj306mlpycq0gz5zkkrj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'67', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'67', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1gqe0v4mamv5gxj9qh4hanftkhqvpnzec438z63",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'68', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'68', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1hmrn6czfq65kqwfeq537ktp8ygzxdx4qc09s4a",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'69', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'69', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1su5tl8scmw4zwjnacaw48wkl8vlz0vkd93af9r",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'70', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'70', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus19fnu72sdpd0550h59g7gznlgrayzwulpr00ukl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 60000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'71', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 600000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'71', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1rklz6e8h8h4875pt55kgpwutd7gy3rps2mtnrr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'72', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'72', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1277jph854ltpp9zxavp4fk2jjurprsd9fyz598",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'73', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'73', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1scefvccult0p9g9vvk2zp6qq7n44cmumgv974g",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'74', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'74', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1lgjzmekp359u28dkngdf98spe88050swvzmm4l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'75', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'75', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1p6wvd9jd0dxueuseghgpnvgl979elus4acpsd9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'76', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'76', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus156x6huxhlqw28awt2cqd0q02qrfxne6h6t8v6q",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'77', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'77', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qtdntjtqcqqnvfsx4c5gc2phtktmjca8m0q0dr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'78', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'78', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1f2ur6q69hstytk7002mgqsuvhr9psmewhjts8z",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'79', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'79', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1cvd8ardpsynhgfhdaapf7akhqv6sc7m975mrdv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'80', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'80', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15nnu9w2g3zj5sku9gl62gl5sdj6m5fdd3selck",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'81', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'81', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus19vvz56u2c7mstv88fmnmlm2kfa8vyp2avy37c8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'82', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'82', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1zkny353z0srmc3yuajv2x2hjstkcun3am2s2s5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'83', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'83', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus19hw2tjza5vuyjrgv0nlcle4mw573wxp559zf9w",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'84', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'84', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus124aw7ncdfefyqm4srujj9h3yxt9qzpsartnjtj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'85', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'85', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ydmngswj235mczwktxz6d2zj64nh5cp8v0f0tt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'86', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'86', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1gyk9tf69huuc7lrrt6myuzufg4zv4tewl4m5lz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'87', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'87', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1lf62vgkt80dcgq0ljmjedvptrj8h93vnqzv38y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'88', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'88', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1zc75guv3vwlhheq76egjesu23eccaa9ke5m62m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'89', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'89', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1cmtfkrzpeau8jy87cftmr87x5vs8vrg2py88cd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'90', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'90', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus154ys5gaceac0m2sj0fskwzptr6tl77lwz2s4dk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'91', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'91', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1tvlzzcgfey8mc7z3mhwepk84kagutdwm459wah",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'92', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'92', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1pvpjqg5p8xwqgcjeqv5vzdlmzlmpw06wvzk8dn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'93', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'93', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ldtg0fl6reuf9w27w6xt9hvqfjal7lggdm0zse",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'94', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'94', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yfpzkqaqgqrs4z4ta9stwht4cgmfqeae9k6kj2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'95', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'95', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xfj26sj8yjtzu632hwryw6k5k8q4t4a8v2v0mu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'96', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'96', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1a3l20l8nwejvkfszggzjeac8lepymh6e26ult5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'97', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'97', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus174v5ghmdy20xtmyjnqsmnn6yv99jcxtmrt9nhq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'98', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'98', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13yjkkxgkg0mk7k727f30hwy78zukld6z4jnz9d",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'99', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'99', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1edf9wnssqddknydsdym28al5axq7dum70kr7gh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'100', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'100', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1pfl4x5q63wl6e76m2jrncxchsh4eruw33d7l75",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'101', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'101', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16g8j2vrcywjskaygezkm5rl40df6m063kj5axq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'102', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'102', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1258ga93qdkk7x58rrfp88zt5y9w64sr662ejed",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'103', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'103', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1k6z0skaz3333445zz6vgl9nsmzkm2a89atgzpc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'104', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'104', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qh9nzgm6q5cfa2mpshwu9guzahf5se7f8cs7g4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 600000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'105', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 6000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'105', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jm8694tdqc6q27my8wnwhe7mmpl93scy2ck8dn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'106', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'106', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1nsh2rw3sjvylgd9gk3jpmfx4dlfgm92yy49540",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'107', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'107', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1uxp2phhpxh7q2zrfmy8pnzt4q9ytg084c6ue3y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'108', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'108', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1nkjv6uvpn0u7qg5g24yaey0ch3upjgcyr608j3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'109', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'109', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1pg3wvrpe3efjt8phj5pf5ftmrk66jr5leq5kf3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'110', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'110', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1rn52cw296jemvujuv6h9824aezv3w2p4jdpfg8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'111', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'111', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1txd4zzds5w07vw7hk9cwmuq3fv0e42uecnf5ut",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'112', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'112', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1zqt6l7yyks097mf4errxd2wjcz6mxd96nf4e8n",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'113', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'113', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ga0ut4yez75rp8077g77uycgchnxyg28n8t2st",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'114', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'114', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1j2kypzc2t4l9qd57qh8ql3ujng65cr33qvugxc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'115', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'115', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yfq50nt44nvf8nt03cqdtwazpw6lthnkwtvczj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'116', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'116', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1scyvhvrepne0fekev9kw6w0u4caq5dyss2z9h8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'117', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'117', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1f2cy4rqyg76q8l8e7xpagj4qgx7nzjdc6amr68",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'118', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'118', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus19ayweyate24cq9enm97mys6yvpj4hg0t6ugz46",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'119', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'119', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1hu4fnqlfze3kedxy8dgg9d2g9uhr9zwg67pa08",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'120', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'120', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1sgctncsl8zaryp5w62xp25qqjhskzqr74p7dfd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'121', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'121', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16273wcdf2jvytsauu7jd78sjp4fh2j8qdhmktv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'122', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'122', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15esv7xd09h2y0fltt83zxgqtzw9xxprkj83csn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'123', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'123', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18har8esnq6gww24qhgsq39g390mn8p7kq6fhl3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'124', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'124', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ty8y07xy43el4w8awz7srwqc8had8ndy8dhmyp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'125', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'125', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1c3kd4e02r5mzg83ezs7yxhwrvyfstqnjpfvrld",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'126', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'126', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1m56g7kzpyvwlcc3mzz9rs5x4u3xuqasq8w66s7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'127', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'127', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1dxd66ecwj99xyezr4p5fq7cfwcqqhj29vxlzu9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'128', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'128', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ml9g8xcuemh3gly6pn90udkadtvqk49u8pc3mz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'129', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'129', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13384dvk54kl83cdcapcl6nzxq35nxlwex4g4xg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'130', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'130', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1a28tjjxyplz3uq0737tgwv7k29e8dj24xeh877",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'131', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'131', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xwerkdrpkuhq0u9uprvp0dms6tc7y5annjys5f",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'132', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'132', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1muy0sy676mc383d566he9lw5a32dkslfkncxur",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'133', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'133', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yatmadtt3qpn7em0r2vmd6ncavdqjlf7fn2hd3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'134', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'134', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus10thamqpnlvawz4zqayvj7t9s0x6uzwz6vq2jdj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'135', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'135', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1y7mc7hekqxxhuerst0ukpeq9k63zy3782nr3dt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'136', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'136', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus153ejpsghh0tzamey70clpcd7g0y9r6g677x0f7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'137', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'137', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1lx0paymqrp528j5t9hjks6auapgfq49vemvrhv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'138', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'138', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1fxsxvek9w0u6q2dy5zkcqxqqlf0kje67s7rd8u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'139', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'139', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1zl5pd3x9h2tj47v7nfwusue3t3lu967zg6udud",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'140', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'140', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qmgvg3qw95ft4sww5lkk0vkypjs737fdtu3rhk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'141', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'141', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1anj83lc0h839vmvltws0a6h7k5znlyq84hp6m0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'142', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'142', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvgnmvh9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'143', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'143', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qwu3jm84hr3sh9kpst3gxlakd22r5vjakwjs8d",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'144', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'144', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ysa48z2anf29ckcmg8rak384s0k8uwd2cx2234",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'145', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'145', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18eqxyetaqt8kym2nqhat532gxtewfsvk3ely5n",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'146', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'146', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1kklwkxzvuefl4kvg4dkzw8hp5dq2marxkdh2rk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'147', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'147', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtadmsx8e",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'148', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'148', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1wgepplh320jtxdfwpnlr3pqpt4sj3xctzq6h2a",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'149', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'149', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jl4gs84hu6s2k24kxrj7549seyczw5cr5asaxg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'150', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'150', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1c78g2twqemmav8dr0u6cncuvn9nf9zm35ctkc5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'151', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'151', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1td7w8a2ktccxktvh72275txv4dpzcn5y785zff",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'152', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'152', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus14u3mjp2zwrm7l8v5x7yxn4ed5t29gu0y0ef0jq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'153', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'153', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1t7hagl6tr9hj7hvt66xv73au3edt8fj0aagwk4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'154', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'154', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1p4xp6m8qgt202aqklwcnhfqx5rg9c2hucrj7qv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'155', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'155', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1cdr7whau0kjreg2u6awc4k04jx2yp2sw5p6y6l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'156', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'156', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15xxam9nwdz53wdl9zsewqpnjel0arf0wqvl2h5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'157', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'157', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1smeeegnxaaamfazx98d0qpnrkkx5qrwkve3rza",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'158', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'158', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1537zcugeec0243matenf36nc90qg0rhh3fggee",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 300000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'159', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 3000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'159', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1cvt8hhmkysu5rdjzvdvvp70tq5u7ae4pq8kw9s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'160', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'160', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15dw76k56hd7x2s7k9rnvkzsv56sam5ujwtfp00",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'161', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'161', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1cvd8ardpsynhgfhdaapf7akhqv6sc7m975mrdv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'162', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'162', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ylvqqfp9fyyr52rnpl4faghh5fmzm5fh4nr7g7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'163', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'163', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1upeztlw8cktcf8w78ayt72g65z05egnxgt6z9l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'164', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'164', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xp9tyghuh7j7a8exqk9uqpmyath7pklejqm4ry",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'165', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'165', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1uaasrym74ld4esmdz6wjxse69zpjkmmlu0x4mr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'166', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'166', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1enn02mahvwyrjdca5htg9rydqrnksscmsjhx4n",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'167', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'167', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13m4yh7ztmps4hjsnyhwy0rxyh6w7ufj6kgqkeu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'168', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'168', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1d68vs6523kp60s8ls67pexr5wmx539na8cm98x",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'169', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'169', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1z0hl0jpetf53mxj8d7n9mt70l0l99ng90hxsse",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'170', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'170', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1zpkv5m338vccu9d5fln6wysjdhl05wp2q7y0he",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'171', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'171', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18n7y8k9yfv9ah4knxhll9hhuaf0r0hgr3qr3wq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'172', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'172', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1rpp52fc6d9gwr2pcshlk3565nqazqym4dlfadz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'173', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 25000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'173', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1h7u9p4pa9faxj3zezs9udxvj8quuqymrxmnfun",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'174', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'174', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1kfnsy5p7pfsqh76k5zzmj2kd5svaf0qwrjl0t8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'175', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'175', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1lsgwstc8edestl9v9t65kcfwjcy4gh8qv6jfc6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'176', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'176', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ztkd0srlqersv4c53kfg3cc5kg03ww79wprwcj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'177', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'177', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15r9s9pctuhf4as2h67naa7ct58fnpn4sx6dx7u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'178', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'178', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus104gqfegwvksn3kfu95dn6upy48vtpuxcnppr72",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'179', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'179', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12neqhcynnfy82lxcdcgj0lmqazr4yn77lmyrdr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'180', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'180', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus120jls24pylcuf8jpu55a0nle9r776rejxupxwj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'181', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'181', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15mzhyljgn57752z877zwshx2kfm4qp4a2e2zmf",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'182', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'182', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1253vr70qkvynz4nyj6retgftjw8zu7zttwh3ym",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'183', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'183', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1urux0644x3gdp7n40z5qfj0zxd2wzhegwjpprk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'184', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'184', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1n4c9txy82r8kklpvrf4m5fk5q3n3cj63e6hc5j",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'185', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'185', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1396cw839aatmnf2f3nmuuh6p6zn2vesym8ucrn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'186', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'186', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1nqsk0mwued2l8zy7calqhnemxuzct89xwgpgwm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'187', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'187', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16ryrmg6csk09mmnswmnkdvtv2a7ug07792trp3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'188', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'188', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1u3p0peu345nvsnh27jcqun2yq89le838lycxp8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'189', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'189', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1kje90w7g29xjwps75qwqyca84yvetp343au0ls",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'190', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'190', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1t5ayje5edr2msh2dqtg4m6xp0fuv4k3qsw4fnd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 600000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'191', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 6000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'191', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ldpfsrvxh674jze42wxr7nwsrwatqpjnlyz6d5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'192', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'192', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1slw8htng4clqqwyk0nfvrydte2prmt2fkxhscy",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'193', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'193', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1t907jgamny9vqkl3ec7sfpdvskqf6wspzexqwn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'194', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'194', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xpj2lh6dzlx22pjuyaelf75g0vug44qgvzfu5u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 500000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'195', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 5000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'195', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yqgm4zkumgv5hf2afp798arjm59tat3vz7p3v0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'196', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'196', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15tt8kvkah5qcs8r24d9v7w2eymg4hq2nd9qvg5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2000000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'197', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 20000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'197', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1vwlkq9xandunkreu49gwkql8vtnxa0ltty7rhu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'198', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'198', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1vw4u7j0dwzampvvmyt65rckvfjyykkkgrcht5l",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'199', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'199', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1els93ysuw4ansfqxe55wlf7ca2rzl0xhvzm6qs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'200', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'200', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1gxw932wm6g0up8pt76af60y4racuugedpfqjfw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'201', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'201', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15nanl7nh4p8f0w7d35xy9z0zg2e6cagq4fw57v",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'202', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'202', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus19gk9fzxx52u2lshxvpsp76vamj4q265chsr6na",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'203', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'203', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1shlcs8lgwxcnsc66gs2yn0k0qqft77hpekmeha",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 2000000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'204', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 20000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'204', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12ymv8mufsrdal5ej3ce9cyjwwmu7kclgxntgln",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'205', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'205', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1d4326e6qataqhz5zpfjtsvg0325pqpd69gfcpq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'206', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'206', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16wusq5lzn8ngtea7ff4e3v9thzxlac70s4l3k2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'207', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'207', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1236v9648strvh8xmvl3g7hcmxmn5q736pkhl8w",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'208', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'208', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1rdh6676x0fdevchtu2xjxpm0pf9xun4kvsscvm",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'209', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'209', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1vntz0u4d88yjxsfm9rmpczrx7295wu9gx2m7qs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'210', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'210', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qql75cyftxtf923vny3qr9hkmdayyny6yss3de",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'211', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'211', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus133alnuggsul62aajwhynp7uhsvc8val6f9afs6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'212', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'212', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1swq7jndpq8seupaehfhpwc8tjy8z6j7z6gy7mp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'213', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'213', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jgvgunr3jck6tn7xkzdrrj7khlge7rkvyenpej",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'214', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'214', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1czgaf8lqfu8cfa74gyuh8ngtfysqlm0xag2psh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 141912000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 4 Years 9%",
+            "memo": "ID:'215', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'215', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ak489h9rs6e728wvrgpkx7rzuu9hf4kusjw968",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'216', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'216', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ry0f50cfu670mxgj0nz6rz0d9jwqyg2kxygsdt",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'217', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'217', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1mcs8pk0f67p9s0mmtz9eyph26kp848rdtgllk8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'218', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'218', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus14kmjrlcreau6duuh3a4r78p30rt9caugy6ahrg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'219', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'219', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1mp7f8rt2jd604ywnhetk2xq4mmj9qluvaj5fxx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'220', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'220', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18fwezlvf9knlalnevyj20lrk6459ypyyvnkzt6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'221', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'221', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1dukvf6l4k928t4ngpcd2w3h3zyvnd278cexqek",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'222', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'222', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12eah23v9dcwcsjps267777klj8kkvwdyltnxrw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'223', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'223', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1heerqcl59yn3jtw99szd8l7q7a6jq24h680rwn",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'224', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'224', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qy5zgzyxn7j22gtj5pd0r8gdgfrsduwrqud6an",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'225', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'225', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1udazut0vnsnsj674sl7zngtguxh9ze4m6e3ecu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'226', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'226', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1hs88mzs5s37t8nueennxy7gxz2stdpjey5mxcg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'227', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'227', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1kklwkxzvuefl4kvg4dkzw8hp5dq2marxkdh2rk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'228', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'228', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1auylykzk6zqxsvrrx6gy2dc4v4l9fp3ttxp7h0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'229', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'229', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1mxzvy5vpt7danrzvgkvvlw3x7wypea3lekjfsc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'230', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'230', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1q50k78pse6vky5gwdsmuf7njcp8ahdlun45uc5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'231', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'231', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1avxc8uyqzf9hzwa9eacgg2x8y473j85sk3v2vr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'232', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'232', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ne69lm0mplfxcxmqlv3ls6wk5z8m3tc3kc08q6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 15000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'233', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'233', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1sey28879jhn9uy822u38vxw3uke8pazwtapvza",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'234', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'234', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1lc4qzvsqfzt2yy9k4596v394se6pg97lqfjvch",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'235', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'235', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus17v6mxjg8t0w5lq9w6qx76k3p7ar7z8q2d00wzh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'236', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'236', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1sd7q4a5v0t3g3r86uzwzkmxdf5mqs6unzcszua",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'237', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'237', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jp56myed7nwy3sre4u445mepkpe79ymmejapwu",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'238', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'238', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus17z889qchneqk94x9mjxw0m0xgcgls9d52tqfdq",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'239', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'239', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1kfapm9d2r8n5rmjvvv5284qp2rdr7t69g8psn0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'240', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'240', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16l5nmctdj4qqk4zqmy8zlkmsaypjzkw4zvh9hf",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'241', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'241', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1sjsdrw4avghcnvm4rkvsd5clhcujgm8d63mwh3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'242', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'242', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1am4366ap64h8gftnfd5xcx6gspk237y8hcdfyk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'243', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'243', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1u8cuvpxmq807q95newex63za3kpw3nqwlftvl3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'244', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'244', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ezjkht68k5rz69c5xeetn59vs3wmw6ffxwcsr3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'245', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'245', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13kzrxg5y4qs97qzf4zdqw9m4z9ydkku6a8njhd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'246', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'246', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1gqj0qsm8dhyer2alw57rwvt0wqp8hhvku2pjyf",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'247', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'247', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1e9kkysfkfq5xr93qyyxsfz0mg43x2fgdywma4y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'248', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'248', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus124qh486fhjst6c2zysxgvusz0vlu867qg2pz8v",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'249', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'249', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1whhfteexl2x4sdl0jfs4nqvdvyh0qx7hhnjgec",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'250', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'250', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1f3jtdegkvq8m8avdfqs478hg94xu097hqdd29v",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'251', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'251', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yyrg823l0pjxvtle9d4hjqgegttharh4def6y7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'252', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'252', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus19jfth3scmug3640fq5zhpye5cw88yqryee55sz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'253', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'253', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1kpd227tfx0x9mfcg4m62tl2mm9d7eag0q4l3hx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'254', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'254', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1sjxkh9rcjjt4n3nj907rhh5ejey4wa023vpwmp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'255', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'255', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1u5s70nmxd7pydjtt70kp842h9pjn3sfupd673a",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'256', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'256', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qcjys29pzv8m75fdt9nszl0llkhjv4n9m0pf0s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 25000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'257', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 250000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'257', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1k0lnzgar08aa95daf5k066kvuvj0fscxnz9866",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'258', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'258', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jjrm4p75euylsy70jxr9p6dsjnnec3qmwnjys9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'259', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'259', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1la56pfek0mpc0x476k40h97kwkh0g73jcx9rk3",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'260', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'260', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1aytql7x689t96yvf5ctdr23d2gx646lv3fhf5h",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'261', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'261', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1y30tmzcz0na4nu0uqdh4460dute9nwhvlq6c8t",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'262', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'262', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1vpqxc97jyqecl0arr7t0je08z06nljv0ls7yyv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'263', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'263', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1whe7zklwmyxw4ct0x2wsex0ztcfd0dyyva074q",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'264', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'264', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1k8ahvt0k5uyycvtzs94cavjk26ratnhu42xtlp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'265', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'265', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvgnmvh9",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'266', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'266', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1wtjqyemv7ud2t8mzr9m5p25sruukkvq57m7nd8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'267', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 4000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'267', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1dzkq4k65usyu6ehqp28wemdjyj84jjzn5vrylh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'268', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'268', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16mam24ag695vh9tdfwsxeejg3wtg0ms33ptjg2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'269', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'269', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ejtfvvpd268hg8xdjpxfagcnj7x52cep8ch0r0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 75000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'270', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 750000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'270', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1d3cul3elpugpu99p62gpu8ml9mx6zhdrmrp3n4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'271', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'271', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus15trkm623zm2r23j2hrqjsry636sckxcz9euyfh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'272', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'272', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus196lwrtuwr2vf79r5jympkjugtsmxkgtwh080zj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'273', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'273', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1gaxcm3petj9z6kvp2w5kcr4usvdvq3hvj5cyjd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'274', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'274', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1tskv880tp95hrpqs7wrqxmp7wrmmr3lc4hvenj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'275', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'275', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1zddlpr6hjzjrunts8qdzkwfpx02nu274fhmfer",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'276', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'276', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18q6scezgt2646rzpc8fmw4jce5zmcvgvve76dv",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'277', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'277', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yws8zcjfsnfgq39c6chsgtm94mt9596m06zm40",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'278', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'278', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1gyk9tf69huuc7lrrt6myuzufg4zv4tewl4m5lz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 50000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'279', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'279', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus160l526l8mkfjeacnhyv5ucvp6uekv9ccvvuyvw",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'280', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'280', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13hvsse9lhszwcktwyy74tgzzzmrqvjxkwgatw5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'281', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'281', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1gxvvskyrpk7cjrd934rgmmxysqrvgqy7pkxft0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'282', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'282', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16g5l0fngqc9dlzvug7k6el6syey8r375rs4n7e",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'283', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'283', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qtnwfkkvwl5haylwl4ppy9tzkffmq560a280k8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'284', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'284', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1j8ux8qvav9rv36zw6e5lkwcdupazruadz4xfda",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 70000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'285', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 700000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'285', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ml9g8xcuemh3gly6pn90udkadtvqk49u8pc3mz",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'286', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'286', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1mq4ruc3zgamspv94ej3ws8c35crqgwyxztyk7u",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'287', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'287', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13ugty8yv3xn96kcet56kkvjx26m9e88v8fjh7m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'288', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'288', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1qajjjmwlnytjfe6l8jtqhev4helx9x47hn6rdl",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1500000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'289', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 15000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'289', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1hv5tlf84nxcqkvsdtnetfdyw3wfnvhl9emvmqs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 30000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'290', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 300000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'290', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12l7dlgqkq3ue89vsckgw35vv5wpp7605t2glk8",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'291', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'291', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1j9nsdtrff2m9w97m7wsnxwyx7dvax2v2cv9mfx",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'292', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'292', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12n9pnwrh2rqqp8a9kad6wadc2hc62ts7e66l6t",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'293', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'293', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ypmdpy7tlep95za2nt9tx5a8tvjykxxssa5kga",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'294', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'294', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1wgthf6t2m26sgfenejht7agnzm4wqa204t0x0s",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 20000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'295', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 200000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'295', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus14f5k9f27nwagph2f46xlcszqa8zq9zz7pfnndp",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'296', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'296', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1hc9ffgdtgeznl4h08gckxncv8at744t9y33c9m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'297', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'297', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1pvmnzwj7pdd4nec3kp0fgdf9w0hp9h6njzryc7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 115000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'298', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1150000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'298', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1teh54u7kjz4p36l63utcu3jcfkygxjp4tytky4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'299', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'299', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1cq4ge3ww6etrsa6t9695yyqmvgzus6l250ycgc",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'300', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'300', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus17ds4n2ukuj2nt46jtuep8z2gcv722ryafj4207",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'301', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'301', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1jvtwr8mx0c6d6dx5x35s2rxlh8scpwnsnu9lr0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'302', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'302', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus165zf3m4ct6rsdkn49mpk5tlwla7hc9u8pjy8yj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'303', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'303', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus19kqmnj2w4ypdw33zltukr9dgtwur56ydp48e57",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 5270400,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'304', Bucket:'14 Presale'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 5270400,
+            "memo": "ID:'304', Bucket:'14 Presale', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1lmwsgy9zv8hyxwsek0pvsq7cpejtkvwkq54uvj",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 286,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "FlexDepositTest 60s-1Y 11%",
+            "memo": "ID:'305', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 2592000,
+            "memo": "ID:'305', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12tqp70mm2ak9lfh9j9eqyldkpey5ntlx8mkftr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 120,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "FlexDepositTest 60s-1Y 11%",
+            "memo": "ID:'306', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 2592000,
+            "memo": "ID:'306', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1maff3tql60ndkwn9mvz06ssywvag4uf4d73csa",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 864000,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "FlexDepositTest 1d-1Y 21%",
+            "memo": "ID:'307', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 2592000,
+            "memo": "ID:'307', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12tqp70mm2ak9lfh9j9eqyldkpey5ntlx8mkftr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 86400,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "FlexDepositTest 1d-1Y 21%",
+            "memo": "ID:'308', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 2592000,
+            "memo": "ID:'308', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -171,12 +6887,175 @@
             "depositDuration": 110376000,
             "timestampOffset": 3600,
             "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "3"
+            "memo": "ID:'309', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 3600,
-            "memo": "3+"
+            "memo": "ID:'309', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1fm0ny2lghpfepry46usu0a8yrm90r90s6rx8f5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'310', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'310', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus102uap4au55t22m797rr030wyrw0jlgw27m99k0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'311', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'311', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18gw475en5h5jvtkslp7xqed7t7ugq6rmjjvpk2",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'312', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'312', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xw2kqx2xzqsvnuecz2yw6fwpt87k48s277n30m",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 2592000,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'313', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 2592000,
+            "memo": "ID:'313', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12tqp70mm2ak9lfh9j9eqyldkpey5ntlx8mkftr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 250000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'314', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 2500000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'314', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1whcusz08xtlx0dgmrsxqt7a8gupgzd32fn7fme",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'315', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'315', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1yzx5v9hjjxth43ajer93pdt786s22ag8pqvsd7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 200000000000000,
+            "nodeID": "NodeID-Gp6VToHm6CEY2abT6g7g4je5KEtm32NBY",
+            "validatorDuration": 31536000,
+            "depositDuration": 110376000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "PreSale 3 Years 8%",
+            "memo": "ID:'316', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 2000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'316', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -196,84 +7075,12 @@
             "depositDuration": 141912000,
             "timestampOffset": 3600,
             "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "4"
+            "memo": "ID:'317', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 1000000000000,
             "timestampOffset": 3600,
-            "memo": "4+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18pry238vq8uzzpar32wa4x4p2rkyc7wxq8a639",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10100000000000000,
-            "timestampOffset": 2592000,
-            "memo": "5+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1prxyey5xugn5c6tqusha9m4hd4rvld23ag7y8x",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 354203350000000000,
-            "timestampOffset": 3600,
-            "memo": "6+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1er4q5rqwl5955y39dyshj8kr9tut3krgz5fjvd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "7"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1fm0ny2lghpfepry46usu0a8yrm90r90s6rx8f5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "8"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 3600,
-            "memo": "8+"
+            "memo": "ID:'317', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -291,510 +7098,12 @@
             "depositDuration": 141912000,
             "timestampOffset": 3600,
             "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "9"
+            "memo": "ID:'318', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 100000000000,
             "timestampOffset": 3600,
-            "memo": "9+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16r6ppaekevfkfrpnr9vfhy09tgupderyf3q6tk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "10"
-          },
-          {
-            "amount": 100000000000,
-            "timestampOffset": 3600,
-            "memo": "10+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus10jd9cn8gw4h75u9wlns6qs022776ljsta9gv8w",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "11"
-          },
-          {
-            "amount": 100000000000000,
-            "timestampOffset": 3600,
-            "memo": "11+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18l0l8dz03vmk7k7y5cgax8k2l5mphj4p73ph4p",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "12"
-          },
-          {
-            "amount": 100000000000000,
-            "timestampOffset": 3600,
-            "memo": "12+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1fjv60r0t87y2m3p49he6gnmgvaze9anhslqxjh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "13"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "13+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1zawetvfggky6yvx5wdcn0tjsalw9ql9dz537x7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 300000000000000000,
-            "timestampOffset": 3600,
-            "memo": "14+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16uhlmjm9nj42gkmexjy5c3x58uadfl6sl9vxd5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "15"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rf43hs576l0jj72haq0h4yq06lmv2pk844uygs",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "16"
-          },
-          {
-            "amount": 100000000000000,
-            "timestampOffset": 3600,
-            "memo": "16+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus194sm66h2qrmtae7gcesnmxdstzqv0mpt7k2snk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 101000000000000,
-            "timestampOffset": 3600,
-            "memo": "17+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12a96grhwgmv489kn9zn5rdm2vj5y8yhush4xu5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "18"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "18+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1tdw5tlm2ccnavy8ndq90c0c55d5qznefcqmg8y",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "19"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "19+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dty07uqqndf22dqkgfq4ysa9nucg33q2kv6j68",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "20"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "20+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ftrh6sly2fh4k8rz4wwp60jj4dfdtg2xxkj3e0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "21"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "21+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1e3zck3mw3z620ujulx96cm4zvs0qdfnljz5uyf",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "22"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1sltcgxr6s90uexlghpqf3qlwh0ptpknx00n0xr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "23"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "23+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus133a4vhn0qa6fzf8434zzy80pdzefq2f8xfuudr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "24"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "24+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12ymv8mufsrdal5ej3ce9cyjwwmu7kclgxntgln",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "25"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "25+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12pz34dgmhe6ahdruf66nvkfrz50mm9zs6nr9sk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "26"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "26+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ytsp00yv55dg72xjlsh3l444a7xczmn25kfc7p",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "27"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "27+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xe5hkpx5w7ryky3ddzjjdwmuuvf8dkpfltnr22",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "28"
-          },
-          {
-            "amount": 1500000000000,
-            "timestampOffset": 3600,
-            "memo": "28+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1d0ydd4wyq670lzrp0y7xd3wej4z7ysp26md7p6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "29"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "29+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13lcv2qp3jl8kkz7hm4uwf5scquvsfnx7q370cg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 31536000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "30"
-          },
-          {
-            "amount": 1000000000000,
-            "timestampOffset": 3600,
-            "memo": "30+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xa6vsx5pwyk7adyz00ldj7n73vr4qma7xfhds0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1010000000000000,
-            "timestampOffset": 3600,
-            "memo": "31+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus102uap4au55t22m797rr030wyrw0jlgw27m99k0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "32"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 3600,
-            "memo": "32+"
+            "memo": "ID:'318', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -812,12 +7121,35 @@
             "depositDuration": 141912000,
             "timestampOffset": 3600,
             "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "33"
+            "memo": "ID:'319', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 10000000000000,
             "timestampOffset": 3600,
-            "memo": "33+"
+            "memo": "ID:'319', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16r6ppaekevfkfrpnr9vfhy09tgupderyf3q6tk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000,
+            "depositDuration": 173448000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "PreSale 5 Years 10%",
+            "memo": "ID:'320', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 100000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'320', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -835,35 +7167,12 @@
             "depositDuration": 173448000,
             "timestampOffset": 3600,
             "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "34"
+            "memo": "ID:'321', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 10000000000000,
             "timestampOffset": 3600,
-            "memo": "34+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dgrg4j4p5e6k5jn8080n6333r934pyum99x6c4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "Undeposit 5 Years 0%",
-            "memo": "35"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 3600,
-            "memo": "35+"
+            "memo": "ID:'321', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -881,12 +7190,29 @@
             "depositDuration": 110376000,
             "timestampOffset": 3600,
             "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "36"
+            "memo": "ID:'322', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 10000000000000,
             "timestampOffset": 3600,
-            "memo": "36+"
+            "memo": "ID:'322', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1er4q5rqwl5955y39dyshj8kr9tut3krgz5fjvd",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 157680000,
+            "depositOfferMemo": "Team 5 Years 0%",
+            "memo": "ID:'323', Bucket:'99 TESTACCOUNT'"
           }
         ]
       },
@@ -904,12 +7230,462 @@
             "depositDuration": 157680000,
             "timestampOffset": 3600,
             "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "37"
+            "memo": "ID:'324', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 10000000000000,
             "timestampOffset": 3600,
-            "memo": "37+"
+            "memo": "ID:'324', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1dgrg4j4p5e6k5jn8080n6333r934pyum99x6c4",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1000000000000000,
+            "depositDuration": 157680000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "Undeposit 5 Years 0%",
+            "memo": "ID:'325', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 10000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'325', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18pry238vq8uzzpar32wa4x4p2rkyc7wxq8a639",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'326', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 100000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'326', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus10jd9cn8gw4h75u9wlns6qs022776ljsta9gv8w",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'327', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 100000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'327', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus18l0l8dz03vmk7k7y5cgax8k2l5mphj4p73ph4p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'328', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 100000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'328', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1fjv60r0t87y2m3p49he6gnmgvaze9anhslqxjh",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'329', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'329', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus16uhlmjm9nj42gkmexjy5c3x58uadfl6sl9vxd5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'330', Bucket:'99 TESTACCOUNT'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1rf43hs576l0jj72haq0h4yq06lmv2pk844uygs",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'331', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 100000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'331', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12a96grhwgmv489kn9zn5rdm2vj5y8yhush4xu5",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'332', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'332', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1tdw5tlm2ccnavy8ndq90c0c55d5qznefcqmg8y",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'333', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'333', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1dty07uqqndf22dqkgfq4ysa9nucg33q2kv6j68",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'334', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'334', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ftrh6sly2fh4k8rz4wwp60jj4dfdtg2xxkj3e0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'335', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'335', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1e3zck3mw3z620ujulx96cm4zvs0qdfnljz5uyf",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'336', Bucket:'99 TESTACCOUNT'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1sltcgxr6s90uexlghpqf3qlwh0ptpknx00n0xr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'337', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'337', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus133a4vhn0qa6fzf8434zzy80pdzefq2f8xfuudr",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'338', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'338', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12ymv8mufsrdal5ej3ce9cyjwwmu7kclgxntgln",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'339', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'339', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus12pz34dgmhe6ahdruf66nvkfrz50mm9zs6nr9sk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'340', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'340', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1ytsp00yv55dg72xjlsh3l444a7xczmn25kfc7p",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'341', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'341', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xe5hkpx5w7ryky3ddzjjdwmuuvf8dkpfltnr22",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 150000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'342', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1500000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'342', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1d0ydd4wyq670lzrp0y7xd3wej4z7ysp26md7p6",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'343', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'343', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus13lcv2qp3jl8kkz7hm4uwf5scquvsfnx7q370cg",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000,
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'344', Bucket:'99 TESTACCOUNT'"
+          },
+          {
+            "amount": 1000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'344', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -927,18 +7703,18 @@
             "depositDuration": 31536000,
             "timestampOffset": 3600,
             "depositOfferMemo": "UnDepositTest 1 Year 9%",
-            "memo": "38"
+            "memo": "ID:'345', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 10000000000000,
             "timestampOffset": 3600,
-            "memo": "38+"
+            "memo": "ID:'345', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1lmwsgy9zv8hyxwsek0pvsq7cpejtkvwkq54uvj",
+        "avaxAddr": "X-columbus12tqp70mm2ak9lfh9j9eqyldkpey5ntlx8mkftr",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": false,
@@ -946,204 +7722,16 @@
         },
         "platformAllocations": [
           {
-            "amount": 1000000000000000,
-            "depositDuration": 86400,
+            "amount": 250000000000000,
+            "depositDuration": 31536000,
             "timestampOffset": 3600,
-            "depositOfferMemo": "FlexDepositTest 60s-1Y 11%",
-            "memo": "39"
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'346', Bucket:'99 TESTACCOUNT'"
           },
           {
-            "amount": 10000000000000,
+            "amount": 2500000000000,
             "timestampOffset": 3600,
-            "memo": "39+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1maff3tql60ndkwn9mvz06ssywvag4uf4d73csa",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 864000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "FlexDepositTest 1d-1Y 21%",
-            "memo": "40"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 3600,
-            "memo": "40+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18gw475en5h5jvtkslp7xqed7t7ugq6rmjjvpk2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 3600,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "41"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 3600,
-            "memo": "41+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xw2kqx2xzqsvnuecz2yw6fwpt87k48s277n30m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 110376000,
-            "timestampOffset": 2592000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "42"
-          },
-          {
-            "amount": 10000000000000,
-            "timestampOffset": 2592000,
-            "memo": "42+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19m2e8p6ce2yx9uf00rw5jm70l4w24x0sun4s4v",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1150000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "43"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1udd7y4uv9kfyh2jsckfztz9crgfve3gcaf906k",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "44"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus196w4wzzzgc5vu38jywtr0na3uh9ml8vqc4030c",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "45"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ca5yhrucv5haavjsw4m8nwx28tzva6f8gxh0ce",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 135000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "46"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jpsr4vqdek4kt79ccndunxscyq2n09lj6e2ecm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "48"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus146qrj047eaapww0mrv52zcg30ycljhhyzymztw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 3600000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "49"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18q6scezgt2646rzpc8fmw4jce5zmcvgvve76dv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 3600000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "51"
+            "memo": "ID:'346', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
@@ -1152,3493 +7740,91 @@
         "avaxAddr": "X-columbus1vctr8ha7zna8fxdkazt5k6cnlj7fmg7enwf08a",
         "xAmount": 0,
         "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 215000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "52"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1emp8mkj8g24wmln7dskagu5a8r3p7qefw6gyqq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "53"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus10jsl9f669s9dn6zpxjgerv57pmhnaup5tuefuw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 3000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "54"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus146qrj047eaapww0mrv52zcg30ycljhhyzymztw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 11550000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "56"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18q6scezgt2646rzpc8fmw4jce5zmcvgvve76dv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 2800000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "57"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rf43hs576l0jj72haq0h4yq06lmv2pk844uygs",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 11550000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "58"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jn87l4s3f0r2xa0kk3nw8n939pvkyjyztz5wqu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 2800000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "59"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18m8cg76v9pwywk0s228swwsnapzhgj5npdz6vp",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 2800000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "60"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ak489h9rs6e728wvrgpkx7rzuu9hf4kusjw968",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "61"
-          },
-          {
-            "amount": 100000000000000,
-            "memo": "61+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18m8cg76v9pwywk0s228swwsnapzhgj5npdz6vp",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 4500000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "64"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1gcmdk8edz6jfg2lk72229xs5r3nxcwv6t70mvf",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "Seed 3 Years 0%",
-            "memo": "65"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1396cw839aatmnf2f3nmuuh6p6zn2vesym8ucrn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "68"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "68+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1nqsk0mwued2l8zy7calqhnemxuzct89xwgpgwm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "69"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "69+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1vedj99e90uppeyza86qmhyyhfcfyhh05wl0tal",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "70"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "70+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ry0f50cfu670mxgj0nz6rz0d9jwqyg2kxygsdt",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "71"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "71+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1tmq8ltmqrsud5ehqsd08lmg0vgxn57mkhq579t",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "72"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "72+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1k05g5q6alpm03ektp6w4y25uqz9nph7deqd5pl",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "73"
-          },
-          {
-            "amount": 150000000000,
-            "memo": "73+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1mcs8pk0f67p9s0mmtz9eyph26kp848rdtgllk8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "74"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "74+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16ryrmg6csk09mmnswmnkdvtv2a7ug07792trp3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "75"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "75+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1039z9rhr70sg02s2qysd0ydkxm4p5ljvf2m5fu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 40000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "76"
-          },
-          {
-            "amount": 400000000000,
-            "memo": "76+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus14kmjrlcreau6duuh3a4r78p30rt9caugy6ahrg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "77"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "77+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1u3p0peu345nvsnh27jcqun2yq89le838lycxp8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "78"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "78+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1r7mmvmcszwtzxjhpeu4zgj6arfztch6tu5ve98",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "79"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "79+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kje90w7g29xjwps75qwqyca84yvetp343au0ls",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "80"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "80+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1mp7f8rt2jd604ywnhetk2xq4mmj9qluvaj5fxx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "81"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "81+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1f4c73ufv6d9z93580jau6ugky9px22y0ypzzut",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "82"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "82+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12kjwnczd3vcjctjjjwu58qs2c76ak4c3p4qd58",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "83"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "83+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jxlplag5299kcns2q86kzpp9jffvww3gj65k8u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "84"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "84+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1eqqw5kc58pfw8p63r4grdwwh2u4u4rgfv5rerv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "85"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "85+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1eyunyvyxfq8c9le0pc24xkdum2xehaumt3pf8g",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "86"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "86+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrkg2ksc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "87"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "87+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1y4044a9ltvz6weh7qvm930x685fa9fap2xjhpu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "88"
-          },
-          {
-            "amount": 5000000000000,
-            "memo": "88+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18fwezlvf9knlalnevyj20lrk6459ypyyvnkzt6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "89"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "89+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dukvf6l4k928t4ngpcd2w3h3zyvnd278cexqek",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "90"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "90+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus124n89hkqa7nacrw28j4q6wn856faf564z4pc74",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "91"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "91+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1t5ayje5edr2msh2dqtg4m6xp0fuv4k3qsw4fnd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 600000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "92"
-          },
-          {
-            "amount": 6000000000000,
-            "memo": "92+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ldpfsrvxh674jze42wxr7nwsrwatqpjnlyz6d5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "93"
-          },
-          {
-            "amount": 5000000000000,
-            "memo": "93+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1heerqcl59yn3jtw99szd8l7q7a6jq24h680rwn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "94"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "94+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18n0pzqv8w97977yr6t37j3ygh56j2d8swu0r9l",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "95"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "95+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qy5zgzyxn7j22gtj5pd0r8gdgfrsduwrqud6an",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "96"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "96+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12e08wmmlauses9u4z7sj306mlpycq0gz5zkkrj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "97"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "97+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1gqe0v4mamv5gxj9qh4hanftkhqvpnzec438z63",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "98"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "98+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1hmrn6czfq65kqwfeq537ktp8ygzxdx4qc09s4a",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "99"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "99+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1su5tl8scmw4zwjnacaw48wkl8vlz0vkd93af9r",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "100"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "100+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1slw8htng4clqqwyk0nfvrydte2prmt2fkxhscy",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "101"
-          },
-          {
-            "amount": 150000000000,
-            "memo": "101+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1udazut0vnsnsj674sl7zngtguxh9ze4m6e3ecu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "102"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "102+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19fnu72sdpd0550h59g7gznlgrayzwulpr00ukl",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 60000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "103"
-          },
-          {
-            "amount": 600000000000,
-            "memo": "103+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1hs88mzs5s37t8nueennxy7gxz2stdpjey5mxcg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "104"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "104+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12sewqfh7q3y0ze0t3yp7l5nq5tjmwytm7wun4e",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "105"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "105+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rklz6e8h8h4875pt55kgpwutd7gy3rps2mtnrr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "106"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "106+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kklwkxzvuefl4kvg4dkzw8hp5dq2marxkdh2rk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "107"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "107+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1277jph854ltpp9zxavp4fk2jjurprsd9fyz598",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "108"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "108+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1scefvccult0p9g9vvk2zp6qq7n44cmumgv974g",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "109"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "109+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1lgjzmekp359u28dkngdf98spe88050swvzmm4l",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "110"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "110+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1auylykzk6zqxsvrrx6gy2dc4v4l9fp3ttxp7h0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "111"
-          },
-          {
-            "amount": 150000000000,
-            "memo": "111+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1p6wvd9jd0dxueuseghgpnvgl979elus4acpsd9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "112"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "112+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1t907jgamny9vqkl3ec7sfpdvskqf6wspzexqwn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "113"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "113+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus156x6huxhlqw28awt2cqd0q02qrfxne6h6t8v6q",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "114"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "114+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1mxzvy5vpt7danrzvgkvvlw3x7wypea3lekjfsc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "115"
-          },
-          {
-            "amount": 150000000000,
-            "memo": "115+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qtdntjtqcqqnvfsx4c5gc2phtktmjca8m0q0dr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "116"
-          },
-          {
-            "amount": 250000000000,
-            "memo": "116+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1f2ur6q69hstytk7002mgqsuvhr9psmewhjts8z",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "117"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "117+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1cvd8ardpsynhgfhdaapf7akhqv6sc7m975mrdv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "118"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "118+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xpj2lh6dzlx22pjuyaelf75g0vug44qgvzfu5u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "119"
-          },
-          {
-            "amount": 5000000000000,
-            "memo": "119+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1q50k78pse6vky5gwdsmuf7njcp8ahdlun45uc5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "120"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "120+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1plhzrxlua2w8dhmw85d8nr907sq3328ln9k98e",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "121"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "121+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus147xtkfw9cpfkyuajzyqh2wzgrmhgf7596tgteh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "122"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "122+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19vvz56u2c7mstv88fmnmlm2kfa8vyp2avy37c8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "123"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "123+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xz37ugnp0aaedt2ur6j7qh6mljvksn0040xwz5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "124"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "124+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1npxkkgtaq8p00uwc8nwrfm25rzf2pdyf2ywpe9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "nodeID": "NodeID-EPnVak5NCap1wdxJRWxKRQNaBfHi9MoVd",
-            "validatorDuration": 31276800,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "125"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "125+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ne69lm0mplfxcxmqlv3ls6wk5z8m3tc3kc08q6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "126"
-          },
-          {
-            "amount": 150000000000,
-            "memo": "126+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19hw2tjza5vuyjrgv0nlcle4mw573wxp559zf9w",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "127"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "127+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1sey28879jhn9uy822u38vxw3uke8pazwtapvza",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "128"
-          },
-          {
-            "amount": 10000000000000,
-            "memo": "128+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus124aw7ncdfefyqm4srujj9h3yxt9qzpsartnjtj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "129"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "129+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kqd0hqxvrjkc0ez30lfst860w2uu6562knn9tx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "130"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "130+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1gyk9tf69huuc7lrrt6myuzufg4zv4tewl4m5lz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "131"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "131+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1lc4qzvsqfzt2yy9k4596v394se6pg97lqfjvch",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "132"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "132+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1lf62vgkt80dcgq0ljmjedvptrj8h93vnqzv38y",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "133"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "133+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1zc75guv3vwlhheq76egjesu23eccaa9ke5m62m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "134"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "134+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1cmtfkrzpeau8jy87cftmr87x5vs8vrg2py88cd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "135"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "135+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus154ys5gaceac0m2sj0fskwzptr6tl77lwz2s4dk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "136"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "136+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1tvlzzcgfey8mc7z3mhwepk84kagutdwm459wah",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "137"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "137+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus17v6mxjg8t0w5lq9w6qx76k3p7ar7z8q2d00wzh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "138"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "138+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yqgm4zkumgv5hf2afp798arjm59tat3vz7p3v0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "139"
-          },
-          {
-            "amount": 250000000000,
-            "memo": "139+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1sd7q4a5v0t3g3r86uzwzkmxdf5mqs6unzcszua",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "140"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "140+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus127fy88q8lfue2teuflgg8yzwdanj096rvk8ewx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "141"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "141+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pvpjqg5p8xwqgcjeqv5vzdlmzlmpw06wvzk8dn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "142"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "142+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ldtg0fl6reuf9w27w6xt9hvqfjal7lggdm0zse",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "143"
-          },
-          {
-            "amount": 10000000000000,
-            "memo": "143+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yfpzkqaqgqrs4z4ta9stwht4cgmfqeae9k6kj2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 30000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "144"
-          },
-          {
-            "amount": 300000000000,
-            "memo": "144+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xfj26sj8yjtzu632hwryw6k5k8q4t4a8v2v0mu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "145"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "145+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jp56myed7nwy3sre4u445mepkpe79ymmejapwu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "146"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "146+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus17z889qchneqk94x9mjxw0m0xgcgls9d52tqfdq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "147"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "147+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16qy2kwmv6xc9wdqpugv9h0udvrmkml5ppy4khl",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "148"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "148+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xsznkqapgemyrm5mm6whkxsd6tjqhx6av3sf0t",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "149"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "149+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13yjkkxgkg0mk7k727f30hwy78zukld6z4jnz9d",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "150"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "150+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1edf9wnssqddknydsdym28al5axq7dum70kr7gh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "151"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "151+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus17jk0qh8727rk9sfd5fdtn3mg83zva23hx592f6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "152"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "152+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kfapm9d2r8n5rmjvvv5284qp2rdr7t69g8psn0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "153"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "153+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16l5nmctdj4qqk4zqmy8zlkmsaypjzkw4zvh9hf",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 400000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "154"
-          },
-          {
-            "amount": 4000000000000,
-            "memo": "154+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1hecqc6fahddfnr90nxdflt0lwkpshr89fz4tf3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 2000000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "155"
-          },
-          {
-            "amount": 20000000000000,
-            "memo": "155+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1vwlkq9xandunkreu49gwkql8vtnxa0ltty7rhu",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "156"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "156+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1sjsdrw4avghcnvm4rkvsd5clhcujgm8d63mwh3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "157"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "157+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pfl4x5q63wl6e76m2jrncxchsh4eruw33d7l75",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "158"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "158+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16g8j2vrcywjskaygezkm5rl40df6m063kj5axq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "159"
-          },
-          {
-            "amount": 1500000000000,
-            "memo": "159+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1am4366ap64h8gftnfd5xcx6gspk237y8hcdfyk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "160"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "160+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qarpkac6r00v4cwdldc099nrypg4mjemth94ww",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "161"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "161+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1u8cuvpxmq807q95newex63za3kpw3nqwlftvl3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "162"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "162+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ezjkht68k5rz69c5xeetn59vs3wmw6ffxwcsr3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "163"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "163+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1vw4u7j0dwzampvvmyt65rckvfjyykkkgrcht5l",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "164"
-          },
-          {
-            "amount": 150000000000,
-            "memo": "164+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ku4xvfreup02ugju8ls6npyfeu2d0vp2g9x3vd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "165"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16g8j2vrcywjskaygezkm5rl40df6m063kj5axq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "166"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16dkxe6puk3y4qm7hjfvg2lwl8r92e27sf93f8r",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 300000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "167"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ty3unkry6cqhyyrv4hl6zuhx0k6z59xyzeh6tj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "168"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1s5nvfwlytnphhzjqm7ep9w7xe25zrep9hqtcue",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 300000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "169"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yz03v8cyvgglekensauc8f40vn9mxdnt3ajjcp",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 157680000,
-            "depositOfferMemo": "Team 5 Years 0%",
-            "memo": "171"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1c6zz8pqjvyd40rq4mre4azaalur7rsdn69hh6u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "172"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "172+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qh9nzgm6q5cfa2mpshwu9guzahf5se7f8cs7g4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "173"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "173+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus15wxmstyfxxx82ewdmz3usvfk20h39zqhvdqf66",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "174"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "174+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jm8694tdqc6q27my8wnwhe7mmpl93scy2ck8dn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "175"
-          },
-          {
-            "amount": 1500000000000,
-            "memo": "175+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xvhn7tf5kqut6ed30s5kdk9du99k30h7f266e3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "176"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "176+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1els93ysuw4ansfqxe55wlf7ca2rzl0xhvzm6qs",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "177"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "177+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1e9kkysfkfq5xr93qyyxsfz0mg43x2fgdywma4y",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "178"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "178+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1nsh2rw3sjvylgd9gk3jpmfx4dlfgm92yy49540",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "179"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "179+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13enppcukm9jxvs4jms25er7u5jntpnm8vrdzek",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "180"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "180+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1uxp2phhpxh7q2zrfmy8pnzt4q9ytg084c6ue3y",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "181"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "181+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1nkjv6uvpn0u7qg5g24yaey0ch3upjgcyr608j3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 30000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "182"
-          },
-          {
-            "amount": 300000000000,
-            "memo": "182+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1u6q5jgrawt0m6g4kcwewut7zfzfu7dddz9vv9g",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "183"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "183+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pg3wvrpe3efjt8phj5pf5ftmrk66jr5leq5kf3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "184"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "184+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pt4aqevy3n3lpjvy6y3e8dnyqnrmzu024884ff",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "185"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "185+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rn52cw296jemvujuv6h9824aezv3w2p4jdpfg8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "186"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "186+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1f3jtdegkvq8m8avdfqs478hg94xu097hqdd29v",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "187"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "187+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yyrg823l0pjxvtle9d4hjqgegttharh4def6y7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "188"
-          },
-          {
-            "amount": 2500000000000,
-            "memo": "188+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1txd4zzds5w07vw7hk9cwmuq3fv0e42uecnf5ut",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "189"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "189+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pcjx5q50mm0095epqfdfzhcgyzjqh4srve9ejl",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "190"
-          },
-          {
-            "amount": 1500000000000,
-            "memo": "190+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19jfth3scmug3640fq5zhpye5cw88yqryee55sz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "191"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "191+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kpd227tfx0x9mfcg4m62tl2mm9d7eag0q4l3hx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "192"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "192+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ga0ut4yez75rp8077g77uycgchnxyg28n8t2st",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "193"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "193+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1sjxkh9rcjjt4n3nj907rhh5ejey4wa023vpwmp",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "194"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "194+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1j2kypzc2t4l9qd57qh8ql3ujng65cr33qvugxc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "195"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "195+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1u5s70nmxd7pydjtt70kp842h9pjn3sfupd673a",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "196"
-          },
-          {
-            "amount": 1500000000000,
-            "memo": "196+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qcjys29pzv8m75fdt9nszl0llkhjv4n9m0pf0s",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "197"
-          },
-          {
-            "amount": 250000000000,
-            "memo": "197+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1gxw932wm6g0up8pt76af60y4racuugedpfqjfw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "198"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "198+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1wmqq9v670z4hrr3x65xhfhttlk9lqu8myp4uyk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "199"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "199+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1k0lnzgar08aa95daf5k066kvuvj0fscxnz9866",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "200"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "200+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yfq50nt44nvf8nt03cqdtwazpw6lthnkwtvczj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "201"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "201+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1scyvhvrepne0fekev9kw6w0u4caq5dyss2z9h8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "202"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "202+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jjrm4p75euylsy70jxr9p6dsjnnec3qmwnjys9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "203"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "203+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1f2cy4rqyg76q8l8e7xpagj4qgx7nzjdc6amr68",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "204"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "204+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus15nanl7nh4p8f0w7d35xy9z0zg2e6cagq4fw57v",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "205"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "205+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1la56pfek0mpc0x476k40h97kwkh0g73jcx9rk3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "206"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "206+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1aytql7x689t96yvf5ctdr23d2gx646lv3fhf5h",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "207"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "207+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1fx8rm8dww6uzstdk65du5d73x0nzntg9cqexm4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "208"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "208+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1y30tmzcz0na4nu0uqdh4460dute9nwhvlq6c8t",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "209"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "209+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1vpqxc97jyqecl0arr7t0je08z06nljv0ls7yyv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "210"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "210+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1whe7zklwmyxw4ct0x2wsex0ztcfd0dyyva074q",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "211"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "211+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus109x70su7sqqn9t2s4danjjueu5mc9jhyawxnly",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "212"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "212+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1k8ahvt0k5uyycvtzs94cavjk26ratnhu42xtlp",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "213"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "213+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvgnmvh9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "214"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "214+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dew8n748nygu6mfflq4f22rs25uu2dss2hfud2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "215"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "215+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1wtjqyemv7ud2t8mzr9m5p25sruukkvq57m7nd8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 400000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "216"
-          },
-          {
-            "amount": 4000000000000,
-            "memo": "216+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dzkq4k65usyu6ehqp28wemdjyj84jjzn5vrylh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "217"
-          },
-          {
-            "amount": 2500000000000,
-            "memo": "217+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1sgyj0xkjt5erpammkfcftg8aqv2fp8e65mu0pr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "218"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "218+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16mam24ag695vh9tdfwsxeejg3wtg0ms33ptjg2",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "219"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "219+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1sgctncsl8zaryp5w62xp25qqjhskzqr74p7dfd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "220"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "220+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus19gk9fzxx52u2lshxvpsp76vamj4q265chsr6na",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "221"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "221+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1shlcs8lgwxcnsc66gs2yn0k0qqft77hpekmeha",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 2000000000000000,
-            "nodeID": "NodeID-P7Afz8yMSGE9XYqRXBXvMCGHj5JtvcK6z",
-            "validatorDuration": 31536000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "222"
-          },
-          {
-            "amount": 20000000000000,
-            "memo": "222+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1cvrvujyg3sd92tek7y02vgs6zlz35rh29djmqn",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "223"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "223+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus10ug0cakympud639d736slusv5smyfc56t8axgm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "224"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "224+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18har8esnq6gww24qhgsq39g390mn8p7kq6fhl3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "225"
-          },
-          {
-            "amount": 5000000000000,
-            "memo": "225+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xvl6dfj5w9f35duqg97g79pnmffya96p464xc4",
-        "xAmount": 0,
-        "addressStates": {
           "consortiumMember": true,
           "kycVerified": true
         },
         "platformAllocations": [
           {
             "amount": 300000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "226"
+            "depositDuration": 31536000,
+            "timestampOffset": 3600,
+            "depositOfferMemo": "UnDepositTest 1 Year 9%",
+            "memo": "ID:'347', Bucket:'99 TESTACCOUNT'"
           },
           {
             "amount": 3000000000000,
-            "memo": "226+"
+            "timestampOffset": 3600,
+            "memo": "ID:'347', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       },
       {
         "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1c3kd4e02r5mzg83ezs7yxhwrvyfstqnjpfvrld",
+        "avaxAddr": "X-columbus1prxyey5xugn5c6tqusha9m4hd4rvld23ag7y8x",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 73105409000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'348', Bucket:'99 TESTACCOUNT', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1zawetvfggky6yvx5wdcn0tjsalw9ql9dz537x7",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 100000000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'349', Bucket:'99 TESTACCOUNT', Type: 'unlocked'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus194sm66h2qrmtae7gcesnmxdstzqv0mpt7k2snk",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 101000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'350', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1xa6vsx5pwyk7adyz00ldj7n73vr4qma7xfhds0",
+        "xAmount": 0,
+        "addressStates": {
+          "consortiumMember": false,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 1010000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'351', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
+          }
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-columbus1kuv84fhr5meu3nwuh4y284k7y2dxatqt94g9z3",
         "xAmount": 0,
         "addressStates": {
           "consortiumMember": true,
@@ -4646,2081 +7832,56 @@
         },
         "platformAllocations": [
           {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "227"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "227+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1m56g7kzpyvwlcc3mzz9rs5x4u3xuqasq8w66s7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "228"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "228+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dxd66ecwj99xyezr4p5fq7cfwcqqhj29vxlzu9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "229"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "229+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ejtfvvpd268hg8xdjpxfagcnj7x52cep8ch0r0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 75000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "230"
-          },
-          {
-            "amount": 750000000000,
-            "memo": "230+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ml9g8xcuemh3gly6pn90udkadtvqk49u8pc3mz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 400000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "231"
-          },
-          {
-            "amount": 4000000000000,
-            "memo": "231+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12ymv8mufsrdal5ej3ce9cyjwwmu7kclgxntgln",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "232"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "232+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13384dvk54kl83cdcapcl6nzxq35nxlwex4g4xg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "233"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "233+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1c65a257ndfgtayq5m3n3z9xhcpkhevszgxlxa3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "234"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "234+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13pk0dtypwfnssdx880hvr9ezjzlvkp5lcr3ltw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "235"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "235+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1a28tjjxyplz3uq0737tgwv7k29e8dj24xeh877",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "236"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "236+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18qm3s0xd0tnm4jwj8ktkrzcvm76tql3dhpv50c",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "237"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "237+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1xwerkdrpkuhq0u9uprvp0dms6tc7y5annjys5f",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "238"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "238+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1fpxdj92sma76eh6pc4myeumnr2v3a8tes8k88d",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": false
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "239"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "239+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1muy0sy676mc383d566he9lw5a32dkslfkncxur",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "240"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "240+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus15trkm623zm2r23j2hrqjsry636sckxcz9euyfh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "241"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "241+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yatmadtt3qpn7em0r2vmd6ncavdqjlf7fn2hd3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 25000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "242"
-          },
-          {
-            "amount": 250000000000,
-            "memo": "242+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus10thamqpnlvawz4zqayvj7t9s0x6uzwz6vq2jdj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "243"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "243+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus196lwrtuwr2vf79r5jympkjugtsmxkgtwh080zj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "244"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "244+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1y7mc7hekqxxhuerst0ukpeq9k63zy3782nr3dt",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "245"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "245+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus153ejpsghh0tzamey70clpcd7g0y9r6g677x0f7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "246"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "246+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1zj4gs3ldxz6sm5d6zjdv36p0ag8rjey6q5pt2t",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "247"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "247+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1fxsxvek9w0u6q2dy5zkcqxqqlf0kje67s7rd8u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "248"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "248+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1nl0pgg4fry3rwxcvw7h0n2ypt65ns0587dqu6g",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "249"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "249+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1m6gxrjq7qesqz2y998zacjjphsehneaqj44pmm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "250"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "250+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1anj83lc0h839vmvltws0a6h7k5znlyq84hp6m0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "251"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "251+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1gaxcm3petj9z6kvp2w5kcr4usvdvq3hvj5cyjd",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "252"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "252+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1wz7n0cf77vsm7nfe7mh0t06kxcc6ezmvgnmvh9",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "253"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "253+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1tskv880tp95hrpqs7wrqxmp7wrmmr3lc4hvenj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "254"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "254+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qwu3jm84hr3sh9kpst3gxlakd22r5vjakwjs8d",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "255"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "255+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ysa48z2anf29ckcmg8rak384s0k8uwd2cx2234",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "256"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "256+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1zddlpr6hjzjrunts8qdzkwfpx02nu274fhmfer",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "257"
-          },
-          {
-            "amount": 1500000000000,
-            "memo": "257+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18q6scezgt2646rzpc8fmw4jce5zmcvgvve76dv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "258"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "258+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1yws8zcjfsnfgq39c6chsgtm94mt9596m06zm40",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "259"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "259+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus18eqxyetaqt8kym2nqhat532gxtewfsvk3ely5n",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "260"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "260+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kklwkxzvuefl4kvg4dkzw8hp5dq2marxkdh2rk",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "261"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "261+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1gyk9tf69huuc7lrrt6myuzufg4zv4tewl4m5lz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 50000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "262"
-          },
-          {
-            "amount": 500000000000,
-            "memo": "262+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtadmsx8e",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "263"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "263+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus160l526l8mkfjeacnhyv5ucvp6uekv9ccvvuyvw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "264"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "264+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13hvsse9lhszwcktwyy74tgzzzmrqvjxkwgatw5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "265"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "265+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1gxvvskyrpk7cjrd934rgmmxysqrvgqy7pkxft0",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "266"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "266+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus169u6vuaqkxl5pwcq3a33336ww7380c3qrmlcsg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "267"
-          },
-          {
-            "amount": 5000000000000,
-            "memo": "267+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jl4gs84hu6s2k24kxrj7549seyczw5cr5asaxg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "268"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "268+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus16g5l0fngqc9dlzvug7k6el6syey8r375rs4n7e",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "269"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "269+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1c78g2twqemmav8dr0u6cncuvn9nf9zm35ctkc5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "270"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "270+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1td7w8a2ktccxktvh72275txv4dpzcn5y785zff",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "271"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "271+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1wpxa43ech79mxs5ta9kgrg3jx03rrjc3sv6qmv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "272"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "272+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qtnwfkkvwl5haylwl4ppy9tzkffmq560a280k8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "273"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "273+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1t7hagl6tr9hj7hvt66xv73au3edt8fj0aagwk4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "274"
-          },
-          {
-            "amount": 1500000000000,
-            "memo": "274+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1p4xp6m8qgt202aqklwcnhfqx5rg9c2hucrj7qv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "275"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "275+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1236v9648strvh8xmvl3g7hcmxmn5q736pkhl8w",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "276"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "276+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1cdr7whau0kjreg2u6awc4k04jx2yp2sw5p6y6l",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "277"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "277+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus15xxam9nwdz53wdl9zsewqpnjel0arf0wqvl2h5",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "278"
-          },
-          {
-            "amount": 1500000000000,
-            "memo": "278+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dgky8sv7ps46hrd29uhltjzjfuaavpgpxxnv80",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "279"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "279+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1537zcugeec0243matenf36nc90qg0rhh3fggee",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 300000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "280"
-          },
-          {
-            "amount": 3000000000000,
-            "memo": "280+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1j8ux8qvav9rv36zw6e5lkwcdupazruadz4xfda",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 70000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "281"
-          },
-          {
-            "amount": 700000000000,
-            "memo": "281+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1rdh6676x0fdevchtu2xjxpm0pf9xun4kvsscvm",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "282"
-          },
-          {
-            "amount": 2500000000000,
-            "memo": "282+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1cvt8hhmkysu5rdjzvdvvp70tq5u7ae4pq8kw9s",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "283"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "283+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ml9g8xcuemh3gly6pn90udkadtvqk49u8pc3mz",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "284"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "284+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus15dw76k56hd7x2s7k9rnvkzsv56sam5ujwtfp00",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "285"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "285+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1mq4ruc3zgamspv94ej3ws8c35crqgwyxztyk7u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "286"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "286+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1cvd8ardpsynhgfhdaapf7akhqv6sc7m975mrdv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "287"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "287+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ylvqqfp9fyyr52rnpl4faghh5fmzm5fh4nr7g7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "288"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "288+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1dxqcc8s3mfgj6thsfmkh5z23gt0fyngjgy5jfe",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "289"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "289+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus13ugty8yv3xn96kcet56kkvjx26m9e88v8fjh7m",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "290"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "290+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1vntz0u4d88yjxsfm9rmpczrx7295wu9gx2m7qs",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 15000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "291"
-          },
-          {
-            "amount": 150000000000,
-            "memo": "291+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus195gy59enhat6qlcqsjrqqn4l68mt7n2x5mh2gv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "292"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "292+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12hcmkc67wjvcdj7vqlzcqrpehs9lp50y3fpkas",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "293"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "293+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qajjjmwlnytjfe6l8jtqhev4helx9x47hn6rdl",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1500000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "294"
-          },
-          {
-            "amount": 15000000000000,
-            "memo": "294+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1hv5tlf84nxcqkvsdtnetfdyw3wfnvhl9emvmqs",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 30000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "295"
-          },
-          {
-            "amount": 300000000000,
-            "memo": "295+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12l7dlgqkq3ue89vsckgw35vv5wpp7605t2glk8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 250000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "296"
-          },
-          {
-            "amount": 2500000000000,
-            "memo": "296+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1te7nplt3t3z44srz60hj3lgd6ft0t58ay58tl7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "297"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "297+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1j9nsdtrff2m9w97m7wsnxwyx7dvax2v2cv9mfx",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "298"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "298+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1umztjffjtgutxmpglyvprx4njx3s93lfrsxysw",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "299"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "299+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12n9pnwrh2rqqp8a9kad6wadc2hc62ts7e66l6t",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "300"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "300+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1d68vs6523kp60s8ls67pexr5wmx539na8cm98x",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "301"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "301+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ulq0adze9dd7gv7taqrl7yyw80xng576wf77y3",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "302"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "302+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus160qmkdkvhzszx4ph6hf7cwj4rmxdnngfjgeqm8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "303"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "303+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1zpuwfdjtzmfvsrdpd742g6hek6m7tfntch8mgq",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "304"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "304+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ypmdpy7tlep95za2nt9tx5a8tvjykxxssa5kga",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "305"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "305+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1wgthf6t2m26sgfenejht7agnzm4wqa204t0x0s",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 20000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "306"
-          },
-          {
-            "amount": 200000000000,
-            "memo": "306+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus14dc8m3xgfavwvwupq4krps8m5f4t2fefxlnafg",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 3000000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "307"
-          },
-          {
-            "amount": 30000000000000,
-            "memo": "307+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1u5mdyuzgurzuv0qg8evm60wur0ru8ehhpe96gv",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "308"
-          },
-          {
-            "amount": 10000000000000,
-            "memo": "308+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1h7u9p4pa9faxj3zezs9udxvj8quuqymrxmnfun",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "309"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "309+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1kfnsy5p7pfsqh76k5zzmj2kd5svaf0qwrjl0t8",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "310"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "310+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1q9ka38c978mj2l77kuh5jtl8745xfuulqdcsly",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 1000000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "311"
-          },
-          {
-            "amount": 10000000000000,
-            "memo": "311+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1qql75cyftxtf923vny3qr9hkmdayyny6yss3de",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "312"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "312+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1pvmnzwj7pdd4nec3kp0fgdf9w0hp9h6njzryc7",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 115000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "313"
-          },
-          {
-            "amount": 1150000000000,
-            "memo": "313+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus133alnuggsul62aajwhynp7uhsvc8val6f9afs6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "314"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "314+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1swq7jndpq8seupaehfhpwc8tjy8z6j7z6gy7mp",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 150000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "315"
-          },
-          {
-            "amount": 1500000000000,
-            "memo": "315+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1lsgwstc8edestl9v9t65kcfwjcy4gh8qv6jfc6",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "nodeID": "NodeID-Gp6VToHm6CEY2abT6g7g4je5KEtm32NBY",
-            "validatorDuration": 31881600,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "316"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "316+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1jgvgunr3jck6tn7xkzdrrj7khlge7rkvyenpej",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "317"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "317+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1ztkd0srlqersv4c53kfg3cc5kg03ww79wprwcj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 200000000000000,
-            "nodeID": "NodeID-9pygZskxbgi5ZKicwu5ES2ZwteTK6MnMH",
-            "validatorDuration": 30412800,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "318"
-          },
-          {
-            "amount": 2000000000000,
-            "memo": "318+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus15r9s9pctuhf4as2h67naa7ct58fnpn4sx6dx7u",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "319"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "319+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus104gqfegwvksn3kfu95dn6upy48vtpuxcnppr72",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 500000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "320"
-          },
-          {
-            "amount": 5000000000000,
-            "memo": "320+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1teh54u7kjz4p36l63utcu3jcfkygxjp4tytky4",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "321"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "321+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1czgaf8lqfu8cfa74gyuh8ngtfysqlm0xag2psh",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 141912000,
-            "depositOfferMemo": "PreSale 4 Years 9%",
-            "memo": "322"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "322+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus12neqhcynnfy82lxcdcgj0lmqazr4yn77lmyrdr",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "323"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "323+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus1cq4ge3ww6etrsa6t9695yyqmvgzus6l250ycgc",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": true,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 100000000000000,
-            "depositDuration": 173448000,
-            "depositOfferMemo": "PreSale 5 Years 10%",
-            "memo": "324"
-          },
-          {
-            "amount": 1000000000000,
-            "memo": "324+"
-          }
-        ]
-      },
-      {
-        "ethAddr": "0x0000000000000000000000000000000000000000",
-        "avaxAddr": "X-columbus120jls24pylcuf8jpu55a0nle9r776rejxupxwj",
-        "xAmount": 0,
-        "addressStates": {
-          "consortiumMember": false,
-          "kycVerified": true
-        },
-        "platformAllocations": [
-          {
-            "amount": 10000000000000,
-            "depositDuration": 110376000,
-            "depositOfferMemo": "PreSale 3 Years 8%",
-            "memo": "325"
-          },
-          {
-            "amount": 100000000000,
-            "memo": "325+"
+            "amount": 1010000000000000,
+            "timestampOffset": 3600,
+            "memo": "ID:'352', Bucket:'99 TESTACCOUNT', Type: 'unlocked incentive'"
           }
         ]
       }
     ],
     "initialMultisigAddresses": [
+      {
+        "alias": "X-columbus12tqp70mm2ak9lfh9j9eqyldkpey5ntlx8mkftr",
+        "addresses": [
+          "X-columbus1qfyvkqnv8yd9rmlf6sv0gdx20dgg4ers4pjp83",
+          "X-columbus1yk9lw48um0r0rn9ydf9fhjfwwfq0qh7qtr9sz7",
+          "X-columbus1fvr4nd743ew0gcy00se24hp2ecpmk4h74sca9g",
+          "X-columbus1dgrg4j4p5e6k5jn8080n6333r934pyum99x6c4",
+          "X-columbus10xf9u6we06ljq20jtq90hj0f6q8l2psp95uzpp",
+          "X-columbus102uap4au55t22m797rr030wyrw0jlgw27m99k0",
+          "X-columbus1c35zu69gd42yu9ecrptzwf0z9g7fhfvr3yu28x",
+          "X-columbus1maff3tql60ndkwn9mvz06ssywvag4uf4d73csa",
+          "X-columbus1lmwsgy9zv8hyxwsek0pvsq7cpejtkvwkq54uvj"
+        ],
+        "threshold": 1,
+        "memo": "1000"
+      },
+      {
+        "alias": "X-columbus1whcusz08xtlx0dgmrsxqt7a8gupgzd32fn7fme",
+        "addresses": [
+          "X-columbus1qfyvkqnv8yd9rmlf6sv0gdx20dgg4ers4pjp83",
+          "X-columbus1yk9lw48um0r0rn9ydf9fhjfwwfq0qh7qtr9sz7",
+          "X-columbus1fvr4nd743ew0gcy00se24hp2ecpmk4h74sca9g",
+          "X-columbus1dgrg4j4p5e6k5jn8080n6333r934pyum99x6c4",
+          "X-columbus10xf9u6we06ljq20jtq90hj0f6q8l2psp95uzpp",
+          "X-columbus102uap4au55t22m797rr030wyrw0jlgw27m99k0",
+          "X-columbus1c35zu69gd42yu9ecrptzwf0z9g7fhfvr3yu28x",
+          "X-columbus1maff3tql60ndkwn9mvz06ssywvag4uf4d73csa",
+          "X-columbus1lmwsgy9zv8hyxwsek0pvsq7cpejtkvwkq54uvj"
+        ],
+        "threshold": 2,
+        "memo": "1001"
+      },
+      {
+        "alias": "X-columbus124te92fnfl94nqdxknw8w0juld4e8rgmucwu2p",
+        "addresses": [
+          "X-columbus1yygtqe5az7cu34z6xqs0007wnccw7y38t4tf26",
+          "X-columbus1tr0q3nv8d6hgh4777dj5trqqpp7netsp2c7vd2",
+          "X-columbus16dkxe6puk3y4qm7hjfvg2lwl8r92e27sf93f8r"
+        ],
+        "threshold": 2,
+        "memo": "101"
+      },
       {
         "alias": "X-columbus1ml9g8xcuemh3gly6pn90udkadtvqk49u8pc3mz",
         "addresses": [
@@ -6750,6 +7911,21 @@
         "memo": "1155"
       },
       {
+        "alias": "X-columbus1k6y2cfw4tv8n2p6lydj9vnj2kefcs4sfg395gx",
+        "addresses": [
+          "X-columbus1p5vqs0aedzx8fmy3nejk6hdm2rtulafycfd940",
+          "X-columbus1rq99jnlyu6pz7yn40sm7g3gpw7zg96pfdz63sz",
+          "X-columbus1ggdq6ynh8svx2w4ahww9y605weaejkcq3ul334",
+          "X-columbus1f2tqt7uc6ltp3u5twmkclkz8wrudwxjyjhehq2",
+          "X-columbus1vykttsktmmzqx27feaqp8d3tsgyxmwf6gm8zfz",
+          "X-columbus1wwzwaztw5720s3yt2awj0yg0ekdt64vj4ulrn9",
+          "X-columbus10mc35x5vhq3dg9vny3hhf3f8c43sdrers97zz6",
+          "X-columbus1uzuch26fsrf0klj0xf6k8ngfvahjz2dc2mzrjf"
+        ],
+        "threshold": 3,
+        "memo": "122"
+      },
+      {
         "alias": "X-columbus1w60r4cm8rm336g9w3c6nj2jx4vkq4lsrkg2ksc",
         "addresses": [
           "X-columbus1xhgfdj0zwqyntv2a43xftcpdqgtzhyyc65gdm6",
@@ -6758,6 +7934,17 @@
         ],
         "threshold": 2,
         "memo": "123"
+      },
+      {
+        "alias": "X-columbus1hhqspfn3chrr8f23kdekcwl26a66nw7wkhlrp4",
+        "addresses": [
+          "X-columbus1rq99jnlyu6pz7yn40sm7g3gpw7zg96pfdz63sz",
+          "X-columbus1reelwcfs8hf8mlh2pwtp58jum78fhlph8rd7dn",
+          "X-columbus1f2tqt7uc6ltp3u5twmkclkz8wrudwxjyjhehq2",
+          "X-columbus16kqqmrpa92upyxy63z02zjyuvdwjtlhzyt9pts"
+        ],
+        "threshold": 2,
+        "memo": "124"
       },
       {
         "alias": "X-columbus133alnuggsul62aajwhynp7uhsvc8val6f9afs6",
@@ -6816,10 +8003,11 @@
         "memo": "158"
       },
       {
-        "alias": "X-columbus1dgky8sv7ps46hrd29uhltjzjfuaavpgpxxnv80",
+        "alias": "X-columbus1smeeegnxaaamfazx98d0qpnrkkx5qrwkve3rza",
         "addresses": [
-          "X-columbus1vveln3mjr9ee2ls5tx39sqygguatt5thk5spvq",
-          "X-columbus1d26p87euze5gjg5zf8d27fx4aq9nnlhvhl9xef"
+          "X-columbus1z3lfk4q88hfv5f8dlde7vrxqd9pta60a3wecc0",
+          "X-columbus1x3dwax0xcrsvwudlcnwjvr6clu9jzyhlzv9fts",
+          "X-columbus16a8rqzehm6httxzcx0aj2rq8z4h7ntmz2m6dr2"
         ],
         "threshold": 1,
         "memo": "168"
@@ -6833,13 +8021,21 @@
         "memo": "169"
       },
       {
-        "alias": "X-columbus169u6vuaqkxl5pwcq3a33336ww7380c3qrmlcsg",
+        "alias": "X-columbus1wgepplh320jtxdfwpnlr3pqpt4sj3xctzq6h2a",
         "addresses": [
-          "X-columbus10a979j54ladz0y9q2672vv4ygpxgfjnugq54r3",
+          "X-columbus1msjywfc88xkqm3vdmhyat6x0ar9galgjdcdu8h",
           "X-columbus17j8tn7asys029zjxj5834zrp50nrl2jzrrl60n"
         ],
         "threshold": 2,
         "memo": "175"
+      },
+      {
+        "alias": "X-columbus1yzx5v9hjjxth43ajer93pdt786s22ag8pqvsd7",
+        "addresses": [
+          "X-columbus1ejmjsgslx2e2zqfu24xlthdnn5zt8255ys0fd8"
+        ],
+        "threshold": 1,
+        "memo": "1957"
       },
       {
         "alias": "X-columbus12neqhcynnfy82lxcdcgj0lmqazr4yn77lmyrdr",
@@ -6887,29 +8083,29 @@
         "memo": "265"
       },
       {
-        "alias": "X-columbus1umztjffjtgutxmpglyvprx4njx3s93lfrsxysw",
+        "alias": "X-columbus13m4yh7ztmps4hjsnyhwy0rxyh6w7ufj6kgqkeu",
         "addresses": [
-          "X-columbus1zcdu7s7zlrq8kfag9e3lm9fh2xxf2zk6yjl46e",
-          "X-columbus1yps0qxtf0gw0c4gsq88659uqvf2st79a36f3mf",
+          "X-columbus1pvjh956nk5pfvs4cxj393srggtuttc0wzjqh2l",
           "X-columbus1yl7sslel748vc2k9jzzuccqh6c4z5pws3ftspn",
+          "X-columbus1g4x9jncqa4qmvsups4n58xecpnfgukxyqj3san",
           "X-columbus1javf0x8m5syvy4c324kf5u8h4ucmktty2es63y"
         ],
         "threshold": 2,
         "memo": "267"
       },
       {
-        "alias": "X-columbus1m6gxrjq7qesqz2y998zacjjphsehneaqj44pmm",
+        "alias": "X-columbus1qmgvg3qw95ft4sww5lkk0vkypjs737fdtu3rhk",
         "addresses": [
           "X-columbus1tue3f8kqn43l7548q35n5l8t6fyhw7a8qq5dmq",
-          "X-columbus1nhkdq29jvecgsnhwxg36g3qy3fd6n7ayny4n7w"
+          "X-columbus1cdqr442s4jvjs9r8twpmz86j5c9ml8w8vuhxwf"
         ],
         "threshold": 1,
         "memo": "294"
       },
       {
-        "alias": "X-columbus1ulq0adze9dd7gv7taqrl7yyw80xng576wf77y3",
+        "alias": "X-columbus1z0hl0jpetf53mxj8d7n9mt70l0l99ng90hxsse",
         "addresses": [
-          "X-columbus1ry2w2pg3fuyx6e58skeajvqh95ctw8k3dyhv0s"
+          "X-columbus1ylygwv9shf7h98hx439jmuyp6adrgl54we4u43"
         ],
         "threshold": 1,
         "memo": "297"
@@ -6968,21 +8164,12 @@
         "memo": "388"
       },
       {
-        "alias": "X-columbus1hecqc6fahddfnr90nxdflt0lwkpshr89fz4tf3",
+        "alias": "X-columbus15tt8kvkah5qcs8r24d9v7w2eymg4hq2nd9qvg5",
         "addresses": [
-          "X-columbus1pv4gg2nlg3ul43cxt5s5lzgvmnxc6tgux7ez4v",
           "X-columbus1k565fpq39tw3x9n9kaaexewnrjdtejej5hfl4x"
         ],
         "threshold": 1,
         "memo": "394"
-      },
-      {
-        "alias": "X-columbus1ut27fsupjgspkmqxpj5gg7jnylm6e7qfguyrej",
-        "addresses": [
-          "X-columbus10ju8xg4fp4j96wn0hu30y3uz02vm65n0aymlvy"
-        ],
-        "threshold": 1,
-        "memo": "395"
       },
       {
         "alias": "X-columbus1pcv7c5r4xp3yd0tepp2l5dxvxgz30xtadmsx8e",
@@ -6993,18 +8180,18 @@
         "memo": "402"
       },
       {
-        "alias": "X-columbus1c6zz8pqjvyd40rq4mre4azaalur7rsdn69hh6u",
+        "alias": "X-columbus1k6z0skaz3333445zz6vgl9nsmzkm2a89atgzpc",
         "addresses": [
-          "X-columbus1agu0s0k7yv77gwzrcc8k0r6t4cwvrhe26juvq0"
+          "X-columbus1r9hyse7qqge3ckwcy7vxtks7ejythgfn9ujneh"
         ],
         "threshold": 1,
         "memo": "421"
       },
       {
-        "alias": "X-columbus15wxmstyfxxx82ewdmz3usvfk20h39zqhvdqf66",
+        "alias": "X-columbus13kzrxg5y4qs97qzf4zdqw9m4z9ydkku6a8njhd",
         "addresses": [
-          "X-columbus1c5hzeksvkgaydyk5mvxqtdu5ud0smeqp9fk4nt",
-          "X-columbus16h4jp22kqeykwsejfsqw2huaeka9hd37n4vdyv",
+          "X-columbus1vs5nw0t5rq3rnq6ehzeu6eptka05kclzve8dd4",
+          "X-columbus16rvf78jypp5c5tf7zw20awnjqk2r78xsjrwzfg",
           "X-columbus1udmhtchhzknfrc674765p7haalzp5nthxh4zk7"
         ],
         "threshold": 2,
@@ -7020,10 +8207,10 @@
         "memo": "423"
       },
       {
-        "alias": "X-columbus1xvhn7tf5kqut6ed30s5kdk9du99k30h7f266e3",
+        "alias": "X-columbus1gqj0qsm8dhyer2alw57rwvt0wqp8hhvku2pjyf",
         "addresses": [
+          "X-columbus1202mhjj7zxsc6d57x382m97mtw68kdw3c54cj7",
           "X-columbus1vk90lszrs4kcpdu3zpqp3zapyvxrp8yhykxwlu",
-          "X-columbus1vl8ac9pa058c6kqchtegqhyvqppa6ax9mms8nr",
           "X-columbus1d0el2szhu3azftp7z8w7vgp5gm2rcfcvptuw34",
           "X-columbus15jrtmg8qf328qkasy892hf2n5hghh8xdgsx4fj",
           "X-columbus1ajp9ctl6wczhk45yz2s66klhlf3czhvxcgcwdn"
@@ -7032,10 +8219,10 @@
         "memo": "424"
       },
       {
-        "alias": "X-columbus160qmkdkvhzszx4ph6hf7cwj4rmxdnngfjgeqm8",
+        "alias": "X-columbus1zpkv5m338vccu9d5fln6wysjdhl05wp2q7y0he",
         "addresses": [
-          "X-columbus13glay5jc4vd2hcunektuxmwmu5sunka69dgpr8",
-          "X-columbus1egpfg0ge9wlvrleevfwcqn6653etptrq5cs3c7"
+          "X-columbus1xzqavra5hmuy0lu34hd68uadruaq2vjz2tgevr",
+          "X-columbus1hapvmtn2ckxhhr4xteuytgyfjal8suz4jc90xh"
         ],
         "threshold": 1,
         "memo": "439"
@@ -7048,6 +8235,24 @@
         ],
         "threshold": 1,
         "memo": "441"
+      },
+      {
+        "alias": "X-columbus1fp0gllrtxljv3gqwc2dq3vuq03vcrkrjkzhwpd",
+        "addresses": [
+          "X-columbus1rng8zue68t0ckhe34vj80mrcz5s0l6xqum2d6t",
+          "X-columbus1de7r6jwww9npznc60a463vll9te5g788uc6vxc",
+          "X-columbus1jrnmlnxcysgsmamjn66zzl6tc6rrwh5n42gl2s"
+        ],
+        "threshold": 2,
+        "memo": "444"
+      },
+      {
+        "alias": "X-columbus15gmmr9we6yhgd7z45ryy886cyqgeuuxctmtc6k",
+        "addresses": [
+          "X-columbus196w4wzzzgc5vu38jywtr0na3uh9ml8vqc4030c"
+        ],
+        "threshold": 1,
+        "memo": "445"
       },
       {
         "alias": "X-columbus1qql75cyftxtf923vny3qr9hkmdayyny6yss3de",
@@ -7076,10 +8281,10 @@
         "memo": "510"
       },
       {
-        "alias": "X-columbus1u5mdyuzgurzuv0qg8evm60wur0ru8ehhpe96gv",
+        "alias": "X-columbus14f5k9f27nwagph2f46xlcszqa8zq9zz7pfnndp",
         "addresses": [
-          "X-columbus1ecgwxcm2txeezupcxckt9cnrznmvzqhm9kwmwm",
-          "X-columbus1mym7xlekckt492d2kv9sgvtuc0lhc8mrcdjwlh"
+          "X-columbus1qhrydqys7fhugrvfeh0mnp2nrr65m43pvvz432",
+          "X-columbus1x2fv48xd6m5au3hxp90mss7ptw3mayxv3m0f7m"
         ],
         "threshold": 1,
         "memo": "515"
@@ -7091,6 +8296,15 @@
         ],
         "threshold": 1,
         "memo": "528"
+      },
+      {
+        "alias": "X-columbus15mzhyljgn57752z877zwshx2kfm4qp4a2e2zmf",
+        "addresses": [
+          "X-columbus1009vem499gs6xnjr0rylcpmhksqhrgunagcyxd",
+          "X-columbus14wjmzwz72wpf9j6tgh9xhq7z9j2epwmj6xy0yk"
+        ],
+        "threshold": 1,
+        "memo": "549"
       },
       {
         "alias": "X-columbus1txd4zzds5w07vw7hk9cwmuq3fv0e42uecnf5ut",
@@ -7106,11 +8320,11 @@
         "memo": "568"
       },
       {
-        "alias": "X-columbus1pcjx5q50mm0095epqfdfzhcgyzjqh4srve9ejl",
+        "alias": "X-columbus1zqt6l7yyks097mf4errxd2wjcz6mxd96nf4e8n",
         "addresses": [
           "X-columbus1qr8x6ksnm0suzluxlvx6a9llxxlkttec4e7lsf",
-          "X-columbus1x6my7jdu0wy2zgfeurt0ue0q7ypnrlacx5nzzu",
-          "X-columbus1g0h99yx8cmklsr223fvuqpx0cyfd6rr2gzp6ld"
+          "X-columbus1g0h99yx8cmklsr223fvuqpx0cyfd6rr2gzp6ld",
+          "X-columbus10hc036xkd376v689m83cvjackv3udeke8f2fv5"
         ],
         "threshold": 2,
         "memo": "569"
@@ -7134,12 +8348,36 @@
         "memo": "602"
       },
       {
-        "alias": "X-columbus1te7nplt3t3z44srz60hj3lgd6ft0t58ay58tl7",
+        "alias": "X-columbus1enn02mahvwyrjdca5htg9rydqrnksscmsjhx4n",
         "addresses": [
-          "X-columbus10kz2mzm5c5e2d2ndlwfsncd5uth38atnvmld6m"
+          "X-columbus1vja8yrr2yvjtmgpw0cap9r240p0kxu8mtyuud9"
         ],
         "threshold": 1,
         "memo": "607"
+      },
+      {
+        "alias": "X-columbus15esv7xd09h2y0fltt83zxgqtzw9xxprkj83csn",
+        "addresses": [
+          "X-columbus10ug0cakympud639d736slusv5smyfc56t8axgm"
+        ],
+        "threshold": 1,
+        "memo": "608"
+      },
+      {
+        "alias": "X-columbus16273wcdf2jvytsauu7jd78sjp4fh2j8qdhmktv",
+        "addresses": [
+          "X-columbus18majy9d7c0zuwpz8r6spzr927xgj9mf7gvm0ww"
+        ],
+        "threshold": 1,
+        "memo": "609"
+      },
+      {
+        "alias": "X-columbus1whhfteexl2x4sdl0jfs4nqvdvyh0qx7hhnjgec",
+        "addresses": [
+          "X-columbus1pt4aqevy3n3lpjvy6y3e8dnyqnrmzu024884ff"
+        ],
+        "threshold": 1,
+        "memo": "610"
       },
       {
         "alias": "X-columbus1qajjjmwlnytjfe6l8jtqhev4helx9x47hn6rdl",
@@ -7150,32 +8388,86 @@
         "memo": "611"
       },
       {
-        "alias": "X-columbus1npxkkgtaq8p00uwc8nwrfm25rzf2pdyf2ywpe9",
+        "alias": "X-columbus1258ga93qdkk7x58rrfp88zt5y9w64sr662ejed",
         "addresses": [
-          "X-columbus1ale9unm94g5at8vp2z0ang7l5hc5maugsrrggh"
+          "X-columbus1qarpkac6r00v4cwdldc099nrypg4mjemth94ww"
+        ],
+        "threshold": 1,
+        "memo": "612"
+      },
+      {
+        "alias": "X-columbus174v5ghmdy20xtmyjnqsmnn6yv99jcxtmrt9nhq",
+        "addresses": [
+          "X-columbus1xsznkqapgemyrm5mm6whkxsd6tjqhx6av3sf0t"
+        ],
+        "threshold": 1,
+        "memo": "613"
+      },
+      {
+        "alias": "X-columbus1a3l20l8nwejvkfszggzjeac8lepymh6e26ult5",
+        "addresses": [
+          "X-columbus16qy2kwmv6xc9wdqpugv9h0udvrmkml5ppy4khl"
+        ],
+        "threshold": 1,
+        "memo": "614"
+      },
+      {
+        "alias": "X-columbus1avxc8uyqzf9hzwa9eacgg2x8y473j85sk3v2vr",
+        "addresses": [
+          "X-columbus1xz37ugnp0aaedt2ur6j7qh6mljvksn0040xwz5"
+        ],
+        "threshold": 1,
+        "memo": "615"
+      },
+      {
+        "alias": "X-columbus15nnu9w2g3zj5sku9gl62gl5sdj6m5fdd3selck",
+        "addresses": [
+          "X-columbus1ctxkgndq8vz082c9r7ef88u295pd2uuxugpkc2"
+        ],
+        "threshold": 1,
+        "memo": "616"
+      },
+      {
+        "alias": "X-columbus17qgahrsfwkkvqhpacf330w37edwt2fdy56l6r3",
+        "addresses": [
+          "X-columbus1y4044a9ltvz6weh7qvm930x685fa9fap2xjhpu"
+        ],
+        "threshold": 1,
+        "memo": "617"
+      },
+      {
+        "alias": "X-columbus1uv72wn6ynluam4mmhf74vtfn7sq5xl9lzw7gkt",
+        "addresses": [
+          "X-columbus1eqqw5kc58pfw8p63r4grdwwh2u4u4rgfv5rerv"
+        ],
+        "threshold": 1,
+        "memo": "618"
+      },
+      {
+        "alias": "X-columbus17ds4n2ukuj2nt46jtuep8z2gcv722ryafj4207",
+        "addresses": [
+          "X-columbus134sgvmyxja3gxgc7u73euespk7de0sfgej37w3"
+        ],
+        "threshold": 1,
+        "memo": "642"
+      },
+      {
+        "alias": "X-columbus1zkny353z0srmc3yuajv2x2hjstkcun3am2s2s5",
+        "addresses": [
+          "X-columbus16jspkntmcazg5gal5r3sxmcuhnga990la5xav4"
         ],
         "threshold": 1,
         "memo": "674"
       },
       {
-        "alias": "X-columbus195gy59enhat6qlcqsjrqqn4l68mt7n2x5mh2gv",
+        "alias": "X-columbus1xp9tyghuh7j7a8exqk9uqpmyath7pklejqm4ry",
         "addresses": [
-          "X-columbus1vqt5lqcw4jrleckhp3z6r3mpame8gdhxhy9j8f",
-          "X-columbus13xugknzqyfptssgke9fwmkveex8z2u3tm9zn3l",
-          "X-columbus1lff8ns8ra2drccej8s6gx5sqadjupj9c7txpks"
+          "X-columbus1ytsp00yv55dg72xjlsh3l444a7xczmn25kfc7p",
+          "X-columbus1wte3r2tahcgewrluxtvdtm5zj3850mluqmqalq",
+          "X-columbus1n3tufnv7a7lvflwfp8zqx08pcnd5raeu5tr49x"
         ],
         "threshold": 2,
         "memo": "675"
-      },
-      {
-        "alias": "X-columbus18m8cg76v9pwywk0s228swwsnapzhgj5npdz6vp",
-        "addresses": [
-          "X-columbus1qdwchlnyh9ztsv85pvzyy830l0ur7nhpfelduz",
-          "X-columbus1yugvehun9ztwradyser8ct4pzfkrs4cf0c66cl",
-          "X-columbus1txt459m2yq657yclyx0fuh3eg88uy0kz8v6j6k"
-        ],
-        "threshold": 2,
-        "memo": "682"
       },
       {
         "alias": "X-columbus1xfj26sj8yjtzu632hwryw6k5k8q4t4a8v2v0mu",
@@ -7206,10 +8498,10 @@
         "memo": "723"
       },
       {
-        "alias": "X-columbus12hcmkc67wjvcdj7vqlzcqrpehs9lp50y3fpkas",
+        "alias": "X-columbus1uaasrym74ld4esmdz6wjxse69zpjkmmlu0x4mr",
         "addresses": [
-          "X-columbus1p0v0fh8mtdqau6qvjfz6ksewgznkqwrf0h0wh2",
-          "X-columbus1nr4nrvdqd8s5setmuuegqs5pv4k9ncvhfq4nt7"
+          "X-columbus1fxr6wspsapcykv4frwepq3pa9zkpqr3knhxumw",
+          "X-columbus1dy2zwpxhdmcsujsu5culd5fw53enx3463lf6nr"
         ],
         "threshold": 2,
         "memo": "728"
@@ -7260,14 +8552,32 @@
         "memo": "766"
       },
       {
-        "alias": "X-columbus14dc8m3xgfavwvwupq4krps8m5f4t2fefxlnafg",
+        "alias": "X-columbus1rpp52fc6d9gwr2pcshlk3565nqazqym4dlfadz",
         "addresses": [
-          "X-columbus1rzhscga3564359xlp666j8gnjth70ps6ycnx6q",
           "X-columbus1t0yu2fp26xwdw052m4v4549hw0cnehvn2n6fje",
-          "X-columbus1vnfj3q296kaaat620npvzlqlhgcthuzkvrckjn"
+          "X-columbus1t68x78yd5f0sujvn8mj05463mg9pycrlt2k3la",
+          "X-columbus1ceyz5f8s5wagsnumj9d7felq03s0nraru2lnc6"
         ],
         "threshold": 2,
         "memo": "777"
+      },
+      {
+        "alias": "X-columbus17crk3v8k09p3hav0ekzvwqlc3kfrhreq39mmhc",
+        "addresses": [
+          "X-columbus13pkc4gy9ver33wdgklxmq2e7zg5455nt983rve",
+          "X-columbus1hygzrvnqflj397886wu6d6xvq6e6yx42gsq64d",
+          "X-columbus1lgu6sxcesryex7dvgrgsvljzu8sgll5zp7fxml"
+        ],
+        "threshold": 2,
+        "memo": "780"
+      },
+      {
+        "alias": "X-columbus1d3cul3elpugpu99p62gpu8ml9mx6zhdrmrp3n4",
+        "addresses": [
+          "X-columbus18qm3s0xd0tnm4jwj8ktkrzcvm76tql3dhpv50c"
+        ],
+        "threshold": 1,
+        "memo": "781"
       },
       {
         "alias": "X-columbus1cq4ge3ww6etrsa6t9695yyqmvgzus6l250ycgc",
@@ -7307,12 +8617,38 @@
         "memo": "862"
       },
       {
-        "alias": "X-columbus1xvl6dfj5w9f35duqg97g79pnmffya96p464xc4",
+        "alias": "X-columbus1nzdp4qpj44dl7frlhfx2efh6mhq5c933pwtxfq",
         "addresses": [
-          "X-columbus1mvysmuzdg3vmhyz5z7z2ar79k8gjshvrgrpw3f"
+          "X-columbus1g85mkrpyuf5ns4vrl8hxeww8alqk2cq2rs0s6u",
+          "X-columbus12dudfc9wd528h27vc0uw7cm7ck0k6fgn5ryl0w",
+          "X-columbus1ud5pmnj78wz0g3psfjg2cqpc8k37enfdcscemr"
+        ],
+        "threshold": 2,
+        "memo": "888"
+      },
+      {
+        "alias": "X-columbus1ty8y07xy43el4w8awz7srwqc8had8ndy8dhmyp",
+        "addresses": [
+          "X-columbus1z5xllk949xjtaf3jyezq4tlu33ag22908yk4dv"
         ],
         "threshold": 1,
         "memo": "914"
+      },
+      {
+        "alias": "X-columbus1n4c9txy82r8kklpvrf4m5fk5q3n3cj63e6hc5j",
+        "addresses": [
+          "X-columbus1z5xllk949xjtaf3jyezq4tlu33ag22908yk4dv"
+        ],
+        "threshold": 1,
+        "memo": "915"
+      },
+      {
+        "alias": "X-columbus1253vr70qkvynz4nyj6retgftjw8zu7zttwh3ym",
+        "addresses": [
+          "X-columbus18n04s6gakwehehtcwhj8gypse5y5lujfghuy03"
+        ],
+        "threshold": 1,
+        "memo": "916"
       },
       {
         "alias": "X-columbus194sm66h2qrmtae7gcesnmxdstzqv0mpt7k2snk",
@@ -7347,6 +8683,107 @@
         "memo": "933"
       },
       {
+        "alias": "X-columbus14jw3xrysalfq33n22e4wgmfwnumjkt4udgt2v8",
+        "addresses": [
+          "X-columbus1s4wlx4rfsk6shfrtrw0kxunefy7we5nfqdx4kz",
+          "X-columbus15cn5qxxfs7ksulm22ra4gl0v76juct92e7gn7x",
+          "X-columbus1kxjatd557dtaflnpu8ulnh6hhq9hhll60zwjp3"
+        ],
+        "threshold": 2,
+        "memo": "940"
+      },
+      {
+        "alias": "X-columbus123q64vzr4kdsgxfntwujjhxapdakz4xs3rsaez",
+        "addresses": [
+          "X-columbus1s4wlx4rfsk6shfrtrw0kxunefy7we5nfqdx4kz",
+          "X-columbus15cn5qxxfs7ksulm22ra4gl0v76juct92e7gn7x",
+          "X-columbus1kxjatd557dtaflnpu8ulnh6hhq9hhll60zwjp3"
+        ],
+        "threshold": 2,
+        "memo": "941"
+      },
+      {
+        "alias": "X-columbus1u3fe3uet9s08d0aja5zme7dy9yx23n8d9ssaa2",
+        "addresses": [
+          "X-columbus1s4wlx4rfsk6shfrtrw0kxunefy7we5nfqdx4kz",
+          "X-columbus15cn5qxxfs7ksulm22ra4gl0v76juct92e7gn7x",
+          "X-columbus1kxjatd557dtaflnpu8ulnh6hhq9hhll60zwjp3"
+        ],
+        "threshold": 2,
+        "memo": "942"
+      },
+      {
+        "alias": "X-columbus1mj0yc9kcxl22kj820dz8ktsmf8azkru0cjw7wz",
+        "addresses": [
+          "X-columbus1s4wlx4rfsk6shfrtrw0kxunefy7we5nfqdx4kz",
+          "X-columbus15cn5qxxfs7ksulm22ra4gl0v76juct92e7gn7x",
+          "X-columbus1kxjatd557dtaflnpu8ulnh6hhq9hhll60zwjp3"
+        ],
+        "threshold": 2,
+        "memo": "943"
+      },
+      {
+        "alias": "X-columbus1xsww8kttcufckh84x49287u8wprz89rfvzc0jj",
+        "addresses": [
+          "X-columbus1s4wlx4rfsk6shfrtrw0kxunefy7we5nfqdx4kz",
+          "X-columbus15cn5qxxfs7ksulm22ra4gl0v76juct92e7gn7x",
+          "X-columbus1kxjatd557dtaflnpu8ulnh6hhq9hhll60zwjp3"
+        ],
+        "threshold": 2,
+        "memo": "944"
+      },
+      {
+        "alias": "X-columbus1s43aum9ctvdyxgdfnyapqdfvy7ddjmc5u648pn",
+        "addresses": [
+          "X-columbus1s4wlx4rfsk6shfrtrw0kxunefy7we5nfqdx4kz",
+          "X-columbus15cn5qxxfs7ksulm22ra4gl0v76juct92e7gn7x",
+          "X-columbus1kxjatd557dtaflnpu8ulnh6hhq9hhll60zwjp3"
+        ],
+        "threshold": 2,
+        "memo": "945"
+      },
+      {
+        "alias": "X-columbus1ext8a4n2ufqvgfhunzq8cvlexz9w8xhxcmutkg",
+        "addresses": [
+          "X-columbus1s4wlx4rfsk6shfrtrw0kxunefy7we5nfqdx4kz",
+          "X-columbus15cn5qxxfs7ksulm22ra4gl0v76juct92e7gn7x",
+          "X-columbus1kxjatd557dtaflnpu8ulnh6hhq9hhll60zwjp3"
+        ],
+        "threshold": 2,
+        "memo": "946"
+      },
+      {
+        "alias": "X-columbus13r5xljkdl7w4g9tcqynfafm4g89mx52edsg8n5",
+        "addresses": [
+          "X-columbus1teeklahjnuwwfna5tvudvrswxerm2fdttd0l2e",
+          "X-columbus1jn87l4s3f0r2xa0kk3nw8n939pvkyjyztz5wqu",
+          "X-columbus1udd7y4uv9kfyh2jsckfztz9crgfve3gcaf906k"
+        ],
+        "threshold": 2,
+        "memo": "947"
+      },
+      {
+        "alias": "X-columbus1eysxq4a0utnrzmjcfnzx227ahlcymd5svjxu5k",
+        "addresses": [
+          "X-columbus196w4wzzzgc5vu38jywtr0na3uh9ml8vqc4030c",
+          "X-columbus18pry238vq8uzzpar32wa4x4p2rkyc7wxq8a639",
+          "X-columbus1jpsr4vqdek4kt79ccndunxscyq2n09lj6e2ecm",
+          "X-columbus1k8k9cj9cvnky0zy8c7mqd9h63swxesd9a2tmsk"
+        ],
+        "threshold": 2,
+        "memo": "948"
+      },
+      {
+        "alias": "X-columbus1lj38gmfuwhd9l3gcn0vavms64xe76ljpa0sc4p",
+        "addresses": [
+          "X-columbus1s4wlx4rfsk6shfrtrw0kxunefy7we5nfqdx4kz",
+          "X-columbus15cn5qxxfs7ksulm22ra4gl0v76juct92e7gn7x",
+          "X-columbus1kxjatd557dtaflnpu8ulnh6hhq9hhll60zwjp3"
+        ],
+        "threshold": 2,
+        "memo": "949"
+      },
+      {
         "alias": "X-columbus1lsgwstc8edestl9v9t65kcfwjcy4gh8qv6jfc6",
         "addresses": [
           "X-columbus1ejmjsgslx2e2zqfu24xlthdnn5zt8255ys0fd8"
@@ -7355,11 +8792,11 @@
         "memo": "957"
       },
       {
-        "alias": "X-columbus1wpxa43ech79mxs5ta9kgrg3jx03rrjc3sv6qmv",
+        "alias": "X-columbus14u3mjp2zwrm7l8v5x7yxn4ed5t29gu0y0ef0jq",
         "addresses": [
-          "X-columbus107pmtdx0rgq2dknf6ffxhlaehmnausdcpesjwg",
-          "X-columbus13p3x5z04cfmln5mn5dj8ljr3a3rj733hgn5629",
-          "X-columbus1ez6s747dce6w9f6tsl96l8ljxx36v8y8jkll4c"
+          "X-columbus1f90eqfg60h6mp79h332gf555xj8aq46mwr4jty",
+          "X-columbus10ucmxrt0wadn2fjxtkem8el9nwn29s3h33c8ae",
+          "X-columbus1sayrny8ynef94v4dhz849jf05n689cam2727ge"
         ],
         "threshold": 2,
         "memo": "975"

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -374,7 +374,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.ColumbusID,
-			expectedID: "2gjCDJT8RDcj7o47LGwgPDtLMgwGcobhjwp8gBzrydmYAkkjtf",
+			expectedID: "VfExrboJVRJin4uxEf2vKiv3h2weZSUwMT9UReNts99J7tPDF",
 		},
 		{
 			networkID:  constants.KopernikusID,

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,7 +370,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "23SLkqz8fHUhV963jPKVTw5v4yoWi9WAaBkAwmgVKVpnPKeiDs",
+			expectedID: "22xY1GTiHPeGtGSUHFMqY1PHQXTLWwj4sR5xj1QaF1w9XArD2b",
 		},
 		{
 			networkID:  constants.ColumbusID,
@@ -413,11 +413,11 @@ func TestVMGenesis(t *testing.T) {
 			vmTest: []vmTest{
 				{
 					vmID:       constants.AVMID,
-					expectedID: "yMQo4UEa2Gkk6aSmifkUuBsystV1iu1NppatvoYz6yCDnRjiq",
+					expectedID: "4Y8KXHrpNRiRBAC3nC6mMzGiE19Rnnwh2rUQ6RU7HdMhvfkS3",
 				},
 				{
 					vmID:       constants.EVMID,
-					expectedID: "RinAZCjd5Dm4wk1FBWiXiiSW2VZkjzgNyR7nNBRkuCvG9zRkJ",
+					expectedID: "2qv12ysjDcdVpJvz3xSaPduX4XhkQNGXafLvvJFLrJgVF7CSjU",
 				},
 			},
 		},
@@ -497,7 +497,7 @@ func TestAVAXAssetID(t *testing.T) {
 	}{
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "2LgYQ5nWZgiwYFVpSoDPma5e3A4GsehYsbCge9eH8Z1149Ca5b",
+			expectedID: "z4V4W25dvCLkv4PKqsaHA1BE1QAfs1Y86xbJeyRE5199dkDhv",
 		},
 		{
 			networkID:  constants.ColumbusID,

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,7 +370,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "22xY1GTiHPeGtGSUHFMqY1PHQXTLWwj4sR5xj1QaF1w9XArD2b",
+			expectedID: "21g8hFdtocBR1oDcFkjZmjFyRoDqz3wGscizyzyCdWpQNcUgMF",
 		},
 		{
 			networkID:  constants.ColumbusID,

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -370,7 +370,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.CaminoID,
-			expectedID: "21g8hFdtocBR1oDcFkjZmjFyRoDqz3wGscizyzyCdWpQNcUgMF",
+			expectedID: "75QK3n1wfbmd1tcH4c6MaoMrRnGkShJEpTbCQtqSpph825MsZ",
 		},
 		{
 			networkID:  constants.ColumbusID,


### PR DESCRIPTION
## Why this should be merged
This PR contains the following changes:
* Changed camino chain config to set the min/max values for validation period to 1/2 year to 5 years. 
* Updated the camino genesis to the latest generated state. 
* Updated all test-cases which check the genesis related hashes to the new values.
It should be merged to update the genesis definition for the camino network to the initial state for the go-live.
* Added the latest changes of the camino genesis also to the columbus genesis

## How this works
The genesis definition is added to the executable and is part of the deployment of the next version. All nodes starting up with network camino will take this genesis definition and spin up the camino main net with the initial validators defined in the genesis.

## How this was tested
The content of the source file was checked multiple times by multiple parties to be correct. 
Another check to verify that the content of the genesis is correct is being done based on the json output in parallel.