### PR TITLE
[PVM] add reward owner to deposit state

### DIFF
--- a/vms/platformvm/deposit/camino_deposit.go
+++ b/vms/platformvm/deposit/camino_deposit.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
+	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/types"
 )
 
@@ -112,12 +113,13 @@ func (o *Offer) Verify() error {
 }
 
 type Deposit struct {
-	DepositOfferID      ids.ID `serialize:"true"` // ID of deposit offer that was used to create this deposit
-	UnlockedAmount      uint64 `serialize:"true"` // How many tokens have already been unlocked from this deposit
-	ClaimedRewardAmount uint64 `serialize:"true"` // How many reward tokens have already been claimed for this deposit
-	Start               uint64 `serialize:"true"` // Timestamp of time, when this deposit was created
-	Duration            uint32 `serialize:"true"` // Duration of this deposit in seconds
-	Amount              uint64 `serialize:"true"` // How many tokens were locked with this deposit
+	DepositOfferID      ids.ID   `serialize:"true"` // ID of deposit offer that was used to create this deposit
+	UnlockedAmount      uint64   `serialize:"true"` // How many tokens have already been unlocked from this deposit
+	ClaimedRewardAmount uint64   `serialize:"true"` // How many reward tokens have already been claimed for this deposit
+	Start               uint64   `serialize:"true"` // Timestamp of time, when this deposit was created
+	Duration            uint32   `serialize:"true"` // Duration of this deposit in seconds
+	Amount              uint64   `serialize:"true"` // How many tokens were locked with this deposit
+	RewardOwner         fx.Owner `serialize:"true"` // The owner who has right to claim rewards for this deposit
 }
 
 func (deposit *Deposit) StartTime() time.Time {

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -428,6 +428,7 @@ func (cs *caminoState) SyncGenesis(s *state, g *genesis.State) error {
 				Start:          block.Timestamp,
 				Duration:       depositTx.DepositDuration,
 				Amount:         depositAmount,
+				RewardOwner:    depositTx.RewardsOwner,
 			}
 
 			currentSupply, err := s.GetCurrentSupply(constants.PrimaryNetworkID)

--- a/vms/platformvm/state/camino_deposit_test.go
+++ b/vms/platformvm/state/camino_deposit_test.go
@@ -15,13 +15,18 @@ import (
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetDeposit(t *testing.T) {
 	depositTxID := ids.GenerateTestID()
-	deposit1 := &deposit.Deposit{Duration: 101}
+	deposit1 := &deposit.Deposit{
+		RewardOwner: &secp256k1fx.OutputOwners{
+			Addrs: []ids.ShortID{{1}},
+		},
+	}
 	depositBytes, err := blocks.GenesisCodec.Marshal(blocks.Version, deposit1)
 	require.NoError(t, err)
 	testError := errors.New("test error")
@@ -593,9 +598,24 @@ func TestWriteDeposits(t *testing.T) {
 	depositTxID1 := ids.ID{1}
 	depositTxID2 := ids.ID{2}
 	depositTxID3 := ids.ID{3}
-	deposit1 := &deposit.Deposit{Duration: 101, Amount: 1}
-	deposit2 := &deposit.Deposit{Duration: 101, Amount: 2}
-	deposit3 := &deposit.Deposit{Duration: 101, Amount: 3}
+	deposit1 := &deposit.Deposit{
+		Duration: 101,
+		RewardOwner: &secp256k1fx.OutputOwners{
+			Addrs: []ids.ShortID{{1}},
+		},
+	}
+	deposit2 := &deposit.Deposit{
+		Duration: 101,
+		RewardOwner: &secp256k1fx.OutputOwners{
+			Addrs: []ids.ShortID{{2}},
+		},
+	}
+	deposit3 := &deposit.Deposit{
+		Duration: 101,
+		RewardOwner: &secp256k1fx.OutputOwners{
+			Addrs: []ids.ShortID{{3}},
+		},
+	}
 	depositEndtime := deposit2.EndTime()
 	deposit1Bytes, err := blocks.GenesisCodec.Marshal(blocks.Version, deposit1)
 	require.NoError(t, err)

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -196,9 +196,10 @@ func TestUnlockDepositTx(t *testing.T) {
 	depositStartTime := time.Now()
 	depositExpiredTime := depositStartTime.Add(100 * time.Second)
 	deposit := &deposits.Deposit{
-		Duration: 60,
-		Amount:   defaultCaminoValidatorWeight,
-		Start:    uint64(depositStartTime.Unix()),
+		Duration:    60,
+		Amount:      defaultCaminoValidatorWeight,
+		Start:       uint64(depositStartTime.Unix()),
+		RewardOwner: &outputOwners,
 	}
 
 	tests := map[string]struct {


### PR DESCRIPTION
Add reward owner field to deposit. This will duplicate depositTx.RewardOwner, but it will remove unnecessary getTx calls in txs execution and service.