### PR TITLE
[PVM] MultisigAliasTx implementation 

### DIFF
--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -19,7 +19,8 @@ type caminoTxMetrics struct {
 	numClaimTxs,
 	numRegisterNodeTxs,
 	numRewardsImportTxs,
-	numBaseTxs prometheus.Counter
+	numBaseTxs,
+	numMultisigAliasTxs prometheus.Counter
 }
 
 func newCaminoTxMetrics(
@@ -42,6 +43,7 @@ func newCaminoTxMetrics(
 		numRegisterNodeTxs:  newTxMetric(namespace, "register_node", registerer, &errs),
 		numRewardsImportTxs: newTxMetric(namespace, "rewards_import", registerer, &errs),
 		numBaseTxs:          newTxMetric(namespace, "base", registerer, &errs),
+		numMultisigAliasTxs: newTxMetric(namespace, "multisig_alias", registerer, &errs),
 	}
 	return m, errs.Err
 }
@@ -76,6 +78,10 @@ func (*txMetrics) BaseTx(*txs.BaseTx) error {
 	return nil
 }
 
+func (*txMetrics) MultisigAliasTx(*txs.MultisigAliasTx) error {
+	return nil
+}
+
 // camino metrics
 
 func (m *caminoTxMetrics) AddressStateTx(*txs.AddressStateTx) error {
@@ -104,11 +110,16 @@ func (m *caminoTxMetrics) RegisterNodeTx(*txs.RegisterNodeTx) error {
 }
 
 func (m *caminoTxMetrics) RewardsImportTx(*txs.RewardsImportTx) error {
-	m.numRegisterNodeTxs.Inc()
+	m.numRewardsImportTxs.Inc()
 	return nil
 }
 
 func (m *caminoTxMetrics) BaseTx(*txs.BaseTx) error {
 	m.numBaseTxs.Inc()
+	return nil
+}
+
+func (m *caminoTxMetrics) MultisigAliasTx(*txs.MultisigAliasTx) error {
+	m.numMultisigAliasTxs.Inc()
 	return nil
 }

--- a/vms/platformvm/txs/camino_multisig_alias_tx_test.go
+++ b/vms/platformvm/txs/camino_multisig_alias_tx_test.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/components/multisig"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+func TestMultisigAliasTxSyntacticVerify(t *testing.T) {
+	ctx := snow.DefaultContextTest()
+	ctx.AVAXAssetID = ids.GenerateTestID()
+
+	memo := []byte("memo")
+	bigMemo := make([]byte, 257)
+	_, err := rand.Read(bigMemo)
+	require.NoError(t, err)
+
+	addr1 := ids.GenerateTestShortID()
+	addr2 := ids.GenerateTestShortID()
+
+	var sortedAddrs []ids.ShortID
+	var unsortedAddrs []ids.ShortID
+	if bytes.Compare(addr1.Bytes(), addr2.Bytes()) < 0 {
+		sortedAddrs = []ids.ShortID{addr1, addr2}
+		unsortedAddrs = []ids.ShortID{addr2, addr1}
+	} else {
+		sortedAddrs = []ids.ShortID{addr2, addr1}
+		unsortedAddrs = []ids.ShortID{addr1, addr2}
+	}
+
+	baseTx := BaseTx{BaseTx: avax.BaseTx{
+		NetworkID:    ctx.NetworkID,
+		BlockchainID: ctx.ChainID,
+	}}
+
+	tests := map[string]struct {
+		tx          *MultisigAliasTx
+		expectedErr error
+	}{
+		"OK": {
+			tx: &MultisigAliasTx{
+				BaseTx: baseTx,
+				MultisigAlias: multisig.Alias{
+					ID:   ids.GenerateTestShortID(),
+					Memo: memo,
+					Owners: &secp256k1fx.OutputOwners{
+						Threshold: 2,
+						Addrs:     sortedAddrs,
+					},
+				},
+				Auth: &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
+			},
+		},
+		"Unordered Owners": {
+			tx: &MultisigAliasTx{
+				BaseTx: baseTx,
+				MultisigAlias: multisig.Alias{
+					ID:   ids.GenerateTestShortID(),
+					Memo: memo,
+					Owners: &secp256k1fx.OutputOwners{
+						Threshold: 2,
+						Addrs:     unsortedAddrs,
+					},
+				},
+				Auth: &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
+			},
+			expectedErr: errFailedToVerifyAliasOrAuth,
+		},
+		"Very big memo": {
+			tx: &MultisigAliasTx{
+				BaseTx: baseTx,
+				MultisigAlias: multisig.Alias{
+					ID:   ids.GenerateTestShortID(),
+					Memo: bigMemo,
+					Owners: &secp256k1fx.OutputOwners{
+						Threshold: 2,
+						Addrs:     sortedAddrs,
+					},
+				},
+				Auth: &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
+			},
+			expectedErr: errFailedToVerifyAliasOrAuth,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, tt.tx.SyntacticVerify(ctx), tt.expectedErr)
+		})
+	}
+}

