### PR TITLE
[PVM] Tests improvements and unlock deposit bugfixes

### DIFF
--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -424,10 +424,10 @@ type RegisterNodeArgs struct {
 	api.UserPass
 	api.JSONFromAddrs
 
-	Change                  platformapi.Owner `json:"change"`
-	OldNodeID               ids.NodeID        `json:"oldNodeID"`
-	NewNodeID               ids.NodeID        `json:"newNodeID"`
-	ConsortiumMemberAddress string            `json:"consortiumMemberAddress"`
+	Change           platformapi.Owner `json:"change"`
+	OldNodeID        ids.NodeID        `json:"oldNodeID"`
+	NewNodeID        ids.NodeID        `json:"newNodeID"`
+	NodeOwnerAddress string            `json:"nodeOwnerAddress"`
 }
 
 // RegisterNode issues an RegisterNodeTx
@@ -444,17 +444,17 @@ func (s *CaminoService) RegisterNode(_ *http.Request, args *RegisterNodeArgs, re
 		return fmt.Errorf(errInvalidChangeAddr, err)
 	}
 
-	// Parse the consortium member address.
-	consortiumMemberAddress, err := avax.ParseServiceAddress(s.addrManager, args.ConsortiumMemberAddress)
+	// Parse the node owner address.
+	nodeOwnerAddress, err := avax.ParseServiceAddress(s.addrManager, args.NodeOwnerAddress)
 	if err != nil {
-		return fmt.Errorf("couldn't parse consortiumMemberAddress: %w", err)
+		return fmt.Errorf("couldn't parse nodeOwnerAddress: %w", err)
 	}
 
 	// Create the transaction
 	tx, err := s.vm.txBuilder.NewRegisterNodeTx(
 		args.OldNodeID,
 		args.NewNodeID,
-		consortiumMemberAddress,
+		nodeOwnerAddress,
 		privKeys,
 		change,
 	)

--- a/vms/platformvm/txs/camino_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_deposit_tx_test.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDepositTxSyntacticVerify(t *testing.T) {
+	ctx := snow.DefaultContextTest()
+	ctx.AVAXAssetID = ids.GenerateTestID()
+	owner1 := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{{1}}}
+
+	tests := map[string]struct {
+		tx          *DepositTx
+		expectedErr error
+	}{
+		"Nil tx": {
+			expectedErr: ErrNilTx,
+		},
+		"Bad reward owner": {
+			tx: &DepositTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+				}},
+				RewardsOwner: (*secp256k1fx.OutputOwners)(nil),
+			},
+			expectedErr: errInvalidRewardOwner,
+		},
+		"To big total deposit amount": {
+			tx: &DepositTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Outs: []*avax.TransferableOutput{
+						generateTestOut(ctx.AVAXAssetID, math.MaxUint64, owner1, locked.ThisTxID, ids.Empty),
+						generateTestOut(ctx.AVAXAssetID, math.MaxUint64, owner1, locked.ThisTxID, ids.Empty),
+					},
+				}},
+				RewardsOwner: &secp256k1fx.OutputOwners{},
+			},
+			expectedErr: errToBigDeposit,
+		},
+		"OK": {
+			tx: &DepositTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+				}},
+				RewardsOwner: &secp256k1fx.OutputOwners{},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, tt.tx.SyntacticVerify(ctx), tt.expectedErr)
+		})
+	}
+}

--- a/vms/platformvm/txs/camino_helpers_test.go
+++ b/vms/platformvm/txs/camino_helpers_test.go
@@ -62,6 +62,21 @@ func generateTestStakeableOut(assetID ids.ID, amount, locktime uint64, outputOwn
 	}
 }
 
