### PR TITLE
[PVM] RewardValidatorTx fix to expected bonded input fields.

### DIFF
--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -292,8 +292,11 @@ func TestNewClaimTx(t *testing.T) {
 				NetworkID:    ctx.NetworkID,
 				BlockchainID: ctx.ChainID,
 				Ins: []*avax.TransferableInput{{
-					UTXOID: feeUTXO.UTXOID,
-					Asset:  feeUTXO.Asset,
+					UTXOID: avax.UTXOID{
+						TxID:        feeUTXO.TxID,
+						OutputIndex: feeUTXO.OutputIndex,
+					},
+					Asset: feeUTXO.Asset,
 					In: &secp256k1fx.TransferInput{
 						Amt:   defaultTxFee,
 						Input: secp256k1fx.Input{SigIndices: []uint32{0}},

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -1585,6 +1585,13 @@ func TestCaminoRewardValidatorTx(t *testing.T) {
 	env.config.BanffTime = env.state.GetTimestamp()
 
 	t.Run("Happy path on abort", func(t *testing.T) {
+		// utxoids are polluted with cached ids, need to clean this non-exported field
+		for _, in := range ins {
+			in.UTXOID = avax.UTXOID{
+				TxID:        in.TxID,
+				OutputIndex: in.OutputIndex,
+			}
+		}
 		txExecutor, tx := execute(t, happyPathTest)
 		txExecutor.OnAbortState.Apply(env.state)
 		env.state.SetHeight(uint64(1))

--- a/vms/platformvm/utxo/camino_helpers_test.go
+++ b/vms/platformvm/utxo/camino_helpers_test.go
@@ -201,7 +201,6 @@ func generateTestUTXO(txID ids.ID, assetID ids.ID, amount uint64, outputOwners s
 		Asset:  avax.Asset{ID: assetID},
 		Out:    out,
 	}
-	testUTXO.InputID()
 	return testUTXO
 }
 
@@ -256,11 +255,13 @@ func generateTestInFromUTXO(utxo *avax.UTXO, sigIndices []uint32) *avax.Transfer
 	}
 
 	// to be sure that utxoid.id is set in both entities
-	utxo.InputID()
 	return &avax.TransferableInput{
-		UTXOID: utxo.UTXOID,
-		Asset:  utxo.Asset,
-		In:     in,
+		UTXOID: avax.UTXOID{
+			TxID:        utxo.TxID,
+			OutputIndex: utxo.OutputIndex,
+		},
+		Asset: utxo.Asset,
+		In:    in,
 	}
 }
 

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -381,9 +381,12 @@ func (h *handler) Lock(
 			}
 
 			ins = append(ins, &avax.TransferableInput{
-				UTXOID: utxo.UTXOID,
-				Asset:  avax.Asset{ID: h.ctx.AVAXAssetID},
-				In:     in,
+				UTXOID: avax.UTXOID{
+					TxID:        utxo.TxID,
+					OutputIndex: utxo.OutputIndex,
+				},
+				Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
+				In:    in,
 			})
 			signers = append(signers, inSigners)
 			owners = append(owners, &innerOut.OutputOwners)
@@ -580,13 +583,16 @@ func (h *handler) unlockUTXOs(
 
 		// Add the input to the consumed inputs
 		ins = append(ins, &avax.TransferableInput{
-			UTXOID: utxo.UTXOID,
-			Asset:  avax.Asset{ID: h.ctx.AVAXAssetID},
+			UTXOID: avax.UTXOID{
+				TxID:        utxo.TxID,
+				OutputIndex: utxo.OutputIndex,
+			},
+			Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 			In: &locked.In{
 				IDs: out.IDs,
 				TransferableIn: &secp256k1fx.TransferInput{
 					Amt:   out.Amount(),
-					Input: secp256k1fx.Input{},
+					Input: secp256k1fx.Input{SigIndices: []uint32{}},
 				},
 			},
 		})
@@ -699,8 +705,11 @@ func (h *handler) UnlockDeposit(
 
 		// Add the input to the consumed inputs
 		ins = append(ins, &avax.TransferableInput{
-			UTXOID: utxo.UTXOID,
-			Asset:  avax.Asset{ID: h.ctx.AVAXAssetID},
+			UTXOID: avax.UTXOID{
+				TxID:        utxo.TxID,
+				OutputIndex: utxo.OutputIndex,
+			},
+			Asset: avax.Asset{ID: h.ctx.AVAXAssetID},
 			In: &locked.In{
 				IDs:            out.IDs,
 				TransferableIn: in,

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -65,7 +65,7 @@ func TestUnlockUTXOs(t *testing.T) {
 			generateWant: func(utxos []*avax.UTXO) want {
 				return want{
 					ins: []*avax.TransferableInput{
-						generateTestInFromUTXO(utxos[0], nil),
+						generateTestInFromUTXO(utxos[0], []uint32{}),
 					},
 					outs: []*avax.TransferableOutput{
 						generateTestOut(ctx.AVAXAssetID, 5, outputOwners, ids.Empty, ids.Empty),
@@ -81,7 +81,7 @@ func TestUnlockUTXOs(t *testing.T) {
 			generateWant: func(utxos []*avax.UTXO) want {
 				return want{
 					ins: []*avax.TransferableInput{
-						generateTestInFromUTXO(utxos[0], nil),
+						generateTestInFromUTXO(utxos[0], []uint32{}),
 					},
 					outs: []*avax.TransferableOutput{
 						generateTestOut(ctx.AVAXAssetID, 5, outputOwners, ids.Empty, ids.Empty),


### PR DESCRIPTION
Fixed dirty UTXOID copying - now only TxID and OutputIndex fields are copied.
Fixed rewardValidatorTx expected inputs - tx was failing with nil SigIndices and dirty UTXOID.id