--- a/vms/platformvm/txs/camino_visitor.go
+++ b/vms/platformvm/txs/camino_visitor.go
@@ -11,4 +11,5 @@ type CaminoVisitor interface {
 	RegisterNodeTx(*RegisterNodeTx) error
 	RewardsImportTx(*RewardsImportTx) error
 	BaseTx(*BaseTx) error
+	MultisigAliasTx(*MultisigAliasTx) error
 }

--- a/vms/platformvm/txs/executor/camino_visitor.go
+++ b/vms/platformvm/txs/executor/camino_visitor.go
@@ -37,6 +37,10 @@ func (*StandardTxExecutor) BaseTx(*txs.BaseTx) error {
 	return errWrongTxType
 }
 
+func (*StandardTxExecutor) MultisigAliasTx(*txs.MultisigAliasTx) error {
+	return errWrongTxType
+}
+
 // Proposal
 
 func (*ProposalTxExecutor) AddressStateTx(*txs.AddressStateTx) error {
@@ -64,6 +68,10 @@ func (*ProposalTxExecutor) RewardsImportTx(*txs.RewardsImportTx) error {
 }
 
 func (*ProposalTxExecutor) BaseTx(*txs.BaseTx) error {
+	return errWrongTxType
+}
+
+func (*ProposalTxExecutor) MultisigAliasTx(*txs.MultisigAliasTx) error {
 	return errWrongTxType
 }
 
@@ -97,6 +105,10 @@ func (*AtomicTxExecutor) BaseTx(*txs.BaseTx) error {
 	return errWrongTxType
 }
 
+func (*AtomicTxExecutor) MultisigAliasTx(*txs.MultisigAliasTx) error {
+	return errWrongTxType
+}
+
 // MemPool
 
 func (v *MempoolTxVerifier) AddressStateTx(tx *txs.AddressStateTx) error {
@@ -124,5 +136,9 @@ func (v *MempoolTxVerifier) RewardsImportTx(tx *txs.RewardsImportTx) error {
 }
 
 func (v *MempoolTxVerifier) BaseTx(tx *txs.BaseTx) error {
+	return v.standardTx(tx)
+}
+
+func (v *MempoolTxVerifier) MultisigAliasTx(tx *txs.MultisigAliasTx) error {
 	return v.standardTx(tx)
 }

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -44,6 +44,11 @@ func (i *issuer) BaseTx(*txs.BaseTx) error {
 	return nil
 }
 
+func (i *issuer) MultisigAliasTx(*txs.MultisigAliasTx) error {
+	i.m.addDecisionTx(i.tx)
+	return nil
+}
+
 // Remover
 
 func (r *remover) AddressStateTx(*txs.AddressStateTx) error {
@@ -77,6 +82,11 @@ func (r *remover) RewardsImportTx(*txs.RewardsImportTx) error {
 }
 
 func (r *remover) BaseTx(*txs.BaseTx) error {
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
+	return nil
+}
+
+func (r *remover) MultisigAliasTx(*txs.MultisigAliasTx) error {
 	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }

--- a/wallet/chain/p/camino_visitor.go
+++ b/wallet/chain/p/camino_visitor.go
@@ -38,6 +38,10 @@ func (b *backendVisitor) BaseTx(tx *txs.BaseTx) error {
 	return b.baseTx(tx)
 }
 
+func (b *backendVisitor) MultisigAliasTx(tx *txs.MultisigAliasTx) error {
+	return b.baseTx(&tx.BaseTx)
+}
+
 // signer
 
 func (s *signerVisitor) AddressStateTx(tx *txs.AddressStateTx) error {
@@ -85,6 +89,14 @@ func (*signerVisitor) RewardsImportTx(*txs.RewardsImportTx) error {
 }
 
 func (s *signerVisitor) BaseTx(tx *txs.BaseTx) error {
+	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
+	if err != nil {
+		return err
+	}
+	return sign(s.tx, txSigners)
+}
+
+func (s *signerVisitor) MultisigAliasTx(tx *txs.MultisigAliasTx) error {
 	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description ##

This PR implements the logic of the creation of a new multisig alias definition and the update of an existing ones by the `multisigAliasTx`.  It was developed under the requirements bellow:

- Adding a new multisig alias does only require the signature of the owner issuing the transaction
- Updating an existing multisig alias require as many signature as the threshold of the alias

## Changes ##

- Added the `mutlistigAliasTx` Implementation in the `camino_tx_executor`
- Minor naming and error handling optimizations
- Implemented unit tests for the executor's logic
- Implemented unit tests for semantic verification of the transaction
- Minor changes on helper functions
