### PR TITLE
[PVM] Define types for offer flags, address state and address state bits

### DIFF
--- a/genesis/camino_config.go
+++ b/genesis/camino_config.go
@@ -211,16 +211,16 @@ type AddressStates struct {
 }
 
 type DepositOffer struct {
-	InterestRateNominator   uint64 `json:"interestRateNominator"`
-	Start                   uint64 `json:"start"`
-	End                     uint64 `json:"end"`
-	MinAmount               uint64 `json:"minAmount"`
-	MinDuration             uint32 `json:"minDuration"`
-	MaxDuration             uint32 `json:"maxDuration"`
-	UnlockPeriodDuration    uint32 `json:"unlockPeriodDuration"`
-	NoRewardsPeriodDuration uint32 `json:"noRewardsPeriodDuration"`
-	Memo                    string `json:"memo"`
-	Flags                   uint64 `json:"flags"`
+	InterestRateNominator   uint64            `json:"interestRateNominator"`
+	Start                   uint64            `json:"start"`
+	End                     uint64            `json:"end"`
+	MinAmount               uint64            `json:"minAmount"`
+	MinDuration             uint32            `json:"minDuration"`
+	MaxDuration             uint32            `json:"maxDuration"`
+	UnlockPeriodDuration    uint32            `json:"unlockPeriodDuration"`
+	NoRewardsPeriodDuration uint32            `json:"noRewardsPeriodDuration"`
+	Memo                    string            `json:"memo"`
+	Flags                   deposit.OfferFlag `json:"flags"`
 }
 
 func (parsedOffer DepositOffer) Unparse(startime uint64) (UnparsedDepositOffer, error) {

--- a/genesis/camino_genesis.go
+++ b/genesis/camino_genesis.go
@@ -364,12 +364,12 @@ func buildPGenesis(config *Config, hrp string, xGenesisBytes []byte, xGenesisDat
 	// Getting args from allocations
 
 	for _, allocation := range config.Camino.Allocations {
-		var addrState uint64
+		var addrState pchaintxs.AddressState
 		if allocation.AddressStates.ConsortiumMember {
-			addrState |= pchaintxs.AddressStateConsortiumBit
+			addrState |= pchaintxs.AddressStateConsortiumMember
 		}
 		if allocation.AddressStates.KYCVerified {
-			addrState |= pchaintxs.AddressStateKycVerifiedBit
+			addrState |= pchaintxs.AddressStateKYCVerified
 		}
 		if addrState != 0 {
 			platformvmArgs.Camino.AddressStates = append(platformvmArgs.Camino.AddressStates, genesis.AddressState{

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -250,10 +250,10 @@ type SetAddressStateArgs struct {
 	api.UserPass
 	api.JSONFromAddrs
 
-	Change  platformapi.Owner `json:"change"`
-	Address string            `json:"address"`
-	State   uint8             `json:"state"`
-	Remove  bool              `json:"remove"`
+	Change  platformapi.Owner   `json:"change"`
+	Address string              `json:"address"`
+	State   txs.AddressStateBit `json:"state"`
+	Remove  bool                `json:"remove"`
 }
 
 // AddAdressState issues an AddAdressStateTx

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -79,7 +79,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 	tx, err := vm.txBuilder.NewAddressStateTx(
 		consortiumMemberKey.Address(),
 		false,
-		txs.AddressStateConsortium,
+		txs.AddressStateBitConsortium,
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		outputOwners,
 	)
@@ -151,7 +151,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 	tx, err = vm.txBuilder.NewAddressStateTx(
 		consortiumMemberKey.Address(),
 		false,
-		txs.AddressStateNodeDeferred,
+		txs.AddressStateBitNodeDeferred,
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		outputOwners,
 	)
@@ -175,7 +175,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 
 	// Verify that the validator's owner's deferred state and consortium member is true
 	ownerState, _ := vm.state.GetAddressStates(consortiumMemberKey.Address())
-	require.Equal(ownerState, txs.AddressStateNodeDeferredBit|txs.AddressStateConsortiumBit)
+	require.Equal(ownerState, txs.AddressStateNodeDeferred|txs.AddressStateConsortiumMember)
 
 	// Fast-forward clock to time for validator to be rewarded
 	vm.clock.Set(endTime)
@@ -226,7 +226,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 
 	// Verify that the validator's owner's deferred state is false
 	ownerState, _ = vm.state.GetAddressStates(consortiumMemberKey.Address())
-	require.Equal(ownerState, txs.AddressStateConsortiumBit)
+	require.Equal(ownerState, txs.AddressStateConsortiumMember)
 
 	timestamp := vm.state.GetTimestamp()
 	require.Equal(endTime.Unix(), timestamp.Unix())
@@ -277,7 +277,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 	tx, err := vm.txBuilder.NewAddressStateTx(
 		consortiumMemberKey.Address(),
 		false,
-		txs.AddressStateConsortium,
+		txs.AddressStateBitConsortium,
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		outputOwners,
 	)
@@ -350,7 +350,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 	tx, err = vm.txBuilder.NewAddressStateTx(
 		consortiumMemberKey.Address(),
 		false,
-		txs.AddressStateNodeDeferred,
+		txs.AddressStateBitNodeDeferred,
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		outputOwners,
 	)
@@ -376,7 +376,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 	tx, err = vm.txBuilder.NewAddressStateTx(
 		consortiumMemberKey.Address(),
 		true,
-		txs.AddressStateNodeDeferred,
+		txs.AddressStateBitNodeDeferred,
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		outputOwners,
 	)

--- a/vms/platformvm/deposit/camino_deposit.go
+++ b/vms/platformvm/deposit/camino_deposit.go
@@ -18,11 +18,13 @@ import (
 	"github.com/ava-labs/avalanchego/vms/types"
 )
 
+type OfferFlag uint64
+
 const (
 	interestRateBase        = 365 * 24 * 60 * 60
 	interestRateDenominator = 1_000_000 * interestRateBase
 
-	OfferFlagLocked uint64 = 0b1
+	OfferFlagLocked OfferFlag = 0b1
 )
 
 var bigInterestRateDenominator = (&big.Int{}).SetInt64(interestRateDenominator)
@@ -41,7 +43,7 @@ type Offer struct {
 	UnlockPeriodDuration    uint32              `serialize:"true" json:"unlockPeriodDuration"`    // Duration of period during which tokens deposited with this offer will be unlocked. The unlock period starts at the end of deposit minus unlockPeriodDuration
 	NoRewardsPeriodDuration uint32              `serialize:"true" json:"noRewardsPeriodDuration"` // Duration of period during which rewards won't be accumulated. No rewards period starts at the end of deposit minus unlockPeriodDuration
 	Memo                    types.JSONByteSlice `serialize:"true" json:"memo"`                    // Arbitrary offer memo
-	Flags                   uint64              `serialize:"true" json:"flags"`                   // Bitfield with flags
+	Flags                   OfferFlag           `serialize:"true" json:"flags"`                   // Bitfield with flags
 }
 
 // Sets offer id from its bytes hash

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -44,8 +44,8 @@ type ConsortiumMemberNodeID struct {
 }
 
 type AddressState struct {
-	Address ids.ShortID `serialize:"true"`
-	State   uint64      `serialize:"true"`
+	Address ids.ShortID      `serialize:"true"`
+	State   txs.AddressState `serialize:"true"`
 }
 
 type Block struct {

--- a/vms/platformvm/state/camino_address_state.go
+++ b/vms/platformvm/state/camino_address_state.go
@@ -8,35 +8,33 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
 // Set a new state assigned to the address id
-func (cs *caminoState) SetAddressStates(address ids.ShortID, states uint64) {
+func (cs *caminoState) SetAddressStates(address ids.ShortID, states txs.AddressState) {
 	cs.modifiedAddressStates[address] = states
 	cs.addressStateCache.Evict(address)
 }
 
 // Return the current state (if exists) for an address
-func (cs *caminoState) GetAddressStates(address ids.ShortID) (uint64, error) {
+func (cs *caminoState) GetAddressStates(address ids.ShortID) (txs.AddressState, error) {
 	// Try to get from modified state
 	item, ok := cs.modifiedAddressStates[address]
 	// Try to get from cache
 	if !ok {
-		var itemIntf interface{}
-		if itemIntf, ok = cs.addressStateCache.Get(address); ok {
-			item = itemIntf.(uint64)
-		}
+		item, ok = cs.addressStateCache.Get(address)
 	}
 	// Finally get it from database
 	if !ok {
 		uintBytes, err := cs.addressStateDB.Get(address[:])
 		switch err {
 		case nil:
-			item = binary.LittleEndian.Uint64(uintBytes)
+			item = txs.AddressState(binary.LittleEndian.Uint64(uintBytes))
 		case database.ErrNotFound:
-			item = 0
+			item = txs.AddressStateEmpty
 		default:
-			return 0, err
+			return txs.AddressStateEmpty, err
 		}
 		cs.addressStateCache.Put(address, item)
 	}
@@ -52,7 +50,7 @@ func (cs *caminoState) writeAddressStates() error {
 			}
 		} else {
 			buf := make([]byte, 8)
-			binary.LittleEndian.PutUint64(buf, val)
+			binary.LittleEndian.PutUint64(buf, uint64(val))
 			if err := cs.addressStateDB.Put(key[:], buf); err != nil {
 				return err
 			}

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
 func NewCaminoDiff(
@@ -93,11 +94,11 @@ func (d *diff) CaminoConfig() (*CaminoConfig, error) {
 	return parentState.CaminoConfig()
 }
 
-func (d *diff) SetAddressStates(address ids.ShortID, states uint64) {
+func (d *diff) SetAddressStates(address ids.ShortID, states txs.AddressState) {
 	d.caminoDiff.modifiedAddressStates[address] = states
 }
 
-func (d *diff) GetAddressStates(address ids.ShortID) (uint64, error) {
+func (d *diff) GetAddressStates(address ids.ShortID) (txs.AddressState, error) {
 	if states, ok := d.caminoDiff.modifiedAddressStates[address]; ok {
 		return states, nil
 	}

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 )
 
 func (s *state) LockedUTXOs(txIDs set.Set[ids.ID], addresses set.Set[ids.ShortID], lockState locked.State) ([]*avax.UTXO, error) {
@@ -48,11 +49,11 @@ func (s *state) CaminoConfig() (*CaminoConfig, error) {
 	return s.caminoState.CaminoConfig(), nil
 }
 
-func (s *state) SetAddressStates(address ids.ShortID, states uint64) {
+func (s *state) SetAddressStates(address ids.ShortID, states txs.AddressState) {
 	s.caminoState.SetAddressStates(address, states)
 }
 
-func (s *state) GetAddressStates(address ids.ShortID) (uint64, error) {
+func (s *state) GetAddressStates(address ids.ShortID) (txs.AddressState, error) {
 	return s.caminoState.GetAddressStates(address)
 }
 

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -248,17 +248,17 @@ func TestSyncGenesis(t *testing.T) {
 				g: defaultGenesisState([]pvm_genesis.AddressState{
 					{
 						Address: initialAdmin,
-						State:   txs.AddressStateRoleAdminBit,
+						State:   txs.AddressStateRoleAdmin,
 					},
 					{
 						Address: shortID,
-						State:   txs.AddressStateRoleKycBit,
+						State:   txs.AddressStateRoleKYC,
 					},
 				}, depositTxs, initialAdmin),
 			},
 			cs: *wrappers.IgnoreError(newCaminoState(baseDB, validatorsDB, prometheus.NewRegistry())).(*caminoState),
 			want: caminoDiff{
-				modifiedAddressStates: map[ids.ShortID]uint64{initialAdmin: txs.AddressStateRoleAdminBit, shortID: txs.AddressStateRoleKycBit},
+				modifiedAddressStates: map[ids.ShortID]txs.AddressState{initialAdmin: txs.AddressStateRoleAdmin, shortID: txs.AddressStateRoleKYC},
 				modifiedDepositOffers: map[ids.ID]*deposit.Offer{
 					depositOffers[0].ID: depositOffers[0],
 					depositOffers[1].ID: depositOffers[1],

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -221,10 +221,10 @@ func (mr *MockChainMockRecorder) DeleteUTXO(arg0 interface{}) *gomock.Call {
 }
 
 // GetAddressStates mocks base method.
-func (m *MockChain) GetAddressStates(arg0 ids.ShortID) (uint64, error) {
+func (m *MockChain) GetAddressStates(arg0 ids.ShortID) (txs.AddressState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAddressStates", arg0)
-	ret0, _ := ret[0].(uint64)
+	ret0, _ := ret[0].(txs.AddressState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -699,7 +699,7 @@ func (mr *MockChainMockRecorder) PutPendingValidator(arg0 interface{}) *gomock.C
 }
 
 // SetAddressStates mocks base method.
-func (m *MockChain) SetAddressStates(arg0 ids.ShortID, arg1 uint64) {
+func (m *MockChain) SetAddressStates(arg0 ids.ShortID, arg1 txs.AddressState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAddressStates", arg0, arg1)
 }

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -245,10 +245,10 @@ func (mr *MockDiffMockRecorder) DeleteUTXO(arg0 interface{}) *gomock.Call {
 }
 
 // GetAddressStates mocks base method.
-func (m *MockDiff) GetAddressStates(arg0 ids.ShortID) (uint64, error) {
+func (m *MockDiff) GetAddressStates(arg0 ids.ShortID) (txs.AddressState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAddressStates", arg0)
-	ret0, _ := ret[0].(uint64)
+	ret0, _ := ret[0].(txs.AddressState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -723,7 +723,7 @@ func (mr *MockDiffMockRecorder) PutPendingValidator(arg0 interface{}) *gomock.Ca
 }
 
 // SetAddressStates mocks base method.
-func (m *MockDiff) SetAddressStates(arg0 ids.ShortID, arg1 uint64) {
+func (m *MockDiff) SetAddressStates(arg0 ids.ShortID, arg1 txs.AddressState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAddressStates", arg0, arg1)
 }

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -293,10 +293,10 @@ func (mr *MockStateMockRecorder) DeleteUTXO(arg0 interface{}) *gomock.Call {
 }
 
 // GetAddressStates mocks base method.
-func (m *MockState) GetAddressStates(arg0 ids.ShortID) (uint64, error) {
+func (m *MockState) GetAddressStates(arg0 ids.ShortID) (txs.AddressState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAddressStates", arg0)
-	ret0, _ := ret[0].(uint64)
+	ret0, _ := ret[0].(txs.AddressState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -864,7 +864,7 @@ func (mr *MockStateMockRecorder) PutPendingValidator(arg0 interface{}) *gomock.C
 }
 
 // SetAddressStates mocks base method.
-func (m *MockState) SetAddressStates(arg0 ids.ShortID, arg1 uint64) {
+func (m *MockState) SetAddressStates(arg0 ids.ShortID, arg1 txs.AddressState) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAddressStates", arg0, arg1)
 }

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -59,7 +59,7 @@ type CaminoTxBuilder interface {
 	NewAddressStateTx(
 		address ids.ShortID,
 		remove bool,
-		state uint8,
+		state txs.AddressStateBit,
 		keys []*secp256k1.PrivateKey,
 		change *secp256k1fx.OutputOwners,
 	) (*txs.Tx, error)
@@ -293,7 +293,7 @@ func (b *caminoBuilder) NewRewardValidatorTx(txID ids.ID) (*txs.Tx, error) {
 func (b *caminoBuilder) NewAddressStateTx(
 	address ids.ShortID,
 	remove bool,
-	state uint8,
+	state txs.AddressStateBit,
 	keys []*secp256k1.PrivateKey,
 	change *secp256k1fx.OutputOwners,
 ) (*txs.Tx, error) {

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -55,37 +55,37 @@ func TestCaminoBuilderTxAddressState(t *testing.T) {
 
 	tests := map[string]struct {
 		remove      bool
-		state       uint8
+		state       txs.AddressStateBit
 		address     ids.ShortID
 		expectedErr error
 	}{
 		"KYC Role: Add": {
 			remove:      false,
-			state:       txs.AddressStateRoleKyc,
+			state:       txs.AddressStateBitRoleKYC,
 			address:     caminoPreFundedKeys[0].PublicKey().Address(),
 			expectedErr: nil,
 		},
 		"KYC Role: Remove": {
 			remove:      true,
-			state:       txs.AddressStateRoleKyc,
+			state:       txs.AddressStateBitRoleKYC,
 			address:     caminoPreFundedKeys[0].PublicKey().Address(),
 			expectedErr: nil,
 		},
 		"Admin Role: Add": {
 			remove:      false,
-			state:       txs.AddressStateRoleAdmin,
+			state:       txs.AddressStateBitRoleAdmin,
 			address:     caminoPreFundedKeys[0].PublicKey().Address(),
 			expectedErr: nil,
 		},
 		"Admin Role: Remove": {
 			remove:      true,
-			state:       txs.AddressStateRoleAdmin,
+			state:       txs.AddressStateBitRoleAdmin,
 			address:     caminoPreFundedKeys[0].PublicKey().Address(),
 			expectedErr: nil,
 		},
 		"Empty Address": {
 			remove:      false,
-			state:       txs.AddressStateRoleKyc,
+			state:       txs.AddressStateBitRoleKYC,
 			address:     ids.ShortEmpty,
 			expectedErr: txs.ErrEmptyAddress,
 		},

--- a/vms/platformvm/txs/camino_address_state_tx_test.go
+++ b/vms/platformvm/txs/camino_address_state_tx_test.go
@@ -90,7 +90,7 @@ func TestAddressStateTxSyntacticVerify(t *testing.T) {
 			Memo:         []byte{1, 2, 3, 4, 5, 6, 7, 8},
 		}},
 		Address: preFundedKeys[0].PublicKey().Address(),
-		State:   AddressStateRoleAdmin,
+		State:   AddressStateBitRoleAdmin,
 		Remove:  false,
 	}
 
@@ -104,7 +104,7 @@ func TestAddressStateTxSyntacticVerify(t *testing.T) {
 			Memo:         []byte{1, 2, 3, 4, 5, 6, 7, 8},
 		}},
 		Address: preFundedKeys[0].PublicKey().Address(),
-		State:   AddressStateRoleAdmin,
+		State:   AddressStateBitRoleAdmin,
 		Remove:  false,
 	}
 
@@ -118,7 +118,7 @@ func TestAddressStateTxSyntacticVerify(t *testing.T) {
 			Memo:         []byte{1, 2, 3, 4, 5, 6, 7, 8},
 		}},
 		Address: preFundedKeys[0].PublicKey().Address(),
-		State:   AddressStateRoleAdmin,
+		State:   AddressStateBitRoleAdmin,
 		Remove:  false,
 	}
 
@@ -143,7 +143,7 @@ func TestAddressStateTxSyntacticVerify(t *testing.T) {
 	require.NoError(err)
 	err = stx.SyntacticVerify(ctx)
 	require.Error(err, ErrInvalidState)
-	addressStateTx.State = AddressStateRoleAdmin
+	addressStateTx.State = AddressStateBitRoleAdmin
 
 	// Locked out
 	stx, err = NewSigned(addressStateTxLocked, Codec, signers)

--- a/vms/platformvm/txs/camino_multisig_alias_tx.go
+++ b/vms/platformvm/txs/camino_multisig_alias_tx.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/vms/components/multisig"
 	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 )
 
 var (
@@ -49,6 +50,10 @@ func (tx *MultisigAliasTx) SyntacticVerify(ctx *snow.Context) error {
 	}
 	if err := verify.All(&tx.MultisigAlias, tx.Auth); err != nil {
 		return fmt.Errorf("%w: %s", errFailedToVerifyAliasOrAuth, err.Error())
+	}
+
+	if err := locked.VerifyNoLocks(tx.Ins, tx.Outs); err != nil {
+		return err
 	}
 
 	// cache that this is valid

--- a/vms/platformvm/txs/executor/camino_advance_time_test.go
+++ b/vms/platformvm/txs/executor/camino_advance_time_test.go
@@ -373,7 +373,7 @@ func deferValidator(env *caminoEnvironment, nodeOwnerAddress ids.ShortID, key *s
 	tx, err := env.txBuilder.NewAddressStateTx(
 		nodeOwnerAddress,
 		false,
-		txs.AddressStateNodeDeferred,
+		txs.AddressStateBitNodeDeferred,
 		[]*secp256k1.PrivateKey{key},
 		outputOwners,
 	)

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -85,6 +85,10 @@ type CaminoProposalTxExecutor struct {
  * has access to this node specific private key.
  */
 func (e *CaminoStandardTxExecutor) verifyNodeSignature(nodeID ids.NodeID) error {
+	if len(e.Tx.Creds) < 2 {
+		return errWrongCredentialsNumber
+	}
+
 	return e.verifyNodeSignatureSig(nodeID, e.Tx.Creds[len(e.Tx.Creds)-1])
 }
 
@@ -132,6 +136,10 @@ func (e *CaminoStandardTxExecutor) AddValidatorTx(tx *txs.AddValidatorTx) error 
 
 	if err := e.Tx.SyntacticVerify(e.Backend.Ctx); err != nil {
 		return err
+	}
+
+	if len(e.Tx.Creds) < 2 {
+		return errWrongCredentialsNumber
 	}
 
 	// verify that node owned by consortium member
@@ -545,7 +553,7 @@ func (e *CaminoProposalTxExecutor) RewardValidatorTx(tx *txs.RewardValidatorTx) 
 		if err != nil {
 			return err
 		}
-		e.OnCommitState.SetAddressStates(nodeOwnerAddressOnCommit, nodeOwnerAddressStateOnCommit&^txs.AddressStateNodeDeferredBit)
+		e.OnCommitState.SetAddressStates(nodeOwnerAddressOnCommit, nodeOwnerAddressStateOnCommit&^txs.AddressStateNodeDeferred)
 
 		// Reset deferred bit on node owner address for onAbortState
 		nodeOwnerAddressOnAbort, err := e.OnAbortState.GetShortIDLink(
@@ -559,7 +567,7 @@ func (e *CaminoProposalTxExecutor) RewardValidatorTx(tx *txs.RewardValidatorTx) 
 		if err != nil {
 			return err
 		}
-		e.OnCommitState.SetAddressStates(nodeOwnerAddressOnAbort, nodeOwnerAddressStateOnAbort&^txs.AddressStateNodeDeferredBit)
+		e.OnCommitState.SetAddressStates(nodeOwnerAddressOnAbort, nodeOwnerAddressStateOnAbort&^txs.AddressStateNodeDeferred)
 	}
 
 	txID := e.Tx.ID()
@@ -962,7 +970,7 @@ func (e *CaminoStandardTxExecutor) RegisterNodeTx(tx *txs.RegisterNodeTx) error 
 		return err
 	}
 
-	if consortiumMemberAddressState&txs.AddressStateConsortiumBit == 0 {
+	if consortiumMemberAddressState&txs.AddressStateConsortiumMember == 0 {
 		return errNotConsortiumMember
 	}
 
@@ -1283,10 +1291,6 @@ func (e *CaminoStandardTxExecutor) BaseTx(tx *txs.BaseTx) error {
 }
 
 func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) error {
-	if err := locked.VerifyNoLocks(tx.Ins, tx.Outs); err != nil {
-		return err
-	}
-
 	if err := e.Tx.SyntacticVerify(e.Ctx); err != nil {
 		return err
 	}
@@ -1301,6 +1305,10 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 	// Update existing multisig definition
 
 	if tx.MultisigAlias.ID != ids.ShortEmpty {
+		if len(e.Tx.Creds) < 2 {
+			return errWrongCredentialsNumber
+		}
+
 		alias, err := e.State.GetMultisigAlias(tx.MultisigAlias.ID)
 		if err != nil {
 			return fmt.Errorf("%w, alias: %s", errAliasNotFound, tx.MultisigAlias.ID)
@@ -1337,7 +1345,7 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		e.Ctx.AVAXAssetID,
 		locked.StateUnlocked,
 	); err != nil {
-		return err
+		return fmt.Errorf("%w: %s", errFlowCheckFailed, err)
 	}
 
 	// update state
@@ -1385,7 +1393,7 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 	}
 
 	// Accumulate roles over all signers
-	roles := uint64(0)
+	roles := txs.AddressStateEmpty
 	for address := range addresses {
 		states, err := e.State.GetAddressStates(address)
 		if err != nil {
@@ -1393,7 +1401,7 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 		}
 		roles |= states
 	}
-	statesBit := uint64(1) << uint64(tx.State)
+	statesBit := txs.AddressState(1) << tx.State // TODO@ check that cast removal is ok
 
 	// Verify that roles are allowed to modify tx.State
 	if err := verifyAccess(roles, statesBit); err != nil {
@@ -1429,7 +1437,7 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 
 	txID := e.Tx.ID()
 
-	if tx.State == txs.AddressStateNodeDeferred {
+	if tx.State == txs.AddressStateBitNodeDeferred {
 		nodeShortID, err := e.State.GetShortIDLink(tx.Address, state.ShortLinkKeyRegisterNode)
 		if err != nil {
 			return fmt.Errorf("couldn't get consortium member registered nodeID: %w", err)
@@ -1466,14 +1474,14 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 	return nil
 }
 
-func verifyAccess(roles, statesBit uint64) error {
+func verifyAccess(roles, statesBit txs.AddressState) error {
 	switch {
-	case (roles & txs.AddressStateRoleAdminBit) != 0:
-	case (txs.AddressStateKycBits & statesBit) != 0:
-		if (roles & txs.AddressStateRoleKycBit) == 0 {
+	case (roles & txs.AddressStateRoleAdmin) != 0:
+	case (txs.AddressStateKYCAll & statesBit) != 0:
+		if (roles & txs.AddressStateRoleKYC) == 0 {
 			return errInvalidRoles
 		}
-	case (txs.AddressStateRoleBits & statesBit) != 0:
+	case (txs.AddressStateRoleAll & statesBit) != 0:
 		return errInvalidRoles
 	}
 	return nil

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -976,7 +976,7 @@ func TestCaminoLockedInsOrLockedOuts(t *testing.T) {
 					Outs:         tt.outs,
 				}},
 				Address: caminoPreFundedKeys[0].PublicKey().Address(),
-				State:   uint8(0),
+				State:   0,
 				Remove:  false,
 			}
 
@@ -1629,27 +1629,27 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 	tests := map[string]struct {
 		stateAddress  ids.ShortID
 		targetAddress ids.ShortID
-		txFlag        uint8
-		existingState uint64
+		txFlag        txs.AddressStateBit
+		existingState txs.AddressState
 		expectedErr   error
-		expectedState uint64
+		expectedState txs.AddressState
 		remove        bool
 	}{
 		// Bob has Admin State, and he is trying to give himself Admin Role (again)
 		"State: Admin, Flag: Admin, Add, Same Address": {
 			stateAddress:  bob,
 			targetAddress: bob,
-			txFlag:        txs.AddressStateRoleAdmin,
-			existingState: txs.AddressStateRoleAdminBit,
-			expectedState: txs.AddressStateRoleAdminBit,
+			txFlag:        txs.AddressStateBitRoleAdmin,
+			existingState: txs.AddressStateRoleAdmin,
+			expectedState: txs.AddressStateRoleAdmin,
 			remove:        false,
 		},
 		// Bob has KYC State, and he is trying to give himself KYC Role (again)
 		"State: KYC, Flag: KYC, Add, Same Address": {
 			stateAddress:  bob,
 			targetAddress: bob,
-			txFlag:        txs.AddressStateRoleKyc,
-			existingState: txs.AddressStateRoleKycBit,
+			txFlag:        txs.AddressStateBitRoleKYC,
+			existingState: txs.AddressStateRoleKYC,
 			expectedErr:   errInvalidRoles,
 			remove:        false,
 		},
@@ -1657,8 +1657,8 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 		"State: KYC, Flag: Admin, Add, Same Address": {
 			stateAddress:  bob,
 			targetAddress: bob,
-			txFlag:        txs.AddressStateRoleAdmin,
-			existingState: txs.AddressStateRoleKycBit,
+			txFlag:        txs.AddressStateBitRoleAdmin,
+			existingState: txs.AddressStateRoleKYC,
 			expectedErr:   errInvalidRoles,
 			remove:        false,
 		},
@@ -1666,26 +1666,26 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 		"State: Admin, Flag: Admin, Add, Different Address": {
 			stateAddress:  bob,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateRoleAdmin,
-			existingState: txs.AddressStateRoleAdminBit,
-			expectedState: txs.AddressStateRoleAdminBit,
+			txFlag:        txs.AddressStateBitRoleAdmin,
+			existingState: txs.AddressStateRoleAdmin,
+			expectedState: txs.AddressStateRoleAdmin,
 			remove:        false,
 		},
 		// Bob has Admin State, and he is trying to give Alice KYC Role
 		"State: Admin, Flag: kyc, Add, Different Address": {
 			stateAddress:  bob,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateRoleKyc,
-			existingState: txs.AddressStateRoleAdminBit,
-			expectedState: txs.AddressStateRoleKycBit,
+			txFlag:        txs.AddressStateBitRoleKYC,
+			existingState: txs.AddressStateRoleAdmin,
+			expectedState: txs.AddressStateRoleKYC,
 			remove:        false,
 		},
 		// Bob has Admin State, and he is trying to remove from Alice the KYC Role
 		"State: Admin, Flag: kyc, Remove, Different Address": {
 			stateAddress:  bob,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateRoleKyc,
-			existingState: txs.AddressStateRoleAdminBit,
+			txFlag:        txs.AddressStateBitRoleKYC,
+			existingState: txs.AddressStateRoleAdmin,
 			expectedState: 0,
 			remove:        true,
 		},
@@ -1693,53 +1693,53 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 		"State: Admin, Flag: KYC Verified, Add, Different Address": {
 			stateAddress:  bob,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateKycVerified,
-			existingState: txs.AddressStateRoleAdminBit,
-			expectedState: txs.AddressStateKycVerifiedBit,
+			txFlag:        txs.AddressStateBitKYCVerified,
+			existingState: txs.AddressStateRoleAdmin,
+			expectedState: txs.AddressStateKYCVerified,
 			remove:        false,
 		},
 		// Bob has Admin State, and he is trying to give Alice the KYC Expired State
 		"State: Admin, Flag: KYC Expired, Add, Different Address": {
 			stateAddress:  bob,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateKycExpired,
-			existingState: txs.AddressStateRoleAdminBit,
-			expectedState: txs.AddressStateKycExpiredBit,
+			txFlag:        txs.AddressStateBitKYCExpired,
+			existingState: txs.AddressStateRoleAdmin,
+			expectedState: txs.AddressStateKYCExpired,
 			remove:        false,
 		},
 		// Bob has Admin State, and he is trying to give Alice the Consortium State
 		"State: Admin, Flag: Consortium, Add, Different Address": {
 			stateAddress:  bob,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateConsortium,
-			existingState: txs.AddressStateRoleAdminBit,
-			expectedState: txs.AddressStateConsortiumBit,
+			txFlag:        txs.AddressStateBitConsortium,
+			existingState: txs.AddressStateRoleAdmin,
+			expectedState: txs.AddressStateConsortiumMember,
 			remove:        false,
 		},
 		// Bob has KYC State, and he is trying to give Alice KYC Expired State
 		"State: KYC, Flag: KYC Expired, Add, Different Address": {
 			stateAddress:  bob,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateKycExpired,
-			existingState: txs.AddressStateRoleKycBit,
-			expectedState: txs.AddressStateKycExpiredBit,
+			txFlag:        txs.AddressStateBitKYCExpired,
+			existingState: txs.AddressStateRoleKYC,
+			expectedState: txs.AddressStateKYCExpired,
 			remove:        false,
 		},
 		// Bob has KYC State, and he is trying to give Alice KYC Expired State
 		"State: KYC, Flag: KYC Verified, Add, Different Address": {
 			stateAddress:  bob,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateKycVerified,
-			existingState: txs.AddressStateRoleKycBit,
-			expectedState: txs.AddressStateKycVerifiedBit,
+			txFlag:        txs.AddressStateBitKYCVerified,
+			existingState: txs.AddressStateRoleKYC,
+			expectedState: txs.AddressStateKYCVerified,
 			remove:        false,
 		},
 		// Some Address has Admin State, and he is trying to give Alice Admin Role
 		"Wrong address": {
 			stateAddress:  ids.GenerateTestShortID(),
 			targetAddress: alice,
-			txFlag:        txs.AddressStateRoleAdmin,
-			existingState: txs.AddressStateRoleAdminBit,
+			txFlag:        txs.AddressStateBitRoleAdmin,
+			existingState: txs.AddressStateRoleAdmin,
 			expectedErr:   errInvalidRoles,
 			remove:        false,
 		},
@@ -1747,8 +1747,8 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 		"Empty State Address": {
 			stateAddress:  ids.ShortEmpty,
 			targetAddress: alice,
-			txFlag:        txs.AddressStateRoleAdmin,
-			existingState: txs.AddressStateRoleAdminBit,
+			txFlag:        txs.AddressStateBitRoleAdmin,
+			existingState: txs.AddressStateRoleAdmin,
 			expectedErr:   errInvalidRoles,
 			remove:        false,
 		},
@@ -1756,8 +1756,8 @@ func TestAddAddressStateTxExecutor(t *testing.T) {
 		"Empty Target Address": {
 			stateAddress:  bob,
 			targetAddress: ids.ShortEmpty,
-			txFlag:        txs.AddressStateRoleAdmin,
-			existingState: txs.AddressStateRoleAdminBit,
+			txFlag:        txs.AddressStateBitRoleAdmin,
+			existingState: txs.AddressStateRoleAdmin,
 			expectedErr:   txs.ErrEmptyAddress,
 			remove:        false,
 		},
@@ -4080,7 +4080,7 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 		"Not consortium member": {
 			state: func(c *gomock.Controller, utx *txs.RegisterNodeTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(uint64(0), nil)
+				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateEmpty, nil)
 				return s
 			},
 			utx: func() *txs.RegisterNodeTx {
@@ -4100,7 +4100,7 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 		"Consortium member has already registered node": {
 			state: func(c *gomock.Controller, utx *txs.RegisterNodeTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumBit, nil)
+				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumMember, nil)
 				s.EXPECT().GetShortIDLink(utx.NodeOwnerAddress, state.ShortLinkKeyRegisterNode).
 					Return(nodeAddr2, nil)
 				return s
@@ -4122,7 +4122,7 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 		"Old node is in current validator's set": {
 			state: func(c *gomock.Controller, utx *txs.RegisterNodeTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumBit, nil)
+				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumMember, nil)
 				s.EXPECT().GetShortIDLink(utx.NodeOwnerAddress, state.ShortLinkKeyRegisterNode).
 					Return(nodeAddr1, nil)
 				expectVerifyMultisigPermission(s, []ids.ShortID{utx.NodeOwnerAddress}, nil)
@@ -4148,7 +4148,7 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 		"Old node is in pending validator's set": {
 			state: func(c *gomock.Controller, utx *txs.RegisterNodeTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumBit, nil)
+				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumMember, nil)
 				s.EXPECT().GetShortIDLink(utx.NodeOwnerAddress, state.ShortLinkKeyRegisterNode).
 					Return(nodeAddr1, nil)
 				expectVerifyMultisigPermission(s, []ids.ShortID{utx.NodeOwnerAddress}, nil)
@@ -4176,7 +4176,7 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 		"Old node is in deferred validator's set": {
 			state: func(c *gomock.Controller, utx *txs.RegisterNodeTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumBit, nil)
+				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumMember, nil)
 				s.EXPECT().GetShortIDLink(utx.NodeOwnerAddress, state.ShortLinkKeyRegisterNode).
 					Return(nodeAddr1, nil)
 				expectVerifyMultisigPermission(s, []ids.ShortID{utx.NodeOwnerAddress}, nil)
@@ -4206,7 +4206,7 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 		"OK: change registered node": {
 			state: func(c *gomock.Controller, utx *txs.RegisterNodeTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumBit, nil)
+				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumMember, nil)
 				s.EXPECT().GetShortIDLink(utx.NodeOwnerAddress, state.ShortLinkKeyRegisterNode).
 					Return(nodeAddr1, nil)
 				expectVerifyMultisigPermission(s, []ids.ShortID{utx.NodeOwnerAddress}, nil)
@@ -4251,7 +4251,7 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 		"OK: consortium member is msig alias": {
 			state: func(c *gomock.Controller, utx *txs.RegisterNodeTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumBit, nil)
+				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumMember, nil)
 				s.EXPECT().GetShortIDLink(utx.NodeOwnerAddress, state.ShortLinkKeyRegisterNode).
 					Return(ids.ShortEmpty, database.ErrNotFound)
 				s.EXPECT().GetShortIDLink(ids.ShortID(utx.NewNodeID), state.ShortLinkKeyRegisterNode).
@@ -4297,7 +4297,7 @@ func TestCaminoStandardTxExecutorRegisterNodeTx(t *testing.T) {
 		"OK": {
 			state: func(c *gomock.Controller, utx *txs.RegisterNodeTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumBit, nil)
+				s.EXPECT().GetAddressStates(utx.NodeOwnerAddress).Return(txs.AddressStateConsortiumMember, nil)
 				s.EXPECT().GetShortIDLink(utx.NodeOwnerAddress, state.ShortLinkKeyRegisterNode).
 					Return(ids.ShortEmpty, database.ErrNotFound)
 				s.EXPECT().GetShortIDLink(ids.ShortID(utx.NewNodeID), state.ShortLinkKeyRegisterNode).
@@ -4755,7 +4755,7 @@ func TestCaminoStandardTxExecutorSuspendValidator(t *testing.T) {
 			tx, err := env.txBuilder.NewAddressStateTx(
 				setAddressStateArgs.address,
 				setAddressStateArgs.remove,
-				txs.AddressStateNodeDeferred,
+				txs.AddressStateBitNodeDeferred,
 				setAddressStateArgs.keys,
 				setAddressStateArgs.changeAddr,
 			)


### PR DESCRIPTION
There are bitfield uint64 fields in offer and addressStateTx (addressState itself). They are arbitrary uint64 fields, but intended to be used with predefined constants. This PR adds `AddressState uint64`, `AddressStateBit uint8` and `OfferFlag uint64` types. It also does some renaming to address state vars/consts to make it more consistent with types.