### PR TITLE
[PVM, API] replace uint64 in camino-service pvm api with json.Uint64

### DIFF
--- a/vms/platformvm/camino_service_test.go
+++ b/vms/platformvm/camino_service_test.go
@@ -222,7 +222,7 @@ func TestCaminoService_GetAllDepositOffers(t *testing.T) {
 	tests := map[string]struct {
 		fields  fields
 		args    args
-		want    []*deposit.Offer
+		want    []*APIDepositOffer
 		wantErr error
 		prepare func(service CaminoService)
 	}{
@@ -236,7 +236,7 @@ func TestCaminoService_GetAllDepositOffers(t *testing.T) {
 				},
 				response: &GetAllDepositOffersReply{},
 			},
-			want: []*deposit.Offer{
+			want: []*APIDepositOffer{
 				{
 					ID:    ids.ID{1},
 					Start: 0,


### PR DESCRIPTION
Replaces uint64 in api args and replies with json.Uint64 which marshals/unmarshals from string to suit front-end needs.