### PR TITLE
[PVM] verifyLock invalid msig fixes

### DIFF
--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -937,11 +937,10 @@ func (h *handler) VerifyLockUTXOs(
 		if lockedOut, ok := out.(*locked.Out); ok {
 			lockIDs = &lockedOut.IDs
 			out = lockedOut.TransferableOut
-		} else {
-			// unlocked tokens can be transferred and must be checked
-			if err := h.fx.VerifyMultisigOwner(out, h.utxosReader); err != nil {
-				return err
-			}
+		}
+
+		if err := h.fx.VerifyMultisigOwner(out, h.utxosReader); err != nil {
+			return err
 		}
 
 		otherLockTxID := &lockIDs.DepositTxID


### PR DESCRIPTION
This PR fixes 2 bugs:
- utxo handler VerifyLockUTXOs allows locked newly locked outputs to have invalid msig owners.
- secp256k1fx fx VerifyMultisigOwner allowed invalid cycle-nested 1-address msig aliases.