+func generateTestStakeableIn(assetID ids.ID, amount, locktime uint64, sigIndices []uint32) *avax.TransferableInput {
+	return &avax.TransferableInput{
+		Asset: avax.Asset{ID: assetID},
+		In: &stakeable.LockIn{
+			Locktime: locktime,
+			TransferableIn: &secp256k1fx.TransferInput{
+				Amt: amount,
+				Input: secp256k1fx.Input{
+					SigIndices: sigIndices,
+				},
+			},
+		},
+	}
+}
+
 func generateTestIn(assetID ids.ID, amount uint64, depositTxID, bondTxID ids.ID, sigIndices []uint32) *avax.TransferableInput {
 	var in avax.TransferableIn = &secp256k1fx.TransferInput{
 		Amt: amount,

--- a/vms/platformvm/txs/camino_register_node_tx_test.go
+++ b/vms/platformvm/txs/camino_register_node_tx_test.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterNodeTxSyntacticVerify(t *testing.T) {
+	ctx := snow.DefaultContextTest()
+	ctx.AVAXAssetID = ids.GenerateTestID()
+	owner1 := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{{0, 1}}}
+	depositTxID := ids.ID{1}
+
+	baseTx := BaseTx{BaseTx: avax.BaseTx{
+		NetworkID:    ctx.NetworkID,
+		BlockchainID: ctx.ChainID,
+	}}
+
+	tests := map[string]struct {
+		tx          *RegisterNodeTx
+		expectedErr error
+	}{
+		"Nil tx": {
+			expectedErr: ErrNilTx,
+		},
+		"Old and new nodeIDs empty": {
+			tx:          &RegisterNodeTx{BaseTx: baseTx},
+			expectedErr: errNoNodeID,
+		},
+		"Consortium member address empty": {
+			tx: &RegisterNodeTx{
+				BaseTx:    baseTx,
+				OldNodeID: ids.NodeID{1},
+				NewNodeID: ids.NodeID{2},
+			},
+			expectedErr: errConsortiumMemberAddrEmpty,
+		},
+		"Locked base tx input": {
+			tx: &RegisterNodeTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Ins: []*avax.TransferableInput{
+						generateTestIn(ctx.AVAXAssetID, 1, depositTxID, ids.Empty, []uint32{0}),
+					},
+				}},
+				OldNodeID:        ids.NodeID{1},
+				NewNodeID:        ids.NodeID{2},
+				NodeOwnerAddress: ids.ShortID{3},
+			},
+			expectedErr: locked.ErrWrongInType,
+		},
+		"Locked base tx output": {
+			tx: &RegisterNodeTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Outs: []*avax.TransferableOutput{
+						generateTestOut(ctx.AVAXAssetID, 1, owner1, depositTxID, ids.Empty),
+					},
+				}},
+				OldNodeID:        ids.NodeID{1},
+				NewNodeID:        ids.NodeID{2},
+				NodeOwnerAddress: ids.ShortID{3},
+			},
+			expectedErr: locked.ErrWrongOutType,
+		},
+		"Stakable base tx input": {
+			tx: &RegisterNodeTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Ins: []*avax.TransferableInput{
+						generateTestStakeableIn(ctx.AVAXAssetID, 1, 0, []uint32{0}),
+					},
+				}},
+				OldNodeID:        ids.NodeID{1},
+				NewNodeID:        ids.NodeID{2},
+				NodeOwnerAddress: ids.ShortID{3},
+			},
+			expectedErr: locked.ErrWrongInType,
+		},
+		"Stakable base tx output": {
+			tx: &RegisterNodeTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Outs: []*avax.TransferableOutput{
+						generateTestStakeableOut(ctx.AVAXAssetID, 1, 0, owner1),
+					},
+				}},
+				OldNodeID:        ids.NodeID{1},
+				NewNodeID:        ids.NodeID{2},
+				NodeOwnerAddress: ids.ShortID{3},
+			},
+			expectedErr: locked.ErrWrongOutType,
+		},
+		"Bad consortium member auth": {
+			tx: &RegisterNodeTx{
+				BaseTx:           baseTx,
+				OldNodeID:        ids.NodeID{1},
+				NewNodeID:        ids.NodeID{2},
+				NodeOwnerAddress: ids.ShortID{3},
+				NodeOwnerAuth:    (*secp256k1fx.Input)(nil),
+			},
+			expectedErr: errBadConsortiumMemberAuth,
+		},
+		"OK": {
+			tx: &RegisterNodeTx{
+				BaseTx:           baseTx,
+				OldNodeID:        ids.NodeID{1},
+				NewNodeID:        ids.NodeID{2},
+				NodeOwnerAuth:    &secp256k1fx.Input{},
+				NodeOwnerAddress: ids.ShortID{3},
+			},
+		},
+		"OK: old nodeID empty": {
+			tx: &RegisterNodeTx{
+				BaseTx:           baseTx,
+				OldNodeID:        ids.EmptyNodeID,
+				NewNodeID:        ids.NodeID{1},
+				NodeOwnerAuth:    &secp256k1fx.Input{},
+				NodeOwnerAddress: ids.ShortID{2},
+			},
+		},
+		"OK: new nodeID empty": {
+			tx: &RegisterNodeTx{
+				BaseTx:           baseTx,
+				OldNodeID:        ids.NodeID{1},
+				NewNodeID:        ids.EmptyNodeID,
+				NodeOwnerAuth:    &secp256k1fx.Input{},
+				NodeOwnerAddress: ids.ShortID{2},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, tt.tx.SyntacticVerify(ctx), tt.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
This PR improves utxo handler tests, camino executor tests, add some missing syntactic tests and fixes following bugs:
- It was possible to unlock deposited tokens as locked with another deposit, even non-existent one.
- It was possible to unlock deposited tokens from active deposit without having signature for it.