### PR TITLE
[PVM] UnlockDepositTx and VerifyUnlockDepositedUTXOs refactoring

### DIFF
--- a/vms/platformvm/state/camino_deposit.go
+++ b/vms/platformvm/state/camino_deposit.go
@@ -146,7 +146,7 @@ func (cs *caminoState) writeDeposits() error {
 		cs.depositsNextToUnlockTime = &nextUnlockTime
 	}
 
-	// adding new deposits to db
+	// adding new deposits to db, deleting removed deposits from db
 	for depositTxID, depositDiff := range cs.modifiedDeposits {
 		delete(cs.modifiedDeposits, depositTxID)
 		if depositDiff.removed {

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -676,7 +676,7 @@ func (b *caminoBuilder) NewSystemUnlockDepositTx(
 		}},
 	}
 
-	tx, err := txs.NewSigned(utx, txs.Codec, make([][]*secp256k1.PrivateKey, len(ins)))
+	tx, err := txs.NewSigned(utx, txs.Codec, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vms/platformvm/txs/camino_add_validator_test.go
+++ b/vms/platformvm/txs/camino_add_validator_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/nodeid"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
@@ -18,8 +17,7 @@ import (
 )
 
 func TestCaminoAddValidatorTxSyntacticVerify(t *testing.T) {
-	ctx := snow.DefaultContextTest()
-	ctx.AVAXAssetID = ids.GenerateTestID()
+	ctx := defaultContext()
 	nodeKey, nodeID := nodeid.GenerateCaminoNodeKeyAndID()
 	signers := [][]*secp256k1.PrivateKey{{caminoPreFundedKeys[0]}, {nodeKey}}
 	outputOwners := secp256k1fx.OutputOwners{

--- a/vms/platformvm/txs/camino_address_state_tx_test.go
+++ b/vms/platformvm/txs/camino_address_state_tx_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
@@ -18,7 +17,7 @@ import (
 
 func TestAddressStateTxSyntacticVerify(t *testing.T) {
 	require := require.New(t)
-	ctx := snow.DefaultContextTest()
+	ctx := defaultContext()
 	signers := [][]*secp256k1.PrivateKey{preFundedKeys}
 
 	var (

--- a/vms/platformvm/txs/camino_claim_tx_test.go
+++ b/vms/platformvm/txs/camino_claim_tx_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
@@ -15,8 +14,7 @@ import (
 )
 
 func TestClaimTxSyntacticVerify(t *testing.T) {
-	ctx := snow.DefaultContextTest()
-	ctx.AVAXAssetID = ids.GenerateTestID()
+	ctx := defaultContext()
 	owner1 := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{{0, 0, 1}}}
 	depositTxID := ids.ID{0, 1}
 	claimableOwnerID1 := ids.ID{0, 2}

--- a/vms/platformvm/txs/camino_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_deposit_tx_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
@@ -16,8 +15,7 @@ import (
 )
 
 func TestDepositTxSyntacticVerify(t *testing.T) {
-	ctx := snow.DefaultContextTest()
-	ctx.AVAXAssetID = ids.GenerateTestID()
+	ctx := defaultContext()
 	owner1 := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{{1}}}
 
 	tests := map[string]struct {

--- a/vms/platformvm/txs/camino_helpers_test.go
+++ b/vms/platformvm/txs/camino_helpers_test.go
@@ -6,6 +6,7 @@ package txs
 import (
 	"time"
 
+	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/vms/platformvm/stakeable"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -62,7 +63,7 @@ func generateTestStakeableOut(assetID ids.ID, amount, locktime uint64, outputOwn
 	}
 }
 
-func generateTestStakeableIn(assetID ids.ID, amount, locktime uint64, sigIndices []uint32) *avax.TransferableInput {
+func generateTestStakeableIn(assetID ids.ID, amount, locktime uint64, sigIndices []uint32) *avax.TransferableInput { //nolint:unparam
 	return &avax.TransferableInput{
 		Asset: avax.Asset{ID: assetID},
 		In: &stakeable.LockIn{
@@ -98,4 +99,12 @@ func generateTestIn(assetID ids.ID, amount uint64, depositTxID, bondTxID ids.ID,
 		Asset:  avax.Asset{ID: assetID},
 		In:     in,
 	}
+}
+
+func defaultContext() *snow.Context {
+	ctx := snow.DefaultContextTest()
+	ctx.AVAXAssetID = ids.ID{'C', 'A', 'M'}
+	ctx.NetworkID = 5
+	ctx.ChainID = ids.ID{'T', 'E', 'S', 'T'}
+	return ctx
 }

--- a/vms/platformvm/txs/camino_register_node_tx_test.go
+++ b/vms/platformvm/txs/camino_register_node_tx_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
-	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
@@ -15,8 +14,7 @@ import (
 )
 
 func TestRegisterNodeTxSyntacticVerify(t *testing.T) {
-	ctx := snow.DefaultContextTest()
-	ctx.AVAXAssetID = ids.GenerateTestID()
+	ctx := defaultContext()
 	owner1 := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{{0, 1}}}
 	depositTxID := ids.ID{1}
 

--- a/vms/platformvm/txs/camino_unlock_deposit_tx.go
+++ b/vms/platformvm/txs/camino_unlock_deposit_tx.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 )
 
 var _ UnsignedTx = (*UnlockDepositTx)(nil)
@@ -28,6 +29,10 @@ func (tx *UnlockDepositTx) SyntacticVerify(ctx *snow.Context) error {
 
 	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {
 		return fmt.Errorf("failed to verify BaseTx: %w", err)
+	}
+
+	if err := locked.VerifyLockMode(tx.Ins, tx.Outs, true); err != nil {
+		return err
 	}
 
 	// cache that this is valid

--- a/vms/platformvm/txs/camino_unlock_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_unlock_deposit_tx_test.go
@@ -9,59 +9,50 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRewardsImportTxSyntacticVerify(t *testing.T) {
+func TestUnlockDepositTxSyntacticVerify(t *testing.T) {
 	ctx := defaultContext()
 
 	tests := map[string]struct {
-		tx          *RewardsImportTx
+		tx          *UnlockDepositTx
 		expectedErr error
 	}{
 		"OK": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
+			tx: &UnlockDepositTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
 				NetworkID:    ctx.NetworkID,
 				BlockchainID: ctx.ChainID,
 				Ins: []*avax.TransferableInput{
 					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
+					generateTestIn(ctx.AVAXAssetID, 1, ids.ID{1}, ids.Empty, []uint32{}),
 				},
+				Outs: []*avax.TransferableOutput{},
 			}}},
 		},
 		"Nil tx": {
 			expectedErr: ErrNilTx,
 		},
-		"Input has wrong asset": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
-				NetworkID:    ctx.NetworkID,
-				BlockchainID: ctx.ChainID,
-				Ins: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{}),
-					generateTestIn(ids.GenerateTestID(), 1, ids.Empty, ids.Empty, []uint32{}),
-				},
-			}}},
-			expectedErr: errNotAVAXAsset,
-		},
-		"Locked input": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
-				NetworkID:    ctx.NetworkID,
-				BlockchainID: ctx.ChainID,
-				Ins: []*avax.TransferableInput{
-					generateTestIn(ctx.AVAXAssetID, 1, ids.GenerateTestID(), ids.Empty, []uint32{}),
-				},
-			}}},
-			expectedErr: locked.ErrWrongInType,
-		},
 		"Stakable input": {
-			tx: &RewardsImportTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
+			tx: &UnlockDepositTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
 				NetworkID:    ctx.NetworkID,
 				BlockchainID: ctx.ChainID,
 				Ins: []*avax.TransferableInput{
-					generateTestStakeableIn(ctx.AVAXAssetID, 1, 1, []uint32{}),
+					generateTestStakeableIn(ctx.AVAXAssetID, 1, 1, []uint32{0}),
 				},
 			}}},
 			expectedErr: locked.ErrWrongInType,
