### PR TITLE
[PVM] Add the functionality of multisig alias definition removal in MultisigAliasTx

### DIFF
--- a/vms/components/multisig/camino_multisig_test.go
+++ b/vms/components/multisig/camino_multisig_test.go
@@ -13,20 +13,34 @@ import (
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 )
 
+var _ Owners = (*testOwners)(nil)
+
+type testOwners struct {
+	avax.TestState
+	isEmpty bool
+}
+
+func (o testOwners) IsZero() bool { return o.isEmpty }
+
 func TestVerify(t *testing.T) {
 	tests := map[string]struct {
 		alias       Alias
-		message     string
 		expectedErr error
 	}{
-		"MemoSizeShouldBeLowerThanMaxMemoSize": {
+		"Memo size should be lower than maxMemoSize": {
 			alias: Alias{
-				Owners: &avax.TestState{},
+				Owners: &testOwners{},
 				Memo:   make([]byte, avax.MaxMemoSize+1),
 				ID:     hashing.ComputeHash160Array(ids.Empty[:]),
 			},
-			message:     "memo size should be lower than max memo size",
-			expectedErr: errMemoIsToBig,
+			expectedErr: errMemoIsTooBig,
+		},
+		"Zero owners": {
+			alias: Alias{
+				ID:     ids.ShortEmpty,
+				Owners: &testOwners{isEmpty: true},
+			},
+			expectedErr: errEmptyAlias,
 		},
 	}
 	for name, tt := range tests {

--- a/vms/platformvm/dac/camino_add_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_add_member_proposal_test.go
@@ -39,7 +39,7 @@ func TestAddMemberProposalVerify(t *testing.T) {
 			},
 			expectedErr: errEndNotAfterStart,
 		},
-		"To small duration": {
+		"Too small duration": {
 			proposal: &AddMemberProposal{
 				Start: 100,
 				End:   100 + AddMemberProposalDuration - 1,
@@ -50,7 +50,7 @@ func TestAddMemberProposalVerify(t *testing.T) {
 			},
 			expectedErr: errWrongDuration,
 		},
-		"To big duration": {
+		"Too big duration": {
 			proposal: &AddMemberProposal{
 				Start: 100,
 				End:   100 + AddMemberProposalDuration + 1,

--- a/vms/platformvm/dac/camino_exclude_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal_test.go
@@ -39,7 +39,7 @@ func TestExcludeMemberProposalVerify(t *testing.T) {
 			},
 			expectedErr: errEndNotAfterStart,
 		},
-		"To small duration": {
+		"Too small duration": {
 			proposal: &ExcludeMemberProposal{
 				Start: 100,
 				End:   100 + ExcludeMemberProposalMinDuration - 1,
@@ -50,7 +50,7 @@ func TestExcludeMemberProposalVerify(t *testing.T) {
 			},
 			expectedErr: errWrongDuration,
 		},
-		"To big duration": {
+		"Too big duration": {
 			proposal: &ExcludeMemberProposal{
 				Start: 100,
 				End:   100 + ExcludeMemberProposalMaxDuration + 1,

--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -28,8 +28,8 @@ var (
 	_ Proposal      = (*GeneralProposal)(nil)
 	_ ProposalState = (*GeneralProposalState)(nil)
 
-	errGeneralProposalOptionIsToBig = errors.New("option size is to big")
-	errNotImplemented               = errors.New("not implemented, should never be called")
+	errGeneralProposalOptionIsTooBig = errors.New("option size is too big")
+	errNotImplemented                = errors.New("not implemented, should never be called")
 )
 
 type GeneralProposal struct {
@@ -84,7 +84,7 @@ func (p *GeneralProposal) Verify() error {
 	for i := 0; i < len(p.Options); i++ {
 		if len(p.Options[i]) > generalProposalMaxOptionSize {
 			return fmt.Errorf("%w (expected: no more than %d, actual: %d, option index: %d)",
-				errGeneralProposalOptionIsToBig, generalProposalMaxOptionSize, len(p.Options[i]), i)
+				errGeneralProposalOptionIsTooBig, generalProposalMaxOptionSize, len(p.Options[i]), i)
 		}
 		for j := i + 1; j < len(p.Options); j++ {
 			if bytes.Equal(p.Options[i], p.Options[j]) {

--- a/vms/platformvm/dac/camino_general_proposal_test.go
+++ b/vms/platformvm/dac/camino_general_proposal_test.go
@@ -69,7 +69,7 @@ func TestGeneralProposalVerify(t *testing.T) {
 			},
 			expectedErr: errEndNotAfterStart,
 		},
-		"To small duration": {
+		"Too small duration": {
 			proposal: &GeneralProposal{
 				Start:   100,
 				End:     100 + GeneralProposalMinDuration - 1,
@@ -82,7 +82,7 @@ func TestGeneralProposalVerify(t *testing.T) {
 			},
 			expectedErr: errWrongDuration,
 		},
-		"To big duration": {
+		"Too big duration": {
 			proposal: &GeneralProposal{
 				Start:   100,
 				End:     100 + generalProposalMaxDuration + 1,
@@ -106,7 +106,7 @@ func TestGeneralProposalVerify(t *testing.T) {
 				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize+1)},
 			},
-			expectedErr: errGeneralProposalOptionIsToBig,
+			expectedErr: errGeneralProposalOptionIsTooBig,
 		},
 		"Not unique option": {
 			proposal: &GeneralProposal{

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -107,7 +107,7 @@ type CaminoDiff interface {
 	// Multisig Owners
 
 	GetMultisigAlias(ids.ShortID) (*multisig.AliasWithNonce, error)
-	SetMultisigAlias(*multisig.AliasWithNonce)
+	SetMultisigAlias(ids.ShortID, *multisig.AliasWithNonce)
 
 	// ShortIDsLink
 
@@ -423,7 +423,7 @@ func (cs *caminoState) syncGenesis(s *state, g *genesis.Genesis) error {
 	// adding msig aliases
 
 	for _, multisigAlias := range g.Camino.MultisigAliases {
-		cs.SetMultisigAlias(&multisig.AliasWithNonce{Alias: *multisigAlias})
+		cs.SetMultisigAlias(multisigAlias.ID, &multisig.AliasWithNonce{Alias: *multisigAlias})
 	}
 
 	// adding blocks (validators and deposits)

--- a/vms/platformvm/state/camino_address_state.go
+++ b/vms/platformvm/state/camino_address_state.go
@@ -44,7 +44,7 @@ func (cs *caminoState) GetAddressStates(address ids.ShortID) (as.AddressState, e
 func (cs *caminoState) writeAddressStates() error {
 	for key, val := range cs.modifiedAddressStates {
 		delete(cs.modifiedAddressStates, key)
-		if val == 0 {
+		if val == as.AddressStateEmpty {
 			if err := cs.addressStateDB.Delete(key[:]); err != nil {
 				return err
 			}

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -264,8 +264,8 @@ func (d *diff) GetNextToUnlockDepositIDsAndTime(removedDepositIDs set.Set[ids.ID
 	return nextDepositIDs, nextUnlockTime, nil
 }
 
-func (d *diff) SetMultisigAlias(alias *multisig.AliasWithNonce) {
-	d.caminoDiff.modifiedMultisigAliases[alias.ID] = alias
+func (d *diff) SetMultisigAlias(id ids.ShortID, alias *multisig.AliasWithNonce) {
+	d.caminoDiff.modifiedMultisigAliases[id] = alias
 }
 
 func (d *diff) GetMultisigAlias(alias ids.ShortID) (*multisig.AliasWithNonce, error) {
@@ -673,8 +673,8 @@ func (d *diff) ApplyCaminoState(baseState Chain) error {
 		}
 	}
 
-	for _, v := range d.caminoDiff.modifiedMultisigAliases {
-		baseState.SetMultisigAlias(v)
+	for multisigAliasID, multisigAlias := range d.caminoDiff.modifiedMultisigAliases {
+		baseState.SetMultisigAlias(multisigAliasID, multisigAlias)
 	}
 
 	for fullKey, link := range d.caminoDiff.modifiedShortLinks {

--- a/vms/platformvm/state/camino_diff_test.go
+++ b/vms/platformvm/state/camino_diff_test.go
@@ -2318,7 +2318,7 @@ func TestDiffSetMultisigAlias(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			tt.diff.SetMultisigAlias(tt.alias)
+			tt.diff.SetMultisigAlias(tt.alias.ID, tt.alias)
 			require.Equal(t, tt.expectedDiff, tt.diff)
 		})
 	}
@@ -5109,8 +5109,8 @@ func TestDiffApplyCaminoState(t *testing.T) {
 						s.EXPECT().ModifyDeposit(depositTxID, depositDiff.Deposit)
 					}
 				}
-				for _, v := range d.caminoDiff.modifiedMultisigAliases {
-					s.EXPECT().SetMultisigAlias(v)
+				for multisigAliasID, multisigAlias := range d.caminoDiff.modifiedMultisigAliases {
+					s.EXPECT().SetMultisigAlias(multisigAliasID, multisigAlias)
 				}
 				for fullKey, link := range d.caminoDiff.modifiedShortLinks {
 					id, key := fromShortLinkKey(fullKey)

--- a/vms/platformvm/state/camino_multisig_alias.go
+++ b/vms/platformvm/state/camino_multisig_alias.go
@@ -19,9 +19,9 @@ type msigAlias struct {
 	Nonce  uint64              `serialize:"true"`
 }
 
-func (cs *caminoState) SetMultisigAlias(ma *multisig.AliasWithNonce) {
-	cs.modifiedMultisigAliases[ma.ID] = ma
-	cs.multisigAliasesCache.Evict(ma.ID)
+func (cs *caminoState) SetMultisigAlias(id ids.ShortID, ma *multisig.AliasWithNonce) {
+	cs.modifiedMultisigAliases[id] = ma
+	cs.multisigAliasesCache.Evict(id)
 }
 
 func (cs *caminoState) GetMultisigAlias(id ids.ShortID) (*multisig.AliasWithNonce, error) {

--- a/vms/platformvm/state/camino_multisig_alias_test.go
+++ b/vms/platformvm/state/camino_multisig_alias_test.go
@@ -223,7 +223,7 @@ func TestSetMultisigAlias(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			caminoState := tt.caminoState(gomock.NewController(t))
-			caminoState.SetMultisigAlias(tt.multisigAlias)
+			caminoState.SetMultisigAlias(tt.multisigAlias.ID, tt.multisigAlias)
 			require.Equal(t, tt.expectedCaminoState(caminoState), caminoState)
 		})
 	}

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -89,8 +89,8 @@ func (s *state) GetNextToUnlockDepositIDsAndTime(removedDepositIDs set.Set[ids.I
 	return s.caminoState.GetNextToUnlockDepositIDsAndTime(removedDepositIDs)
 }
 
-func (s *state) SetMultisigAlias(owner *multisig.AliasWithNonce) {
-	s.caminoState.SetMultisigAlias(owner)
+func (s *state) SetMultisigAlias(id ids.ShortID, owner *multisig.AliasWithNonce) {
+	s.caminoState.SetMultisigAlias(id, owner)
 }
 
 func (s *state) GetMultisigAlias(alias ids.ShortID) (*multisig.AliasWithNonce, error) {

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -955,15 +955,15 @@ func (mr *MockChainMockRecorder) SetFeeDistribution(arg0 any) *gomock.Call {
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockChain) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
+func (m *MockChain) SetMultisigAlias(arg0 ids.ShortID, arg1 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMultisigAlias", arg0)
+	m.ctrl.Call(m, "SetMultisigAlias", arg0, arg1)
 }
 
 // SetMultisigAlias indicates an expected call of SetMultisigAlias.
-func (mr *MockChainMockRecorder) SetMultisigAlias(arg0 any) *gomock.Call {
+func (mr *MockChainMockRecorder) SetMultisigAlias(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockChain)(nil).SetMultisigAlias), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockChain)(nil).SetMultisigAlias), arg0, arg1)
 }
 
 // SetNotDistributedValidatorReward mocks base method.
@@ -2203,15 +2203,15 @@ func (mr *MockStateMockRecorder) SetLastAccepted(blkID any) *gomock.Call {
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockState) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
+func (m *MockState) SetMultisigAlias(arg0 ids.ShortID, arg1 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMultisigAlias", arg0)
+	m.ctrl.Call(m, "SetMultisigAlias", arg0, arg1)
 }
 
 // SetMultisigAlias indicates an expected call of SetMultisigAlias.
-func (mr *MockStateMockRecorder) SetMultisigAlias(arg0 any) *gomock.Call {
+func (mr *MockStateMockRecorder) SetMultisigAlias(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockState)(nil).SetMultisigAlias), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockState)(nil).SetMultisigAlias), arg0, arg1)
 }
 
 // SetNotDistributedValidatorReward mocks base method.
@@ -3256,15 +3256,15 @@ func (mr *MockDiffMockRecorder) SetFeeDistribution(arg0 any) *gomock.Call {
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockDiff) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
+func (m *MockDiff) SetMultisigAlias(arg0 ids.ShortID, arg1 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMultisigAlias", arg0)
+	m.ctrl.Call(m, "SetMultisigAlias", arg0, arg1)
 }
 
 // SetMultisigAlias indicates an expected call of SetMultisigAlias.
-func (mr *MockDiffMockRecorder) SetMultisigAlias(arg0 any) *gomock.Call {
+func (mr *MockDiffMockRecorder) SetMultisigAlias(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockDiff)(nil).SetMultisigAlias), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockDiff)(nil).SetMultisigAlias), arg0, arg1)
 }
 
 // SetNotDistributedValidatorReward mocks base method.

--- a/vms/platformvm/txs/camino_deposit_tx.go
+++ b/vms/platformvm/txs/camino_deposit_tx.go
@@ -19,7 +19,7 @@ import (
 var (
 	_ UnsignedTx = (*DepositTx)(nil)
 
-	errTooBigDeposit         = errors.New("to big deposit")
+	errTooBigDeposit         = errors.New("too big deposit")
 	errInvalidRewardOwner    = errors.New("invalid reward owner")
 	errBadOfferOwnerAuth     = errors.New("bad offer owner auth")
 	errBadDepositCreatorAuth = errors.New("bad deposit creator auth")

--- a/vms/platformvm/txs/camino_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_deposit_tx_test.go
@@ -39,7 +39,7 @@ func TestDepositTxSyntacticVerify(t *testing.T) {
 			},
 			expectedErr: errInvalidRewardOwner,
 		},
-		"To big total deposit amount": {
+		"Too big total deposit amount": {
 			tx: &DepositTx{
 				BaseTx: BaseTx{BaseTx: avax.BaseTx{
 					NetworkID:    ctx.NetworkID,

--- a/vms/platformvm/txs/camino_multisig_alias_tx.go
+++ b/vms/platformvm/txs/camino_multisig_alias_tx.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	_                            UnsignedTx = (*MultisigAliasTx)(nil)
-	errFailedToVerifyAliasOrAuth            = errors.New("failed to verify alias or auth")
+	_ UnsignedTx = (*MultisigAliasTx)(nil)
+
+	errFailedToVerifyAliasOrAuth = errors.New("failed to verify alias or auth")
 )
 
 // MultisigAliasTx is an unsigned multisig alias tx

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -56,6 +56,7 @@ var (
 	errDepositDurationTooBig             = errors.New("deposit duration is greater than deposit offer maximum duration")
 	errSupplyOverflow                    = errors.New("resulting total supply would be more than allowed maximum")
 	errNotConsortiumMember               = errors.New("address isn't consortium member")
+	errConsortiumMember                  = errors.New("address is consortium member")
 	errValidatorNotFound                 = errors.New("validator not found")
 	errConsortiumMemberHasNode           = errors.New("consortium member already has registered node")
 	errSignatureMissing                  = errors.New("wrong signature")
@@ -1535,15 +1536,7 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		return err
 	}
 
-	baseCreds := e.Tx.Creds[:len(e.Tx.Creds)]
-
-	var aliasID ids.ShortID
-	nonce := uint64(0)
-
-	txID := e.Tx.ID()
-
 	// verify that alias isn't nesting another alias
-
 	isNestedMsig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
 	switch {
 	case err != nil:
@@ -1552,14 +1545,21 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		return errNestedMsigAlias
 	}
 
-	// Update existing multisig definition
+	aliasAddrState := as.AddressStateEmpty
+	baseCreds := e.Tx.Creds[:len(e.Tx.Creds)]
+	var aliasID ids.ShortID
+	nonce := uint64(0)
+	txID := e.Tx.ID()
+	isRemoval := tx.MultisigAlias.Owners.IsZero()
+	isUpdating := tx.MultisigAlias.ID != ids.ShortEmpty
+	// syntactically valid multisig alias ensures that is removal is also updating
 
-	if tx.MultisigAlias.ID != ids.ShortEmpty {
+	if isUpdating {
 		if len(e.Tx.Creds) < 2 {
 			return errWrongCredentialsNumber
 		}
 
-		alias, err := e.State.GetMultisigAlias(tx.MultisigAlias.ID)
+		oldAlias, err := e.State.GetMultisigAlias(tx.MultisigAlias.ID)
 		if err != nil {
 			return fmt.Errorf("%w, alias: %s", errAliasNotFound, tx.MultisigAlias.ID)
 		}
@@ -1570,14 +1570,28 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 			e.Tx.Unsigned,
 			tx.Auth,
 			e.Tx.Creds[len(e.Tx.Creds)-1],
-			alias.Owners,
+			oldAlias.Owners,
 			e.State,
 		); err != nil {
 			return fmt.Errorf("%w: %w", errAliasCredentialMismatch, err)
 		}
 
-		aliasID = alias.ID
-		nonce = alias.Nonce + 1
+		if isRemoval {
+			// verify that alias isn't consortium member or role admin
+			aliasAddrState, err = e.State.GetAddressStates(tx.MultisigAlias.ID)
+			switch {
+			case err != nil:
+				return err
+			case aliasAddrState.Is(as.AddressStateConsortium):
+				return errConsortiumMember
+			case aliasAddrState.Is(as.AddressStateRoleAdmin):
+				return errAdminCannotBeDeleted
+			}
+		} else {
+			nonce = oldAlias.Nonce + 1
+		}
+
+		aliasID = oldAlias.ID
 	} else {
 		aliasID = multisig.ComputeAliasID(txID)
 	}
@@ -1604,14 +1618,21 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 
 	// update state
 
-	e.State.SetMultisigAlias(&multisig.AliasWithNonce{
-		Alias: multisig.Alias{
-			ID:     aliasID,
-			Memo:   tx.MultisigAlias.Memo,
-			Owners: tx.MultisigAlias.Owners,
-		},
-		Nonce: nonce,
-	})
+	var msigAlias *multisig.AliasWithNonce
+	if isRemoval && aliasAddrState != as.AddressStateEmpty {
+		e.State.SetAddressStates(tx.MultisigAlias.ID, as.AddressStateEmpty)
+	} else if !isRemoval {
+		msigAlias = &multisig.AliasWithNonce{
+			Alias: multisig.Alias{
+				ID:     aliasID,
+				Memo:   tx.MultisigAlias.Memo,
+				Owners: tx.MultisigAlias.Owners,
+			},
+			Nonce: nonce,
+		}
+	}
+
+	e.State.SetMultisigAlias(aliasID, msigAlias)
 
 	// Consume the UTXOS
 	avax.Consume(e.State, tx.Ins)

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -5376,6 +5376,14 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 	ownerUTXO := generate.UTXO(ids.GenerateTestID(), ctx.AVAXAssetID, test.TxFee, owner, ids.Empty, ids.Empty, true)
 	msigUTXO := generate.UTXO(ids.GenerateTestID(), ctx.AVAXAssetID, test.TxFee, *msigOwner, ids.Empty, ids.Empty, true)
 
+	baseTx := txs.BaseTx{
+		BaseTx: avax.BaseTx{
+			NetworkID:    ctx.NetworkID,
+			BlockchainID: ctx.ChainID,
+			Ins:          []*avax.TransferableInput{generate.InFromUTXO(t, ownerUTXO, []uint32{0}, false)},
+		},
+	}
+
 	caminoGenesisConf := api.Camino{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
@@ -5394,13 +5402,7 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				return s
 			},
 			utx: &txs.MultisigAliasTx{
-				BaseTx: txs.BaseTx{
-					BaseTx: avax.BaseTx{
-						NetworkID:    ctx.NetworkID,
-						BlockchainID: ctx.ChainID,
-						Ins:          []*avax.TransferableInput{generate.InFromUTXO(t, ownerUTXO, []uint32{0}, false)},
-					},
-				},
+				BaseTx: baseTx,
 				MultisigAlias: multisig.Alias{
 					ID:     ids.ShortID{},
 					Memo:   msigAlias.Memo,
@@ -5421,13 +5423,7 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				return s
 			},
 			utx: &txs.MultisigAliasTx{
-				BaseTx: txs.BaseTx{
-					BaseTx: avax.BaseTx{
-						NetworkID:    ctx.NetworkID,
-						BlockchainID: ctx.ChainID,
-						Ins:          []*avax.TransferableInput{generate.InFromUTXO(t, ownerUTXO, []uint32{0}, false)},
-					},
-				},
+				BaseTx:        baseTx,
 				MultisigAlias: msigAlias.Alias,
 				Auth:          &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
 			},
@@ -5449,13 +5445,7 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				return s
 			},
 			utx: &txs.MultisigAliasTx{
-				BaseTx: txs.BaseTx{
-					BaseTx: avax.BaseTx{
-						NetworkID:    ctx.NetworkID,
-						BlockchainID: ctx.ChainID,
-						Ins:          []*avax.TransferableInput{generate.InFromUTXO(t, ownerUTXO, []uint32{0}, false)},
-					},
-				},
+				BaseTx:        baseTx,
 				MultisigAlias: msigAlias.Alias,
 				Auth:          &secp256k1fx.Input{SigIndices: []uint32{0}},
 			},
@@ -5464,6 +5454,56 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				{msigKeys[0]},
 			},
 			expectedErr: errAliasCredentialMismatch,
+		},
+		"Removing alias with consortium addr state": {
+			state: func(t *testing.T, c *gomock.Controller, utx *txs.MultisigAliasTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().GetMultisigAlias(msigAlias.ID).Return(msigAlias, nil)
+				expect.VerifyMultisigPermission(t, s, []ids.ShortID{
+					msigAliasOwners.Addrs[0],
+					msigAliasOwners.Addrs[1],
+				}, []*multisig.AliasWithNonce{})
+				s.EXPECT().GetAddressStates(msigAlias.Alias.ID).Return(as.AddressStateConsortium, nil)
+				return s
+			},
+			utx: &txs.MultisigAliasTx{
+				BaseTx: baseTx,
+				MultisigAlias: multisig.Alias{
+					ID:     msigAlias.ID,
+					Owners: &secp256k1fx.OutputOwners{},
+				},
+				Auth: &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
+			},
+			signers: [][]*secp256k1.PrivateKey{
+				{ownerKey},
+				{msigKeys[0], msigKeys[1]},
+			},
+			expectedErr: errConsortiumMember,
+		},
+		"Removing alias with role admin addr state": {
+			state: func(t *testing.T, c *gomock.Controller, utx *txs.MultisigAliasTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().GetMultisigAlias(msigAlias.ID).Return(msigAlias, nil)
+				expect.VerifyMultisigPermission(t, s, []ids.ShortID{
+					msigAliasOwners.Addrs[0],
+					msigAliasOwners.Addrs[1],
+				}, []*multisig.AliasWithNonce{})
+				s.EXPECT().GetAddressStates(msigAlias.Alias.ID).Return(as.AddressStateRoleAdmin, nil)
+				return s
+			},
+			utx: &txs.MultisigAliasTx{
+				BaseTx: baseTx,
+				MultisigAlias: multisig.Alias{
+					ID:     msigAlias.ID,
+					Owners: &secp256k1fx.OutputOwners{},
+				},
+				Auth: &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
+			},
+			signers: [][]*secp256k1.PrivateKey{
+				{ownerKey},
+				{msigKeys[0], msigKeys[1]},
+			},
+			expectedErr: errAdminCannotBeDeleted,
 		},
 		"OK, update existing alias": {
 			state: func(t *testing.T, c *gomock.Controller, utx *txs.MultisigAliasTx, txID ids.ID) *state.MockDiff {
@@ -5476,7 +5516,7 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				}, []*multisig.AliasWithNonce{})
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyLock(t, s, utx.Ins, []*avax.UTXO{ownerUTXO}, []ids.ShortID{ownerAddr}, nil)
-				s.EXPECT().SetMultisigAlias(&multisig.AliasWithNonce{
+				s.EXPECT().SetMultisigAlias(msigAlias.ID, &multisig.AliasWithNonce{
 					Alias: msigAlias.Alias,
 					Nonce: msigAlias.Nonce + 1,
 				})
@@ -5485,15 +5525,70 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				return s
 			},
 			utx: &txs.MultisigAliasTx{
-				BaseTx: txs.BaseTx{
-					BaseTx: avax.BaseTx{
-						NetworkID:    ctx.NetworkID,
-						BlockchainID: ctx.ChainID,
-						Ins:          []*avax.TransferableInput{generate.InFromUTXO(t, ownerUTXO, []uint32{0}, false)},
-					},
-				},
+				BaseTx:        baseTx,
 				MultisigAlias: msigAlias.Alias,
 				Auth:          &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
+			},
+			signers: [][]*secp256k1.PrivateKey{
+				{ownerKey},
+				{msigKeys[0], msigKeys[1]},
+			},
+		},
+		"OK, remove existing alias with non-empty addr state": {
+			state: func(t *testing.T, c *gomock.Controller, utx *txs.MultisigAliasTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().GetMultisigAlias(msigAlias.ID).Return(msigAlias, nil)
+				expect.VerifyMultisigPermission(t, s, []ids.ShortID{
+					msigAliasOwners.Addrs[0],
+					msigAliasOwners.Addrs[1],
+				}, []*multisig.AliasWithNonce{})
+				s.EXPECT().GetAddressStates(msigAlias.Alias.ID).Return(as.AddressStateKYCVerified, nil)
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
+				expect.VerifyLock(t, s, utx.Ins, []*avax.UTXO{ownerUTXO}, []ids.ShortID{ownerAddr}, nil)
+				s.EXPECT().SetAddressStates(msigAlias.Alias.ID, as.AddressStateEmpty)
+				s.EXPECT().SetMultisigAlias(msigAlias.Alias.ID, nil)
+				expect.ConsumeUTXOs(t, s, utx.Ins)
+				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
+				return s
+			},
+			utx: &txs.MultisigAliasTx{
+				BaseTx: baseTx,
+				MultisigAlias: multisig.Alias{
+					ID:     msigAlias.ID,
+					Memo:   msigAlias.Memo,
+					Owners: &secp256k1fx.OutputOwners{},
+				},
+				Auth: &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
+			},
+			signers: [][]*secp256k1.PrivateKey{
+				{ownerKey},
+				{msigKeys[0], msigKeys[1]},
+			},
+		},
+		"OK, remove existing alias with empty addr state": {
+			state: func(t *testing.T, c *gomock.Controller, utx *txs.MultisigAliasTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().GetMultisigAlias(msigAlias.ID).Return(msigAlias, nil)
+				expect.VerifyMultisigPermission(t, s, []ids.ShortID{
+					msigAliasOwners.Addrs[0],
+					msigAliasOwners.Addrs[1],
+				}, []*multisig.AliasWithNonce{})
+				s.EXPECT().GetAddressStates(msigAlias.Alias.ID).Return(as.AddressStateEmpty, nil)
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
+				expect.VerifyLock(t, s, utx.Ins, []*avax.UTXO{ownerUTXO}, []ids.ShortID{ownerAddr}, nil)
+				s.EXPECT().SetMultisigAlias(msigAlias.Alias.ID, nil)
+				expect.ConsumeUTXOs(t, s, utx.Ins)
+				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
+				return s
+			},
+			utx: &txs.MultisigAliasTx{
+				BaseTx: baseTx,
+				MultisigAlias: multisig.Alias{
+					ID:     msigAlias.ID,
+					Memo:   msigAlias.Memo,
+					Owners: &secp256k1fx.OutputOwners{},
+				},
+				Auth: &secp256k1fx.Input{SigIndices: []uint32{0, 1}},
 			},
 			signers: [][]*secp256k1.PrivateKey{
 				{ownerKey},
@@ -5506,9 +5601,10 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				expect.GetMultisigAliases(t, s, msigAliasOwners.Addrs, nil)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyLock(t, s, utx.Ins, []*avax.UTXO{ownerUTXO}, []ids.ShortID{ownerAddr}, nil)
-				s.EXPECT().SetMultisigAlias(&multisig.AliasWithNonce{
+				aliasID := multisig.ComputeAliasID(txID)
+				s.EXPECT().SetMultisigAlias(aliasID, &multisig.AliasWithNonce{
 					Alias: multisig.Alias{
-						ID:     multisig.ComputeAliasID(txID),
+						ID:     aliasID,
 						Memo:   msigAlias.Memo,
 						Owners: msigAlias.Owners,
 					},
@@ -5519,13 +5615,7 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				return s
 			},
 			utx: &txs.MultisigAliasTx{
-				BaseTx: txs.BaseTx{
-					BaseTx: avax.BaseTx{
-						NetworkID:    ctx.NetworkID,
-						BlockchainID: ctx.ChainID,
-						Ins:          []*avax.TransferableInput{generate.InFromUTXO(t, ownerUTXO, []uint32{0}, false)},
-					},
-				},
+				BaseTx: baseTx,
 				MultisigAlias: multisig.Alias{
 					ID:     ids.ShortID{},
 					Memo:   msigAlias.Memo,
@@ -5547,9 +5637,10 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 					msigAliasOwners.Addrs[0],
 					msigAliasOwners.Addrs[1],
 				}, []*multisig.AliasWithNonce{msigAlias})
-				s.EXPECT().SetMultisigAlias(&multisig.AliasWithNonce{
+				aliasID := multisig.ComputeAliasID(txID)
+				s.EXPECT().SetMultisigAlias(aliasID, &multisig.AliasWithNonce{
 					Alias: multisig.Alias{
-						ID:     multisig.ComputeAliasID(txID),
+						ID:     aliasID,
 						Memo:   msigAlias.Memo,
 						Owners: msigAlias.Owners,
 					},

--- a/vms/secp256k1fx/output_owners.go
+++ b/vms/secp256k1fx/output_owners.go
@@ -110,6 +110,10 @@ func (out *OutputOwners) Equals(other *OutputOwners) bool {
 	return true
 }
 
+func (out *OutputOwners) IsZero() bool {
+	return out.Equals(&OutputOwners{})
+}
+
 func (out *OutputOwners) Verify() error {
 	switch {
 	case out == nil:


### PR DESCRIPTION
## Why this should be merged
This PR adds the functionality of removing a multisig alias definition. Alias cannot be removed if its consortium member or role admin.
## How this works
If MultisigAliasTx contains empty multisig alias definition, but non-empty alias ID, than its removal.
To clarify: empty alias definition means that owners has no address and threshold is 0.
## How this was tested
By existing unit test with newly added test cases.
## Co-authors:
@evlekht rebased to latest dev, resolved conflicts. Cleaned up code, extended tests, added new checks and a few fixes.