### PR TITLE
[TECH-836] - Admin API DNS Rebinding mitigation

### DIFF
--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -62,6 +62,7 @@ type Config struct {
 	HTTPServer   server.PathAdderWithReadLock
 	VMRegistry   registry.VMRegistry
 	VMManager    vms.Manager
+	HttpHost     string
 }
 
 // Admin is the API service for node admin management
@@ -83,6 +84,15 @@ func NewService(config Config) (*common.HTTPHandler, error) {
 	}, "admin"); err != nil {
 		return nil, err
 	}
+
+	// Check if the given hostname matches the configured host via CLI
+	newServer.RegisterValidateRequestFunc(func(r *rpc.RequestInfo, _i interface{}) error {
+		if r.Request.Host != config.HttpHost {
+			return errors.New("unrecognized hostname")
+		}
+		return nil
+	})
+
 	return &common.HTTPHandler{Handler: newServer}, nil
 }
 

--- a/api/admin/service_test.go
+++ b/api/admin/service_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms"
 	"github.com/ava-labs/avalanchego/vms/registry"
+
+	"github.com/gorilla/rpc/v2"
 )
 
 var errOops = errors.New("oops")
@@ -120,4 +122,23 @@ func TestLoadVMsGetAliasesFails(t *testing.T) {
 	err := resources.admin.LoadVMs(&http.Request{}, nil, &reply)
 
 	require.Equal(t, err, errOops)
+}
+
+func TestBlockRequestsWithNonMatchingHostnamesWrongHostname(t *testing.T) {
+	rpcReq := rpc.RequestInfo{Request: &http.Request{Host: "something-else.com"}}
+	f := BlockRequestsWithNonMatchingHostnames("test.com")
+
+	err := f(&rpcReq, nil)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unrecognized hostname")
+}
+
+func TestBlockRequestsWithNonMatchingHostnamesCorrectHostname(t *testing.T) {
+	rpcReq := rpc.RequestInfo{Request: &http.Request{Host: "test.com"}}
+	f := BlockRequestsWithNonMatchingHostnames("test.com")
+
+	err := f(&rpcReq, nil)
+
+	require.Nil(t, err, "result error was not nil, expected matching Hostnames to not raise erros")
 }


### PR DESCRIPTION
## Why this should be merged
To fix a DNS rebinding attack against locally running node.
Refer to the ticket for further details on how the attack works.
## How this works
This assumes the attacker has no control over the Host header of a sent address. (This could not be the case, please verify)
Now every request to the admin API needs to have the hostname that ist set in the `--http-host` flag. Otherwise requests will fail.
This is not optional.

## How this was tested
Added two new tests. 