+		},
+		"Stakable output": {
+			tx: &UnlockDepositTx{BaseTx: BaseTx{BaseTx: avax.BaseTx{
+				NetworkID:    ctx.NetworkID,
+				BlockchainID: ctx.ChainID,
+				Outs: []*avax.TransferableOutput{
+					generateTestStakeableOut(ctx.AVAXAssetID, 1, 1, secp256k1fx.OutputOwners{}),
+				},
+			}}},
+			expectedErr: locked.ErrWrongOutType,
 		},
 	}
 	for name, tt := range tests {

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -34,39 +34,43 @@ var (
 	_ txs.Visitor = (*CaminoStandardTxExecutor)(nil)
 	_ txs.Visitor = (*CaminoProposalTxExecutor)(nil)
 
-	errNodeSignatureMissing         = errors.New("last signature is not nodeID's signature")
-	errWrongLockMode                = errors.New("this tx can't be used with this caminoGenesis.LockModeBondDeposit")
-	errRecoverAdresses              = errors.New("cannot recover addresses from credentials")
-	errInvalidRoles                 = errors.New("invalid role")
-	errValidatorExists              = errors.New("node is already a validator")
-	errInvalidSystemTxBody          = errors.New("tx body doesn't match expected one")
-	errRemoveValidatorToEarly       = errors.New("attempting to remove validator before its end time")
-	errRemoveWrongValidator         = errors.New("attempting to remove wrong validator")
-	errDepositOfferNotActiveYet     = errors.New("deposit offer not active yet")
-	errDepositOfferInactive         = errors.New("deposit offer inactive")
-	errDepositToSmall               = errors.New("deposit amount is less than deposit offer minimum amount")
-	errDepositToBig                 = errors.New("deposit amount is greater than deposit offer available amount")
-	errDepositDurationToSmall       = errors.New("deposit duration is less than deposit offer minmum duration")
-	errDepositDurationToBig         = errors.New("deposit duration is greater than deposit offer maximum duration")
-	errSupplyOverflow               = errors.New("resulting total supply would be more, than allowed maximum")
-	errNotConsortiumMember          = errors.New("address isn't consortium member")
-	errValidatorNotFound            = errors.New("validator not found")
-	errConsortiumMemberHasNode      = errors.New("consortium member already has registered node")
-	errConsortiumSignatureMissing   = errors.New("wrong consortium's member signature")
-	errNodeNotRegistered            = errors.New("no address registered for this node")
-	errNotNodeOwner                 = errors.New("node is registered for another address")
-	errNodeAlreadyRegistered        = errors.New("node is already registered")
-	errClaimableCredentialMissmatch = errors.New("claimable credential isn't matching")
-	errDepositNotFound              = errors.New("deposit not found")
-	errWrongCredentialsNumber       = errors.New("unexpected number of credentials")
-	ErrWrongOwnerType               = errors.New("wrong owner type")
-	errImportedUTXOMissmatch        = errors.New("imported input doesn't match expected utxo")
-	errInputAmountMissmatch         = errors.New("utxo amount doesn't match input amount")
-	errInputsUTXOSMismatch          = errors.New("number of inputs is different from number of utxos")
-	errWrongClaimedAmount           = errors.New("claiming more than was available to claim")
-	errNoUnlock                     = errors.New("no tokens unlocked")
-	errAliasCredentialMismatch      = errors.New("alias credential isn't matching")
-	errAliasNotFound                = errors.New("alias not found on state")
+	errNodeSignatureMissing           = errors.New("last signature is not nodeID's signature")
+	errWrongLockMode                  = errors.New("this tx can't be used with this caminoGenesis.LockModeBondDeposit")
+	errRecoverAdresses                = errors.New("cannot recover addresses from credentials")
+	errInvalidRoles                   = errors.New("invalid role")
+	errValidatorExists                = errors.New("node is already a validator")
+	errInvalidSystemTxBody            = errors.New("tx body doesn't match expected one")
+	errRemoveValidatorToEarly         = errors.New("attempting to remove validator before its end time")
+	errRemoveWrongValidator           = errors.New("attempting to remove wrong validator")
+	errDepositOfferNotActiveYet       = errors.New("deposit offer not active yet")
+	errDepositOfferInactive           = errors.New("deposit offer inactive")
+	errDepositToSmall                 = errors.New("deposit amount is less than deposit offer minimum amount")
+	errDepositToBig                   = errors.New("deposit amount is greater than deposit offer available amount")
+	errDepositDurationToSmall         = errors.New("deposit duration is less than deposit offer minmum duration")
+	errDepositDurationToBig           = errors.New("deposit duration is greater than deposit offer maximum duration")
+	errSupplyOverflow                 = errors.New("resulting total supply would be more than allowed maximum")
+	errNotConsortiumMember            = errors.New("address isn't consortium member")
+	errValidatorNotFound              = errors.New("validator not found")
+	errConsortiumMemberHasNode        = errors.New("consortium member already has registered node")
+	errConsortiumSignatureMissing     = errors.New("wrong consortium's member signature")
+	errNodeNotRegistered              = errors.New("no address registered for this node")
+	errNotNodeOwner                   = errors.New("node is registered for another address")
+	errNodeAlreadyRegistered          = errors.New("node is already registered")
+	errClaimableCredentialMismatch    = errors.New("claimable credential isn't matching")
+	errDepositNotFound                = errors.New("deposit not found")
+	errWrongCredentialsNumber         = errors.New("unexpected number of credentials")
+	errWrongOwnerType                 = errors.New("wrong owner type")
+	errImportedUTXOMismatch           = errors.New("imported input doesn't match expected utxo")
+	errInputAmountMismatch            = errors.New("utxo amount doesn't match input amount")
+	errInputsUTXOSMismatch            = errors.New("number of inputs is different from number of utxos")
+	errWrongClaimedAmount             = errors.New("claiming more than was available to claim")
+	errNoUnlock                       = errors.New("no tokens unlocked")
+	errAliasCredentialMismatch        = errors.New("alias credential isn't matching")
+	errAliasNotFound                  = errors.New("alias not found on state")
+	errUnlockedMoreThanAvailable      = errors.New("unlocked more deposited tokens than was available for unlock")
+	errMixedDeposits                  = errors.New("tx has expired deposit input and active-deposit/unlocked input")
+	errExpiredDepositNotFullyUnlocked = errors.New("unlocked only part of expired deposit")
+	errBurnedDepositUnlock            = errors.New("burned undeposited tokens")
 )
 
 type CaminoStandardTxExecutor struct {
@@ -195,7 +199,7 @@ func (e *CaminoStandardTxExecutor) AddValidatorTx(tx *txs.AddValidatorTx) error 
 
 		rewardOwner, ok := tx.RewardsOwner.(*secp256k1fx.OutputOwners)
 		if !ok {
-			return ErrWrongOwnerType
+			return errWrongOwnerType
 		}
 
 		if err := e.Fx.VerifyMultisigOwner(
@@ -617,7 +621,7 @@ func (e *CaminoStandardTxExecutor) DepositTx(tx *txs.DepositTx) error {
 
 	rewardOwner, ok := tx.RewardsOwner.(*secp256k1fx.OutputOwners)
 	if !ok {
-		return ErrWrongOwnerType
+		return errWrongOwnerType
 	}
 
 	if err := e.Fx.VerifyMultisigOwner(
@@ -691,45 +695,114 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 		return errWrongLockMode
 	}
 
-	if err := locked.VerifyLockMode(tx.Ins, tx.Outs, caminoConfig.LockModeBondDeposit); err != nil {
-		return err
-	}
-
 	if err := e.Tx.SyntacticVerify(e.Backend.Ctx); err != nil {
 		return err
 	}
 
-	newUnlockedAmounts, err := e.FlowChecker.VerifyUnlockDeposit(
+	chainTimestamp := uint64(e.State.GetTimestamp().Unix())
+	consumedDepositedAmounts := make(map[ids.ID]uint64)
+	producedDepositedAmounts := make(map[ids.ID]uint64)
+	hasExpiredDeposits := false
+	hasActiveDepositsOrUnlockedIns := false
+	consumed := uint64(0)
+
+	for _, input := range tx.Ins {
+		lockedIn, ok := input.In.(*locked.In)
+		switch {
+		case ok && lockedIn.DepositTxID != ids.Empty:
+			if _, ok := consumedDepositedAmounts[lockedIn.DepositTxID]; !ok {
+				deposit, err := e.State.GetDeposit(lockedIn.DepositTxID)
+				if err != nil {
+					return err
+				}
+
+				isExpired := deposit.IsExpired(chainTimestamp)
+
+				if hasExpiredDeposits && !isExpired || hasActiveDepositsOrUnlockedIns && isExpired {
+					return errMixedDeposits
+				}
+
+				hasExpiredDeposits = isExpired
+				hasActiveDepositsOrUnlockedIns = !isExpired
+			}
+
+			consumedDepositedAmounts[lockedIn.DepositTxID], err = math.Add64(consumedDepositedAmounts[lockedIn.DepositTxID], lockedIn.Amount())
+			if err != nil {
+				return err
+			}
+		case !ok && hasExpiredDeposits:
+			return errMixedDeposits
+		case !ok:
+			hasActiveDepositsOrUnlockedIns = true
+		}
+
+		consumed, err = math.Add64(consumed, input.In.Amount())
+		if err != nil {
+			return err
+		}
+	}
+
+	if hasExpiredDeposits && len(e.Tx.Creds) > 0 {
+		return errWrongCredentialsNumber
+	}
+
+	produced := uint64(0)
+	for _, output := range tx.Outs {
+		if lockedOut, ok := output.Out.(*locked.Out); ok && lockedOut.DepositTxID != ids.Empty {
+			producedDepositedAmounts[lockedOut.DepositTxID], err = math.Add64(producedDepositedAmounts[lockedOut.DepositTxID], lockedOut.Amount())
+			if err != nil {
+				return err
+			}
+		}
+		produced, err = math.Add64(produced, output.Out.Amount())
+		if err != nil {
+			return err
+		}
+	}
+
+	if hasExpiredDeposits && consumed != produced {
+		return errBurnedDepositUnlock
+	}
+
+	amountToBurn := e.Config.TxFee
+	if hasExpiredDeposits {
+		amountToBurn = 0
+	}
+
+	if err := e.FlowChecker.VerifyUnlockDeposit(
 		e.State,
 		tx,
 		tx.Ins,
 		tx.Outs,
 		e.Tx.Creds,
-		e.Config.TxFee,
+		amountToBurn,
 		e.Ctx.AVAXAssetID,
-	)
-	if err != nil {
+		!hasExpiredDeposits,
+	); err != nil {
 		return fmt.Errorf("%w: %s", errFlowCheckFailed, err)
 	}
 
-	txID := e.Tx.ID()
-
-	for depositTxID, newlyUnlockedAmount := range newUnlockedAmounts {
-		if newlyUnlockedAmount == 0 {
-			return errNoUnlock
-		}
-
+	for depositTxID, consumedDepositedAmount := range consumedDepositedAmounts {
 		deposit, err := e.State.GetDeposit(depositTxID)
 		if err != nil {
 			return err
 		}
 
-		newUnlockedAmount, err := math.Add64(newlyUnlockedAmount, deposit.UnlockedAmount)
+		unlockedAmount := consumedDepositedAmount - producedDepositedAmounts[depositTxID]
+		newTotalUnlockedAmount, err := math.Add64(unlockedAmount, deposit.UnlockedAmount)
 		if err != nil {
 			return err
 		}
 
-		if newUnlockedAmount == deposit.Amount { // full unlock
+		if newTotalUnlockedAmount == deposit.UnlockedAmount {
+			return errNoUnlock
+		}
+
+		if deposit.IsExpired(chainTimestamp) {
+			if newTotalUnlockedAmount != deposit.Amount {
+				return errExpiredDepositNotFullyUnlocked
+			}
+
 			offer, err := e.State.GetDepositOffer(deposit.DepositOfferID)
 			if err != nil {
 				return err
@@ -745,7 +818,7 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 				if err == database.ErrNotFound {
 					scepOwner, ok := deposit.RewardOwner.(*secp256k1fx.OutputOwners)
 					if !ok {
-						return ErrWrongOwnerType
+						return errWrongOwnerType
 					}
 					claimable = &state.Claimable{
 						Owner: scepOwner,
@@ -767,10 +840,19 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 				e.State.SetClaimable(claimableOwnerID, newClaimable)
 			}
 			e.State.RemoveDeposit(depositTxID, deposit)
-		} else { // partial unlock
+		} else {
+			offer, err := e.State.GetDepositOffer(deposit.DepositOfferID)
+			if err != nil {
+				return err
+			}
+
+			if unlockableAmount := deposit.UnlockableAmount(offer, chainTimestamp); unlockableAmount < newTotalUnlockedAmount {
+				return errUnlockedMoreThanAvailable
+			}
+
 			e.State.ModifyDeposit(depositTxID, &deposits.Deposit{
 				DepositOfferID:      deposit.DepositOfferID,
-				UnlockedAmount:      newUnlockedAmount,
+				UnlockedAmount:      newTotalUnlockedAmount,
 				ClaimedRewardAmount: deposit.ClaimedRewardAmount,
 				Amount:              deposit.Amount,
 				Start:               deposit.Start,
@@ -779,6 +861,8 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 			})
 		}
 	}
+
+	txID := e.Tx.ID()
 
 	avax.Consume(e.State, tx.Ins)
 	avax.Produce(e.State, txID, tx.Outs)
@@ -826,7 +910,7 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 				deposit.RewardOwner,
 				e.State,
 			); err != nil {
-				return fmt.Errorf("%w: %s", errClaimableCredentialMissmatch, err)
+				return fmt.Errorf("%w: %s", errClaimableCredentialMismatch, err)
 			}
 
 			// Checking claimed amount
@@ -876,7 +960,7 @@ func (e *CaminoStandardTxExecutor) ClaimTx(tx *txs.ClaimTx) error {
 				treasuryClaimable.Owner,
 				e.State,
 			); err != nil {
-				return fmt.Errorf("%w: %s", errClaimableCredentialMissmatch, err)
+				return fmt.Errorf("%w: %s", errClaimableCredentialMismatch, err)
 			}
 
 			// Checking claimed amount
@@ -1129,7 +1213,7 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 			utxo := utxos[i]
 
 			if utxo.InputID() != in.InputID() {
-				return errImportedUTXOMissmatch
+				return errImportedUTXOMismatch
 			}
 
 			out, ok := utxo.Out.(*secp256k1fx.TransferOutput)
@@ -1139,7 +1223,7 @@ func (e *CaminoStandardTxExecutor) RewardsImportTx(tx *txs.RewardsImportTx) erro
 			}
 
 			if out.Amt != in.In.Amount() {
-				return fmt.Errorf("utxo.Amt %d, input.Amt %d: %w", out.Amt, in.In.Amount(), errInputAmountMissmatch)
+				return fmt.Errorf("utxo.Amt %d, input.Amt %d: %w", out.Amt, in.In.Amount(), errInputAmountMismatch)
 			}
 		}
 	}

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -41,11 +41,10 @@ var (
 	errAssetIDMismatch           = errors.New("utxo/input/output assetID is different from expected asset id")
 	errLockIDsMismatch           = errors.New("input lock ids is different from utxo lock ids")
 	errFailToGetDeposit          = errors.New("couldn't get deposit")
-	errUnlockedMoreThanAvailable = errors.New("unlocked more deposited tokens, than was available for unlock")
-	errNotConsumedDeposit        = errors.New("didn't consume whole deposit amount, but deposit is expired and can't be partially unlocked")
 	errLockedUTXO                = errors.New("can't spend locked utxo")
 	errNotLockedUTXO             = errors.New("can't spend unlocked utxo")
-	errUTXOOutTypeOrAmtMissmatch = errors.New("inner out isn't *secp256k1fx.TransferOutput or inner out amount != input.Amt")
+	errUTXOOutTypeOrAmtMismatch  = errors.New("inner out isn't *secp256k1fx.TransferOutput or inner out amount != input.Amt")
+	errCantSpend                 = errors.New("can't spend utxo with given credential and input")
 )
 
 // Creates UTXOs from [outs] and adds them to the UTXO set.
@@ -164,19 +163,19 @@ type CaminoVerifier interface {
 	// - [creds] are the credentials of [tx], which allow [ins] to be spent.
 	// - [burnedAmount] if any of deposits are still active, then unlocked inputs must have at least [burnedAmount] more than unlocked outs.
 	// - [assetID] is id of allowed asset, ins/outs with other assets will return error
-	// Returns:
-	// - map[depositTxID]unlockedAmount
+	// - [verifyCreds] if false, [creds] will be ignored
 	//
 	// Precondition: [tx] has already been syntactically verified.
 	VerifyUnlockDeposit(
-		state state.Chain,
+		utxoDB avax.UTXOGetter,
 		tx txs.UnsignedTx,
 		ins []*avax.TransferableInput,
 		outs []*avax.TransferableOutput,
 		creds []verify.Verifiable,
 		burnedAmount uint64,
 		assetID ids.ID,
-	) (map[ids.ID]uint64, error)
+		verifyCreds bool,
+	) error
 
 	Unlocker
 }
@@ -570,11 +569,8 @@ func (h *handler) unlockUTXOs(
 
 	for _, utxo := range utxos {
 		out, ok := utxo.Out.(*locked.Out)
-		if !ok {
-			// This output isn't locked
-			return nil, nil, errNotLockedUTXO
-		} else if !out.IsLockedWith(removedLockState) {
-			// This output doesn't have required lockState
+		if !ok || !out.IsLockedWith(removedLockState) {
+			// This output isn't locked or doesn't have required lockState
 			return nil, nil, errNotLockedUTXO
 		}
 
@@ -1020,19 +1016,25 @@ func (h *handler) VerifyLockUTXOs(
 }
 
 func (h *handler) VerifyUnlockDeposit(
-	state state.Chain,
+	utxoDB avax.UTXOGetter,
 	tx txs.UnsignedTx,
 	ins []*avax.TransferableInput,
 	outs []*avax.TransferableOutput,
 	creds []verify.Verifiable,
 	burnedAmount uint64,
 	assetID ids.ID,
-) (map[ids.ID]uint64, error) {
+	verifyCreds bool,
+) error {
+	msigState, ok := utxoDB.(secp256k1fx.AliasGetter)
+	if !ok {
+		return secp256k1fx.ErrNotAliasGetter
+	}
+
 	utxos := make([]*avax.UTXO, len(ins))
 	for index, input := range ins {
-		utxo, err := state.GetUTXO(input.InputID())
+		utxo, err := utxoDB.GetUTXO(input.InputID())
 		if err != nil {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"failed to read consumed UTXO %s due to: %w",
 				&input.UTXOID,
 				err,
@@ -1041,11 +1043,11 @@ func (h *handler) VerifyUnlockDeposit(
 		utxos[index] = utxo
 	}
 
-	return h.VerifyUnlockDepositedUTXOs(state, tx, utxos, ins, outs, creds, burnedAmount, assetID)
+	return h.VerifyUnlockDepositedUTXOs(msigState, tx, utxos, ins, outs, creds, burnedAmount, assetID, verifyCreds)
 }
 
 func (h *handler) VerifyUnlockDepositedUTXOs(
-	chainState state.Chain,
+	msigState secp256k1fx.AliasGetter,
 	tx txs.UnsignedTx,
 	utxos []*avax.UTXO,
 	ins []*avax.TransferableInput,
@@ -1053,18 +1055,10 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 	creds []verify.Verifiable,
 	burnedAmount uint64,
 	assetID ids.ID,
-) (map[ids.ID]uint64, error) {
-	if len(ins) != len(creds) {
-		return nil, fmt.Errorf(
-			"there are %d inputs and %d credentials: %w",
-			len(ins),
-			len(creds),
-			errInputsCredentialsMismatch,
-		)
-	}
-
+	verifyCreds bool,
+) error {
 	if len(ins) != len(utxos) {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"there are %d inputs and %d utxos: %w",
 			len(ins),
 			len(utxos),
@@ -1072,29 +1066,32 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 		)
 	}
 
-	for _, cred := range creds {
-		if err := cred.Verify(); err != nil {
-			return nil, errBadCredentials
-		}
+	if verifyCreds && len(ins) != len(creds) {
+		return fmt.Errorf(
+			"there are %d inputs and %d credentials: %w",
+			len(ins),
+			len(creds),
+			errInputsCredentialsMismatch,
+		)
 	}
 
-	type depositUnlock struct {
-		consumed uint64 // consumed amount
-		produced uint64 // produced amount
+	if verifyCreds {
+		for _, cred := range creds {
+			if err := cred.Verify(); err != nil {
+				return errBadCredentials
+			}
+		}
 	}
-	depositUnlocks := make(map[ids.ID]*depositUnlock) // depositTxID -> *depositUnlock
 
 	consumedUnlocked := uint64(0)
 	consumed := make(map[ids.ID]map[ids.ID]uint64) // ownerID -> bondTxID -> amount
 
-	currentTimestamp := uint64(chainState.GetTimestamp().Unix())
-
-	// iterate over ins, get utxos, fill the maps (consumed, depositUnlock)
+	// iterate over ins, get utxos, calculate consumed values
 	for index, input := range ins {
 		utxo := utxos[index] // The UTXO consumed by [input]
 
 		if utxoAssetID := utxo.AssetID(); utxoAssetID != assetID {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"utxo %d has asset ID %s but expect %s: %w",
 				index,
 				utxoAssetID,
@@ -1104,7 +1101,7 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 		}
 
 		if inputAssetID := input.AssetID(); inputAssetID != assetID {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"input %d has asset ID %s but expect %s: %w",
 				index,
 				inputAssetID,
@@ -1115,12 +1112,11 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 
 		out := utxo.Out
 		lockIDs := &locked.IDsEmpty
-		isDeposited := false
 		if lockedOut, ok := out.(*locked.Out); ok {
 			// utxo isn't deposited, so it can't be unlocked
 			// bonded-not-deposited utxos are not allowed
-			if isDeposited = lockedOut.DepositTxID != ids.Empty; !isDeposited {
-				return nil, errUnlockingUnlockedUTXO
+			if lockedOut.DepositTxID == ids.Empty {
+				return errUnlockingUnlockedUTXO
 			}
 			out = lockedOut.TransferableOut
 			lockIDs = &lockedOut.IDs
@@ -1128,40 +1124,31 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 
 		in := input.In
 		if lockedIn, ok := in.(*locked.In); ok {
-			// This input is locked, but its LockIDs is wrong
+			// Input is locked, but LockIDs isn't matching utxo's
 			if *lockIDs != lockedIn.IDs {
-				return nil, errLockIDsMismatch
+				return errLockIDsMismatch
 			}
 			in = lockedIn.TransferableIn
 		} else if lockIDs.IsLocked() {
-			// The UTXO says it's locked, but this input, which consumes it,
-			// is not locked - this is invalid.
-			return nil, errLockedFundsNotMarkedAsLocked
+			// The UTXO is locked, but consuming input isn't locked
+			return errLockedFundsNotMarkedAsLocked
 		}
 
 		consumedAmount := in.Amount()
 
-		if isDeposited {
-			// verifying that input amount equal to utxo amount
-			if innerOut, ok := out.(*secp256k1fx.TransferOutput); !ok || innerOut.Amt != consumedAmount {
-				return nil, fmt.Errorf("failed to verify transfer: %w", errUTXOOutTypeOrAmtMissmatch)
+		if verifyCreds {
+			if err := h.fx.VerifyMultisigTransfer(tx, in, creds[index], out, msigState); err != nil {
+				return fmt.Errorf("failed to verify transfer: %w: %s", errCantSpend, err)
 			}
+		} else if innerOut, ok := out.(*secp256k1fx.TransferOutput); !ok || innerOut.Amt != consumedAmount {
+			return fmt.Errorf("failed to verify transfer: %w", errUTXOOutTypeOrAmtMismatch)
+		}
 
-			deposit, err := chainState.GetDeposit(lockIDs.DepositTxID)
-			if err != nil {
-				return nil, err
-			}
-
-			if !deposit.IsExpired(currentTimestamp) {
-				if err := h.fx.VerifyMultisigTransfer(tx, in, creds[index], out, chainState); err != nil {
-					return nil, fmt.Errorf("failed to verify transfer: %w", err)
-				}
-			}
-
-			// calculating consumed amounts
+		// calculating consumed amounts
+		if lockIDs.IsLocked() {
 			ownerID, err := txs.GetOutputOwnerID(out)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
 			consumedOwnerAmounts, ok := consumed[ownerID]
@@ -1172,38 +1159,19 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 
 			newAmount, err := math.Add64(consumedOwnerAmounts[lockIDs.BondTxID], consumedAmount)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			consumedOwnerAmounts[lockIDs.BondTxID] = newAmount
-
-			depUnlock, ok := depositUnlocks[lockIDs.DepositTxID]
-			if !ok {
-				depUnlock = &depositUnlock{}
-				depositUnlocks[lockIDs.DepositTxID] = depUnlock
-			}
-
-			newAmount, err = math.Add64(depUnlock.consumed, consumedAmount)
-			if err != nil {
-				return nil, err
-			}
-			depUnlock.consumed = newAmount
 		} else {
-			if err := h.fx.VerifyMultisigTransfer(tx, in, creds[index], out, chainState); err != nil {
-				return nil, fmt.Errorf("failed to verify transfer: %w", err)
-			}
-
-			// calculating consumed amounts
 			newAmount, err := math.Add64(consumedUnlocked, consumedAmount)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			consumedUnlocked = newAmount
 		}
 	}
 
 	// iterating over outs, checking produced amounts with consumed map
-	// filling deposit produced amounts
-
 	for _, output := range outs {
 		out := output.Out
 		lockIDs := &locked.IDsEmpty
@@ -1213,8 +1181,8 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 			out = lockedOut.TransferableOut
 		} else {
 			// unlocked tokens can be transferred and must be checked
-			if err := h.fx.VerifyMultisigOwner(out, chainState); err != nil {
-				return nil, err
+			if err := h.fx.VerifyMultisigOwner(out, msigState); err != nil {
+				return err
 			}
 		}
 
@@ -1222,7 +1190,7 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 
 		ownerID, err := txs.GetOutputOwnerID(out)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		consumedOwnerAmounts, ok := consumed[ownerID]
@@ -1236,7 +1204,7 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 
 		if consumedAmount < amountToRemoveFromConsumed {
 			if isLocked {
-				return nil, fmt.Errorf(
+				return fmt.Errorf(
 					"address %s produces %d and consumes %d for lockIDs %+v with unlock '%s': %w",
 					ownerID,
 					producedAmount,
@@ -1250,7 +1218,7 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 			amountToRemoveFromConsumed = consumedAmount
 			amountToRemoveFromConsumedUnlocked := producedAmount - consumedAmount
 			if consumedUnlocked < amountToRemoveFromConsumedUnlocked {
-				return nil, fmt.Errorf(
+				return fmt.Errorf(
 					"address %s produces %d and consumes %d unlocked and %d locked with %+v: %w",
 					ownerID,
 					producedAmount,
@@ -1263,82 +1231,11 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 			consumedUnlocked -= amountToRemoveFromConsumedUnlocked
 		}
 		consumedOwnerAmounts[lockIDs.BondTxID] -= amountToRemoveFromConsumed
-
-		if lockIDs.DepositTxID != ids.Empty {
-			depUnlock, ok := depositUnlocks[lockIDs.DepositTxID]
-			if !ok {
-				depUnlock = &depositUnlock{}
-				depositUnlocks[lockIDs.DepositTxID] = depUnlock
-			}
-
-			newAmount, err := math.Add64(depUnlock.produced, producedAmount)
-			if err != nil {
-				return nil, err
-			}
-			depUnlock.produced = newAmount
-		}
-	}
-
-	// this map will list how much tokens was unlocked from each deposit
-	unlockedAmount := make(map[ids.ID]uint64) // depositTxID -> amount
-	// if there are no deposits - its not system tx and we need to burn fee
-	needToBurn := len(depositUnlocks) == 0
-
-	for depositTxID, depUnlock := range depositUnlocks {
-		if depUnlock.consumed < depUnlock.produced {
-			return nil, errWrongProducedAmount
-		}
-
-		unlockedDepositAmount := depUnlock.consumed - depUnlock.produced
-
-		deposit, err := chainState.GetDeposit(depositTxID)
-		if err != nil {
-			return nil, err
-		}
-
-		depositOffer, err := chainState.GetDepositOffer(deposit.DepositOfferID)
-		if err != nil {
-			return nil, err
-		}
-
-		unlockableAmount := deposit.UnlockableAmount(depositOffer, currentTimestamp)
-
-		// if we don't need keys, than deposit is expired and must be fully unlocked
-		// that means that tx must fully consume remaining deposited tokens and
-		// produce them as unlocked
-		isExpired := deposit.IsExpired(currentTimestamp)
-
-		// if there are active deposit - its not system tx and we need to burn fee
-		if !isExpired {
-			needToBurn = true
-		}
-
-		if isExpired &&
-			(unlockedDepositAmount != unlockableAmount ||
-				depUnlock.consumed != unlockableAmount) {
-			return nil, fmt.Errorf("expired deposit (%s) unlockable amount (%d) isn't equal to consumed (%d) and produced (%d) amount: %w",
-				depositTxID,
-				unlockableAmount,
-				depUnlock.consumed,
-				depUnlock.produced,
-				errNotConsumedDeposit)
-		}
-
-		// checking that we unlocked no more, than was available for unlock
-		if unlockedDepositAmount > unlockableAmount {
-			return nil, fmt.Errorf("unlockedDepositAmount %d > %d unlockableAmount: %w",
-				unlockedDepositAmount,
-				unlockableAmount,
-				errUnlockedMoreThanAvailable)
-		}
-
-		unlockedAmount[depositTxID] = unlockedDepositAmount
 	}
 
 	// checking that we burned required amount
-
-	if needToBurn && consumedUnlocked < burnedAmount {
-		return nil, fmt.Errorf(
+	if consumedUnlocked < burnedAmount {
+		return fmt.Errorf(
 			"asset %s burned %d unlocked, but needed to burn %d: %w",
 			assetID,
 			consumedUnlocked,
@@ -1347,7 +1244,7 @@ func (h *handler) VerifyUnlockDepositedUTXOs(
 		)
 	}
 
-	return unlockedAmount, nil
+	return nil
 }
 
 func (*handler) isMultisigTransferOutput(utxoDB avax.UTXOReader, out verify.State) bool {

--- a/vms/platformvm/utxo/mock_verifier.go
+++ b/vms/platformvm/utxo/mock_verifier.go
@@ -101,16 +101,15 @@ func (mr *MockVerifierMockRecorder) VerifySpendUTXOs(arg0, arg1, arg2, arg3, arg
 }
 
 // VerifyUnlockDeposit mocks base method.
-func (m *MockVerifier) VerifyUnlockDeposit(arg0 state.Chain, arg1 txs.UnsignedTx, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID) (map[ids.ID]uint64, error) {
+func (m *MockVerifier) VerifyUnlockDeposit(arg0 avax.UTXOGetter, arg1 txs.UnsignedTx, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID, arg7 bool)  error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyUnlockDeposit", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
-	ret0, _ := ret[0].(map[ids.ID]uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "VerifyUnlockDeposit", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // VerifyUnlockDeposit indicates an expected call of VerifyUnlockDeposit.
-func (mr *MockVerifierMockRecorder) VerifyUnlockDeposit(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockVerifierMockRecorder) VerifyUnlockDeposit(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUnlockDeposit", reflect.TypeOf((*MockVerifier)(nil).VerifyUnlockDeposit), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUnlockDeposit", reflect.TypeOf((*MockVerifier)(nil).VerifyUnlockDeposit), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }


### PR DESCRIPTION
## Why this should be merged
VerifyUnlockDepositedUTXOs method is part of handler in utxos package, so it meant to verify semantics of utxos, inputs and outputs. But it was doing transaction specific logic as well, like checking deposits unlockable amounts and deposits expiration.
This PR changes that by moving all transaction specific logic to unlockDepositTx execution. It also explicitly forbid to mix expired deposit inputs with unlocked or active deposit inputs. 
This PR also includes unit-tests for changed methods and minor improvements into unrelated tests.

## How this works
All transaction specific logic that was in utxo handler is moved into unlockDepositTx executor method, and then refactored.

## How this was tested
unit tests