### PR TITLE
[KYB/KYC] added KYB flag

### DIFF
--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -71,6 +71,30 @@ func TestCaminoBuilderTxAddressState(t *testing.T) {
 			address:     caminoPreFundedKeys[0].PublicKey().Address(),
 			expectedErr: nil,
 		},
+		"KYC Verified: Add": {
+			remove:      false,
+			state:       txs.AddressStateKycVerified,
+			address:     caminoPreFundedKeys[0].PublicKey().Address(),
+			expectedErr: nil,
+		},
+		"KYC Verified: Remove": {
+			remove:      true,
+			state:       txs.AddressStateKycVerified,
+			address:     caminoPreFundedKeys[0].PublicKey().Address(),
+			expectedErr: nil,
+		},
+		"KYB Verified: Add": {
+			remove:      false,
+			state:       txs.AddressStateKybVerified,
+			address:     caminoPreFundedKeys[0].PublicKey().Address(),
+			expectedErr: nil,
+		},
+		"KYB Verified: Remove": {
+			remove:      true,
+			state:       txs.AddressStateKybVerified,
+			address:     caminoPreFundedKeys[0].PublicKey().Address(),
+			expectedErr: nil,
+		},
 		"Admin Role: Add": {
 			remove:      false,
 			state:       txs.AddressStateRoleAdmin,

--- a/vms/platformvm/txs/camino_address_state_tx.go
+++ b/vms/platformvm/txs/camino_address_state_tx.go
@@ -19,13 +19,13 @@ const (
 	AddressStateRoleKycBit   = uint64(0b10)
 	AddressStateRoleBits     = uint64(0b11)
 
+	AddressStateKybVerified    = uint8(31)
+	AddressStateKybVerifiedBit = uint64(0b0010000000000000000000000000000000)
 	AddressStateKycVerified    = uint8(32)
-	AddressStateKycVerifiedBit = uint64(0b00100000000000000000000000000000000)
+	AddressStateKycVerifiedBit = uint64(0b0100000000000000000000000000000000)
 	AddressStateKycExpired     = uint8(33)
-	AddressStateKycExpiredBit  = uint64(0b01000000000000000000000000000000000)
-	AddressStateKybVerified    = uint8(34)
-	AddressStateKybVerifiedBit = uint64(0b10000000000000000000000000000000000)
-	AddressStateKycBits        = uint64(0b11100000000000000000000000000000000)
+	AddressStateKycExpiredBit  = uint64(0b1000000000000000000000000000000000)
+	AddressStateKycBits        = uint64(0b11111111000000000000000000000000000)
 
 	AddressStateConsortium      = uint8(38)
 	AddressStateConsortiumBit   = uint64(0b0100000000000000000000000000000000000000)

--- a/vms/platformvm/txs/camino_address_state_tx.go
+++ b/vms/platformvm/txs/camino_address_state_tx.go
@@ -20,10 +20,12 @@ const (
 	AddressStateRoleBits     = uint64(0b11)
 
 	AddressStateKycVerified    = uint8(32)
-	AddressStateKycVerifiedBit = uint64(0b0100000000000000000000000000000000)
+	AddressStateKycVerifiedBit = uint64(0b00100000000000000000000000000000000)
 	AddressStateKycExpired     = uint8(33)
-	AddressStateKycExpiredBit  = uint64(0b1000000000000000000000000000000000)
-	AddressStateKycBits        = uint64(0b1100000000000000000000000000000000)
+	AddressStateKycExpiredBit  = uint64(0b01000000000000000000000000000000000)
+	AddressStateKybVerified    = uint8(34)
+	AddressStateKybVerifiedBit = uint64(0b10000000000000000000000000000000000)
+	AddressStateKycBits        = uint64(0b11100000000000000000000000000000000)
 
 	AddressStateConsortium      = uint8(38)
 	AddressStateConsortiumBit   = uint64(0b0100000000000000000000000000000000000000)


### PR DESCRIPTION
- Added KYB Flag
- Add new test cases

## Why this should be merged
To set the new KYB state i need a new StateBit/Flag on P-Chain, this PR implements this.
This assumes that the extension of the `AddressStateKycBits` is transparent to the Authentication logic and will just work. @Markus please confim.

## How this works
Add a new State Bit for the new State.

## How this was tested
added 4 new unit tests
