### PR TITLE
Admin Removal Forbidding

### DIFF
--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -71,6 +71,7 @@ var (
 	errMixedDeposits                  = errors.New("tx has expired deposit input and active-deposit/unlocked input")
 	errExpiredDepositNotFullyUnlocked = errors.New("unlocked only part of expired deposit")
 	errBurnedDepositUnlock            = errors.New("burned undeposited tokens")
+	errAdminCannotBeDeleted           = errors.New("admin cannot be deleted")
 )
 
 type CaminoStandardTxExecutor struct {
@@ -1513,6 +1514,11 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 	// Calculate new states
 	newStates := states
 	if tx.Remove && (states&statesBit) != 0 {
+		for signerAddresses := range addresses {
+			if signerAddresses == tx.Address && (states&txs.AddressStateRoleAdmin) == 1 {
+				return errAdminCannotBeDeleted
+			}
+		}
 		newStates ^= statesBit
 	} else if !tx.Remove {
 		newStates |= statesBit

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -1672,6 +1672,15 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 			expectedState: txs.AddressStateRoleAdmin,
 			remove:        false,
 		},
+		// Bob has Admin State, and he is trying to remove from Alice the Admin Role
+		"State: Admin, Flag: Admin, Remove, Different Address": {
+			stateAddress:  bob,
+			targetAddress: alice,
+			txFlag:        txs.AddressStateBitRoleAdmin,
+			existingState: txs.AddressStateRoleAdmin,
+			expectedState: 0,
+			remove:        true,
+		},
 		// Bob has Admin State, and he is trying to give Alice KYC Role
 		"State: Admin, Flag: kyc, Add, Different Address": {
 			stateAddress:  bob,
@@ -1688,6 +1697,16 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 			txFlag:        txs.AddressStateBitRoleKYC,
 			existingState: txs.AddressStateRoleAdmin,
 			expectedState: 0,
+			remove:        true,
+		},
+		// Bob has Admin State, and he is trying to remove it from himself
+		"State: Admin, Flag: admin, Remove, Same Address": {
+			stateAddress:  bob,
+			targetAddress: bob,
+			txFlag:        txs.AddressStateBitRoleAdmin,
+			existingState: txs.AddressStateRoleAdmin,
+			expectedState: 0,
+			expectedErr:   errAdminCannotBeDeleted,
 			remove:        true,
 		},
 		// Bob has Admin State, and he is trying to give Alice the KYC Verified State


### PR DESCRIPTION
## Why this should be merged
AddressStateTx handler allows a user to remove the admin bit from themselves. If the only administrative account does this, there will be no remaining admins. This PR solves this issue by forbidding an account to revoke the admin role iff the target address is the same as the signer's.

## How this works
Added some simple statements in AddressStateTx function. They check:

1. If the state address is the same as the tx's address
2. If the state is Admin

If both these conditions are true then, it throws an "admin cannot be deleted" error.

## How this was tested
With test case addition in TestAddAddressStateTxExecutor function.