### PR TITLE
Dep offer tx

### DIFF
--- a/codec/camino_codec.go
+++ b/codec/camino_codec.go
@@ -5,10 +5,17 @@ package codec
 
 const UpgradePrefix = uint64(0xFFFFFFFFFFFF0000)
 
-func BuildUpgradeVersionID(version uint16) uint64 {
-	return UpgradePrefix | uint64(version)
+type UpgradeVersionID uint64
+
+const (
+	UpgradeVersion0 UpgradeVersionID = UpgradeVersionID(UpgradePrefix)
+	UpgradeVersion1 UpgradeVersionID = UpgradeVersionID(UpgradePrefix | uint64(1))
+)
+
+func (id UpgradeVersionID) Version() uint16 {
+	return uint16(id & 0xFFFF)
 }
 
-func GetUpgradeVersion(id uint64) uint16 {
-	return uint16(id & 0xFFFF)
+func BuildUpgradeVersionID(version uint16) UpgradeVersionID {
+	return UpgradeVersionID(UpgradePrefix | uint64(version))
 }

--- a/codec/camino_test_codec.go
+++ b/codec/camino_test_codec.go
@@ -14,7 +14,7 @@ var VersionTests = []func(c GeneralCodec, t testing.TB){
 }
 
 type UpgradeStruct struct {
-	UpgradeVersionID uint64
+	UpgradeVersionID UpgradeVersionID
 	Field1           uint32 `serialize:"true"`
 	Field2           uint32 `serialize:"true"`
 	Version1         uint32 `serialize:"true" upgradeVersion:"1"`
@@ -22,7 +22,7 @@ type UpgradeStruct struct {
 }
 
 type UpgradeStructOld struct {
-	UpgradeVersionID uint64
+	UpgradeVersionID UpgradeVersionID
 	Field1           uint32 `serialize:"true"`
 	Field2           uint32 `serialize:"true"`
 	Version1         uint32 `serialize:"true" upgradeVersion:"1"`

--- a/codec/reflectcodec/type_codec.go
+++ b/codec/reflectcodec/type_codec.go
@@ -211,7 +211,7 @@ func (c *genericCodec) size(value reflect.Value) (int, bool, error) {
 		if serializedFields.CheckUpgrade {
 			upgradeVersionID := value.Field(0).Uint()
 			if upgradeVersionID&codec.UpgradePrefix == codec.UpgradePrefix {
-				upgradeVersion = codec.GetUpgradeVersion(upgradeVersionID)
+				upgradeVersion = codec.UpgradeVersionID(upgradeVersionID).Version()
 				size += wrappers.LongLen
 			}
 		}
@@ -351,7 +351,7 @@ func (c *genericCodec) marshal(value reflect.Value, p *wrappers.Packer, maxSlice
 		if serializedFields.CheckUpgrade {
 			upgradeVersionID := value.Field(0).Uint()
 			if upgradeVersionID&codec.UpgradePrefix == codec.UpgradePrefix {
-				upgradeVersion = codec.GetUpgradeVersion(upgradeVersionID)
+				upgradeVersion = codec.UpgradeVersionID(upgradeVersionID).Version()
 				p.PackLong(upgradeVersionID)
 				if p.Err != nil {
 					return p.Err
@@ -539,7 +539,7 @@ func (c *genericCodec) unmarshal(p *wrappers.Packer, value reflect.Value, maxSli
 				p.RevertLong()
 			default:
 				value.Field(0).SetUint(upgradeVersionID)
-				upgradeVersion = codec.GetUpgradeVersion(upgradeVersionID)
+				upgradeVersion = codec.UpgradeVersionID(upgradeVersionID).Version()
 				if upgradeVersion > serializedFieldIndices.MaxUpgradeVersion {
 					return fmt.Errorf("incompatible upgrade version: %d", upgradeVersion)
 				}

--- a/genesis/camino_genesis.go
+++ b/genesis/camino_genesis.go
@@ -570,7 +570,7 @@ func DepositOfferFromConfig(configDepositOffer DepositOffer) (*deposit.Offer, er
 		Memo:                    types.JSONByteSlice(configDepositOffer.Memo),
 		Flags:                   configDepositOffer.Flags,
 	}
-	if err := offer.SetID(); err != nil {
+	if err := genesis.SetDepositOfferID(offer); err != nil {
 		return nil, err
 	}
 	return offer, nil

--- a/vms/platformvm/api/camino_test.go
+++ b/vms/platformvm/api/camino_test.go
@@ -43,7 +43,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 		Flags:                   9,
 		Memo:                    []byte("some memo"),
 	}
-	require.NoError(t, depositOffer.SetID())
+	require.NoError(t, genesis.SetDepositOfferID(depositOffer))
 
 	weight := json.Uint64(987654321)
 

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -924,6 +924,9 @@ type APIDepositOffer struct {
 	NoRewardsPeriodDuration uint32              `json:"noRewardsPeriodDuration"` // Duration of period during which rewards won't be accumulated. No rewards period starts at the end of deposit minus unlockPeriodDuration
 	Memo                    types.JSONByteSlice `json:"memo"`                    // Arbitrary offer memo
 	Flags                   utilsjson.Uint64    `json:"flags"`                   // Bitfield with flags
+	TotalMaxRewardAmount    utilsjson.Uint64    `json:"totalMaxRewardAmount"`    // Maximum amount that can be rewarded for all deposits created with this offer in total
+	RewardedAmount          utilsjson.Uint64    `json:"rewardedAmount"`          // Amount that was already rewarded (including potential rewards) for deposits created with this offer
+	OwnerAddress            ids.ShortID         `json:"ownerAddress"`            // Address that can sign deposit-creator permission
 }
 
 type GetAllDepositOffersArgs struct {
@@ -968,5 +971,8 @@ func apiOfferFromOffer(offer *deposit.Offer) *APIDepositOffer {
 		NoRewardsPeriodDuration: offer.NoRewardsPeriodDuration,
 		Memo:                    offer.Memo,
 		Flags:                   utilsjson.Uint64(offer.Flags),
+		TotalMaxRewardAmount:    utilsjson.Uint64(offer.TotalMaxRewardAmount),
+		RewardedAmount:          utilsjson.Uint64(offer.RewardedAmount),
+		OwnerAddress:            offer.OwnerAddress,
 	}
 }

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/platformvm/genesis"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
@@ -469,7 +470,7 @@ func TestDepositsAutoUnlock(t *testing.T) {
 		LockModeBondDeposit: true,
 		DepositOffers:       []*deposit.Offer{depositOffer},
 	}
-	require.NoError(caminoGenesisConf.DepositOffers[0].SetID())
+	require.NoError(genesis.SetDepositOfferID(caminoGenesisConf.DepositOffers[0]))
 
 	vm := newCaminoVM(caminoGenesisConf, []api.UTXO{{
 		Amount:  json.Uint64(depositOffer.MinAmount + defaultTxFee),

--- a/vms/platformvm/deposit/camino_deposit_offer.go
+++ b/vms/platformvm/deposit/camino_deposit_offer.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package deposit
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/types"
+)
+
+const (
+	interestRateBase               = 365 * 24 * 60 * 60
+	interestRateDenominator        = 1_000_000 * interestRateBase
+	OfferMinDepositAmount   uint64 = 1 * units.MilliAvax
+)
+
+var (
+	bigInterestRateDenominator = (&big.Int{}).SetInt64(interestRateDenominator)
+
+	errWrongLimitValues           = errors.New("can only use either TotalMaxAmount or TotalMaxRewardAmount")
+	errDepositedMoreThanMaxAmount = errors.New("offer deposited amount is more than offer total max amount")
+	errRewardedMoreThanMaxAmount  = errors.New("offer deposits total reward amount is more than offer total max reward amount")
+	errMinAmountToSmall           = errors.New("offer minAmount is to small")
+	errWrongRewardValues          = errors.New("offer interest rate and total max reward amount must both be zero or not zero")
+)
+
+type OfferFlag uint64
+
+const (
+	OfferFlagNone   OfferFlag = 0
+	OfferFlagLocked OfferFlag = 0b1
+)
+
+type Offer struct {
+	UpgradeVersionID codec.UpgradeVersionID
+	ID               ids.ID
+
+	InterestRateNominator   uint64              `serialize:"true" json:"interestRateNominator"`                   // deposit.Amount * (interestRateNominator / interestRateDenominator) == reward for deposit with 1 year duration
+	Start                   uint64              `serialize:"true" json:"start"`                                   // Unix time in seconds, when this offer becomes active (can be used to create new deposits)
+	End                     uint64              `serialize:"true" json:"end"`                                     // Unix time in seconds, when this offer becomes inactive (can't be used to create new deposits)
+	MinAmount               uint64              `serialize:"true" json:"minAmount"`                               // Minimum amount that can be deposited with this offer
+	TotalMaxAmount          uint64              `serialize:"true" json:"totalMaxAmount"`                          // Maximum amount that can be deposited with this offer in total (across all deposits)
+	DepositedAmount         uint64              `serialize:"true" json:"depositedAmount"`                         // Amount that was already deposited with this offer
+	MinDuration             uint32              `serialize:"true" json:"minDuration"`                             // Minimum duration of deposit created with this offer
+	MaxDuration             uint32              `serialize:"true" json:"maxDuration"`                             // Maximum duration of deposit created with this offer
+	UnlockPeriodDuration    uint32              `serialize:"true" json:"unlockPeriodDuration"`                    // Duration of period during which tokens deposited with this offer will be unlocked. The unlock period starts at the end of deposit minus unlockPeriodDuration
+	NoRewardsPeriodDuration uint32              `serialize:"true" json:"noRewardsPeriodDuration"`                 // Duration of period during which rewards won't be accumulated. No rewards period starts at the end of deposit minus unlockPeriodDuration
+	Memo                    types.JSONByteSlice `serialize:"true" json:"memo"`                                    // Arbitrary offer memo
+	Flags                   OfferFlag           `serialize:"true" json:"flags"`                                   // Bitfield with flags
+	TotalMaxRewardAmount    uint64              `serialize:"true" json:"totalMaxRewardAmount" upgradeVersion:"1"` // Maximum amount that can be rewarded for all deposits created with this offer in total
+	RewardedAmount          uint64              `serialize:"true" json:"rewardedAmount"       upgradeVersion:"1"` // Amount that was already rewarded (including potential rewards) for deposits created with this offer
+	OwnerAddress            ids.ShortID         `serialize:"true" json:"ownerAddress"         upgradeVersion:"1"` // Address that can sign deposit-creator permission
+}
+
+// Time when this offer becomes active
+func (o *Offer) StartTime() time.Time {
+	return time.Unix(int64(o.Start), 0)
+}
+
+// Time when this offer becomes inactive
+func (o *Offer) EndTime() time.Time {
+	return time.Unix(int64(o.End), 0)
+}
+
+// Return 0 if o.TotalMaxAmount is 0.
+func (o *Offer) RemainingAmount() uint64 {
+	return o.TotalMaxAmount - o.DepositedAmount
+}
+
+// Returns maximum possible amount that could be deposited with this offer. Return 0 if o.TotalMaxRewardAmount is 0.
+func (o *Offer) MaxRemainingAmountByReward() uint64 {
+	// rewardsPeriodDuration = deposit.Duration - offer.NoRewardsPeriodDuration
+	// using MaxDuration, cause its the case, where most reward per deposit amount is issued
+	bigRewardsPeriodDuration := (&big.Int{}).SetUint64(uint64(o.MaxDuration - o.NoRewardsPeriodDuration))
+
+	// depositAmount := remainingRewardAmount * interestRateBase / (offer.InterestRate * rewardsPeriodDuration)
+	denominator := (&big.Int{}).SetUint64(o.InterestRateNominator)
+	denominator.Mul(denominator, bigRewardsPeriodDuration)
+
+	nominator := (&big.Int{}).SetUint64(o.RemainingReward())
+	nominator.Mul(nominator, bigInterestRateDenominator)
+
+	return nominator.Div(nominator, denominator).Uint64()
+}
+
+// Return 0 if o.TotalMaxRewardAmount is 0.
+func (o *Offer) RemainingReward() uint64 {
+	return o.TotalMaxRewardAmount - o.RewardedAmount
+}
+
+// Calculates max remaining reward amount by using offer max duration. Return 0 if o.TotalMaxAmount is 0.
+func (o *Offer) MaxRemainingRewardByTotalMaxAmount() uint64 {
+	dummyDeposit := &Deposit{
+		Amount:   o.RemainingAmount(),
+		Duration: o.MaxDuration,
+	}
+	return dummyDeposit.TotalReward(o)
+}
+
+func (o *Offer) IsActiveAt(timestamp uint64) bool {
+	return o.Start <= timestamp && timestamp <= o.End && o.Flags&OfferFlagLocked == 0
+}
+
+func (o *Offer) InterestRateFloat64() float64 {
+	return float64(o.InterestRateNominator) / float64(interestRateDenominator)
+}
+
+func (o *Offer) Verify() error {
+	// common checks
+	switch {
+	case o.Start >= o.End:
+		return fmt.Errorf(
+			"deposit offer starttime (%v) is not before its endtime (%v)",
+			o.Start,
+			o.End,
+		)
+	case o.MinDuration > o.MaxDuration:
+		return errors.New("deposit minimum duration is greater than maximum duration")
+	case o.MinDuration == 0:
+		return errors.New("deposit offer has zero minimum duration")
+	case o.MinDuration < o.NoRewardsPeriodDuration:
+		return fmt.Errorf(
+			"deposit offer minimum duration (%v) is less than no-rewards period duration (%v)",
+			o.MinDuration,
+			o.NoRewardsPeriodDuration,
+		)
+	case o.MinDuration < o.UnlockPeriodDuration:
+		return fmt.Errorf(
+			"deposit offer minimum duration (%v) is less than unlock period duration (%v)",
+			o.MinDuration,
+			o.UnlockPeriodDuration,
+		)
+	case len(o.Memo) > avax.MaxMemoSize:
+		return fmt.Errorf("deposit offer memo is larger (%d bytes) than max of %d bytes", len(o.Memo), avax.MaxMemoSize)
+	case o.DepositedAmount > o.TotalMaxAmount:
+		return errDepositedMoreThanMaxAmount
+	case o.RewardedAmount > o.TotalMaxRewardAmount:
+		return errRewardedMoreThanMaxAmount
+	}
+
+	// version-specific checks
+	if o.UpgradeVersionID.Version() > 0 {
+		switch {
+		case o.TotalMaxAmount != 0 && o.TotalMaxRewardAmount != 0:
+			return errWrongLimitValues
+		case o.MinAmount < OfferMinDepositAmount:
+			return errMinAmountToSmall
+		case o.TotalMaxRewardAmount == 0 && o.InterestRateNominator != 0 ||
+			o.TotalMaxRewardAmount != 0 && o.InterestRateNominator == 0:
+			return errWrongRewardValues
+		}
+	}
+
+	return nil
+}
+
+func (o *Offer) PermissionMsg(depositCreatorAddres ids.ShortID) []byte {
+	msg := make([]byte, len(o.ID)+len(depositCreatorAddres))
+	copy(msg, o.ID[:])
+	copy(msg[len(o.ID):], depositCreatorAddres[:])
+	return msg
+}

--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -9,8 +9,8 @@ import (
 )
 
 type CaminoFx interface {
-	// Recovers signers addresses from [verifies] credentials for [utx] transaction
-	RecoverAddresses(utx secp256k1fx.UnsignedTx, verifies []verify.Verifiable) (secp256k1fx.RecoverMap, error)
+	// Recovers signers addresses from [credentials] for [msg] bytes (e.g. transaction bytes)
+	RecoverAddresses(msg []byte, credentials []verify.Verifiable) (secp256k1fx.RecoverMap, error)
 
 	// Verifies that Multisig aliases are on inputs are only used in supported hierarchy
 	VerifyMultisigOwner(outIntf, msigIntf interface{}) error
@@ -24,6 +24,10 @@ type CaminoFx interface {
 	// VerifyMultisigPermission returns nil if credential [credIntf] proves that [controlGroup] assents to transaction [utx].
 	// Multisig aliases supported.
 	VerifyMultisigPermission(txIntf, inIntf, credIntf, controlGroup, msigIntf interface{}) error
+
+	// VerifyMultisigMessage returns nil if credential [credIntf] proves that [controlGroup] signed [msgBytes].
+	// Multisig aliases supported.
+	VerifyMultisigMessage(msgBytes []byte, inIntf, credIntf, controlGroup, msigIntf interface{}) error
 
 	// CollectMultisigAliases returns an array of OutputOwners part of the owner
 	CollectMultisigAliases(ownerIntf, msigIntf interface{}) ([]interface{}, error)

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -112,7 +112,7 @@ func (mr *MockFxMockRecorder) Initialize(arg0 interface{}) *gomock.Call {
 }
 
 // RecoverAddresses mocks base method.
-func (m *MockFx) RecoverAddresses(arg0 secp256k1fx.UnsignedTx, arg1 []verify.Verifiable) (secp256k1fx.RecoverMap, error) {
+func (m *MockFx) RecoverAddresses(arg0 []byte, arg1 []verify.Verifiable) (secp256k1fx.RecoverMap, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecoverAddresses", arg0, arg1)
 	ret0, _ := ret[0].(secp256k1fx.RecoverMap)
@@ -166,6 +166,20 @@ func (m *MockFx) VerifyMultisigTransfer(arg0, arg1, arg2, arg3, arg4 interface{}
 func (mr *MockFxMockRecorder) VerifyMultisigTransfer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigTransfer", reflect.TypeOf((*MockFx)(nil).VerifyMultisigTransfer), arg0, arg1, arg2, arg3, arg4)
+}
+
+// VerifyMultisigMessage mocks base method.
+func (m *MockFx) VerifyMultisigMessage(arg0 []byte, arg1, arg2, arg3, arg4 interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyMultisigMessage", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyMultisigMessage indicates an expected call of VerifyMultisigMessage.
+func (mr *MockFxMockRecorder) VerifyMultisigMessage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigMessage", reflect.TypeOf((*MockFx)(nil).VerifyMultisigMessage), arg0, arg1, arg2, arg3, arg4)
 }
 
 // VerifyPermission mocks base method.

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/hashing"
 	"github.com/ava-labs/avalanchego/vms/components/multisig"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
@@ -26,7 +27,7 @@ type Camino struct {
 
 func (c *Camino) Init() error {
 	for _, offer := range c.DepositOffers {
-		if err := offer.SetID(); err != nil {
+		if err := SetDepositOfferID(offer); err != nil {
 			return err
 		}
 	}
@@ -87,4 +88,14 @@ func (b *Block) Txs() []*txs.Tx {
 	txs = append(txs, b.Validators...)
 	txs = append(txs, b.Deposits...)
 	return append(txs, b.UnlockedUTXOsTxs...)
+}
+
+// Generate deposit offer id from its bytes hash and set it to offer's ID field
+func SetDepositOfferID(offer *deposit.Offer) error {
+	bytes, err := txs.GenesisCodec.Marshal(txs.Version, offer)
+	if err != nil {
+		return err
+	}
+	offer.ID = hashing.ComputeHash256Array(bytes)
+	return nil
 }

--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -20,7 +20,8 @@ type caminoTxMetrics struct {
 	numRegisterNodeTxs,
 	numRewardsImportTxs,
 	numBaseTxs,
-	numMultisigAliasTxs prometheus.Counter
+	numMultisigAliasTxs,
+	numAddDepositOfferTxs prometheus.Counter
 }
 
 func newCaminoTxMetrics(
@@ -36,14 +37,15 @@ func newCaminoTxMetrics(
 	m := &caminoTxMetrics{
 		txMetrics: *txm,
 		// Camino specific tx metrics
-		numAddressStateTxs:  newTxMetric(namespace, "add_address_state", registerer, &errs),
-		numDepositTxs:       newTxMetric(namespace, "deposit", registerer, &errs),
-		numUnlockDepositTxs: newTxMetric(namespace, "unlock_deposit", registerer, &errs),
-		numClaimTxs:         newTxMetric(namespace, "claim", registerer, &errs),
-		numRegisterNodeTxs:  newTxMetric(namespace, "register_node", registerer, &errs),
-		numRewardsImportTxs: newTxMetric(namespace, "rewards_import", registerer, &errs),
-		numBaseTxs:          newTxMetric(namespace, "base", registerer, &errs),
-		numMultisigAliasTxs: newTxMetric(namespace, "multisig_alias", registerer, &errs),
+		numAddressStateTxs:    newTxMetric(namespace, "add_address_state", registerer, &errs),
+		numDepositTxs:         newTxMetric(namespace, "deposit", registerer, &errs),
+		numUnlockDepositTxs:   newTxMetric(namespace, "unlock_deposit", registerer, &errs),
+		numClaimTxs:           newTxMetric(namespace, "claim", registerer, &errs),
+		numRegisterNodeTxs:    newTxMetric(namespace, "register_node", registerer, &errs),
+		numRewardsImportTxs:   newTxMetric(namespace, "rewards_import", registerer, &errs),
+		numBaseTxs:            newTxMetric(namespace, "base", registerer, &errs),
+		numMultisigAliasTxs:   newTxMetric(namespace, "multisig_alias", registerer, &errs),
+		numAddDepositOfferTxs: newTxMetric(namespace, "add_deposit_offer", registerer, &errs),
 	}
 	return m, errs.Err
 }
@@ -79,6 +81,10 @@ func (*txMetrics) BaseTx(*txs.BaseTx) error {
 }
 
 func (*txMetrics) MultisigAliasTx(*txs.MultisigAliasTx) error {
+	return nil
+}
+
+func (*txMetrics) AddDepositOfferTx(*txs.AddDepositOfferTx) error {
 	return nil
 }
 
@@ -121,5 +127,10 @@ func (m *caminoTxMetrics) BaseTx(*txs.BaseTx) error {
 
 func (m *caminoTxMetrics) MultisigAliasTx(*txs.MultisigAliasTx) error {
 	m.numMultisigAliasTxs.Inc()
+	return nil
+}
+
+func (m *caminoTxMetrics) AddDepositOfferTx(*txs.AddDepositOfferTx) error {
+	m.numAddDepositOfferTxs.Inc()
 	return nil
 }

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -75,7 +75,6 @@ type CaminoDiff interface {
 
 	// Deposit offers
 
-	// precondition: offer.SetID() must be called and return no error
 	SetDepositOffer(offer *deposit.Offer)
 	GetDepositOffer(offerID ids.ID) (*deposit.Offer, error)
 	GetAllDepositOffers() ([]*deposit.Offer, error)

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -211,7 +211,7 @@ func TestSyncGenesis(t *testing.T) {
 		},
 	}
 	for _, offer := range depositOffers {
-		require.NoError(offer.SetID())
+		require.NoError(pvm_genesis.SetDepositOfferID(offer))
 	}
 
 	depositTx1, err := txs.NewSigned(&txs.DepositTx{

--- a/vms/platformvm/txs/camino_add_deposit_offer_tx.go
+++ b/vms/platformvm/txs/camino_add_deposit_offer_tx.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/verify"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+)
+
+var (
+	_ UnsignedTx = (*AddDepositOfferTx)(nil)
+
+	errBadDepositOffer                 = errors.New("bad deposit offer")
+	errBadDepositOfferCreatorAuth      = errors.New("bad deposit offer creator auth")
+	errEmptyDepositOfferCreatorAddress = errors.New("deposit offer creator address is empty")
+	errWrongDepositOfferVersion        = errors.New("wrong deposit offer version")
+)
+
+// AddDepositOfferTx is an unsigned depositTx
+type AddDepositOfferTx struct {
+	// Metadata, inputs and outputs
+	BaseTx `serialize:"true"`
+	// deposit offer that will be added
+	DepositOffer *deposit.Offer `serialize:"true" json:"depositOffer"`
+	// Address that have "deposit offers creator" role
+	DepositOfferCreatorAddress ids.ShortID `serialize:"true" json:"depositOfferCreatorAddress"`
+	// Auth that will be used to verify credential for deposit offers creator
+	DepositOfferCreatorAuth verify.Verifiable `serialize:"true" json:"depositOfferCreatorAuth"`
+}
+
+// SyntacticVerify returns nil if [tx] is valid
+func (tx *AddDepositOfferTx) SyntacticVerify(ctx *snow.Context) error {
+	switch {
+	case tx == nil:
+		return ErrNilTx
+	case tx.SyntacticallyVerified: // already passed syntactic verification
+		return nil
+	case tx.DepositOfferCreatorAddress == ids.ShortEmpty:
+		return errEmptyDepositOfferCreatorAddress
+	case tx.DepositOffer.UpgradeVersionID.Version() == 0:
+		return errWrongDepositOfferVersion
+	}
+
+	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {
+		return fmt.Errorf("failed to verify BaseTx: %w", err)
+	}
+
+	if err := tx.DepositOffer.Verify(); err != nil {
+		return fmt.Errorf("%w: %s", errBadDepositOffer, err)
+	}
+
+	if err := tx.DepositOfferCreatorAuth.Verify(); err != nil {
+		return fmt.Errorf("%w: %s", errBadDepositOfferCreatorAuth, err)
+	}
+
+	if err := locked.VerifyNoLocks(tx.Ins, tx.Outs); err != nil {
+		return err
+	}
+
+	// cache that this is valid
+	tx.SyntacticallyVerified = true
+	return nil
+}
+
+func (tx *AddDepositOfferTx) Visit(visitor Visitor) error {
+	return visitor.AddDepositOfferTx(tx)
+}

--- a/vms/platformvm/txs/camino_add_deposit_offer_tx_test.go
+++ b/vms/platformvm/txs/camino_add_deposit_offer_tx_test.go
@@ -1,0 +1,156 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/codec"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddDepositOfferTxSyntacticVerify(t *testing.T) {
+	ctx := snow.DefaultContextTest()
+	ctx.AVAXAssetID = ids.GenerateTestID()
+	owner1 := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{{0, 0, 1}}}
+	depositTxID := ids.ID{0, 1}
+	creatorAddress := ids.ShortID{1}
+
+	offer1 := &deposit.Offer{
+		UpgradeVersionID: codec.UpgradeVersion1,
+		End:              1,
+		MinDuration:      1,
+		MaxDuration:      1,
+		MinAmount:        deposit.OfferMinDepositAmount,
+	}
+
+	baseTx := BaseTx{BaseTx: avax.BaseTx{
+		NetworkID:    ctx.NetworkID,
+		BlockchainID: ctx.ChainID,
+	}}
+
+	tests := map[string]struct {
+		tx          *AddDepositOfferTx
+		expectedErr error
+	}{
+		"Nil tx": {
+			expectedErr: ErrNilTx,
+		},
+		"Empty deposit offer creator address": {
+			tx: &AddDepositOfferTx{
+				BaseTx: baseTx,
+			},
+			expectedErr: errEmptyDepositOfferCreatorAddress,
+		},
+		"Bad deposit offer": {
+			tx: &AddDepositOfferTx{
+				BaseTx:                     baseTx,
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer:               &deposit.Offer{UpgradeVersionID: codec.UpgradeVersion1},
+			},
+			expectedErr: errBadDepositOffer,
+		},
+		"Bad deposit offer creator auth": {
+			tx: &AddDepositOfferTx{
+				BaseTx:                     baseTx,
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer:               offer1,
+				DepositOfferCreatorAuth:    (*secp256k1fx.Input)(nil),
+			},
+			expectedErr: errBadDepositOfferCreatorAuth,
+		},
+		"Deposit offer version 0": {
+			tx: &AddDepositOfferTx{
+				BaseTx:                     baseTx,
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer: &deposit.Offer{
+					End:         1,
+					MinDuration: 1,
+					MaxDuration: 1,
+					MinAmount:   deposit.OfferMinDepositAmount,
+				},
+			},
+			expectedErr: errWrongDepositOfferVersion,
+		},
+		"Locked base tx input": {
+			tx: &AddDepositOfferTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Ins: []*avax.TransferableInput{
+						generateTestIn(ctx.AVAXAssetID, 1, depositTxID, ids.Empty, []uint32{0}),
+					},
+				}},
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer:               offer1,
+				DepositOfferCreatorAuth:    &secp256k1fx.Input{SigIndices: []uint32{}},
+			},
+			expectedErr: locked.ErrWrongInType,
+		},
+		"Locked base tx output": {
+			tx: &AddDepositOfferTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Outs: []*avax.TransferableOutput{
+						generateTestOut(ctx.AVAXAssetID, 1, owner1, depositTxID, ids.Empty),
+					},
+				}},
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer:               offer1,
+				DepositOfferCreatorAuth:    &secp256k1fx.Input{SigIndices: []uint32{}},
+			},
+			expectedErr: locked.ErrWrongOutType,
+		},
+		"Stakable base tx input": {
+			tx: &AddDepositOfferTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Ins: []*avax.TransferableInput{
+						generateTestStakeableIn(ctx.AVAXAssetID, 1, 1, []uint32{0}),
+					},
+				}},
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer:               offer1,
+				DepositOfferCreatorAuth:    &secp256k1fx.Input{SigIndices: []uint32{}},
+			},
+			expectedErr: locked.ErrWrongInType,
+		},
+		"Stakable base tx output": {
+			tx: &AddDepositOfferTx{
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+					Outs: []*avax.TransferableOutput{
+						generateTestStakeableOut(ctx.AVAXAssetID, 1, 1, owner1),
+					},
+				}},
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer:               offer1,
+				DepositOfferCreatorAuth:    &secp256k1fx.Input{SigIndices: []uint32{}},
+			},
+			expectedErr: locked.ErrWrongOutType,
+		},
+		"OK: v1": {
+			tx: &AddDepositOfferTx{
+				BaseTx:                     baseTx,
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer:               offer1,
+				DepositOfferCreatorAuth:    &secp256k1fx.Input{SigIndices: []uint32{}},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, tt.tx.SyntacticVerify(ctx), tt.expectedErr)
+		})
+	}
+}

--- a/vms/platformvm/txs/camino_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_deposit_tx_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
@@ -49,13 +50,63 @@ func TestDepositTxSyntacticVerify(t *testing.T) {
 			},
 			expectedErr: errToBigDeposit,
 		},
-		"OK": {
+		"V1, bad deposit creator auth": {
+			tx: &DepositTx{
+				UpgradeVersionID: codec.UpgradeVersion1,
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+				}},
+				RewardsOwner:       &secp256k1fx.OutputOwners{},
+				DepositCreatorAuth: (*secp256k1fx.Input)(nil),
+			},
+			expectedErr: errBadDepositCreatorAuth,
+		},
+		"V1, bad deposit offer owner auth": {
+			tx: &DepositTx{
+				UpgradeVersionID: codec.UpgradeVersion1,
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+				}},
+				RewardsOwner:          &secp256k1fx.OutputOwners{},
+				DepositCreatorAuth:    &secp256k1fx.Input{},
+				DepositOfferOwnerAuth: (*secp256k1fx.Input)(nil),
+			},
+			expectedErr: errBadOfferOwnerAuth,
+		},
+		"OK: v0": {
 			tx: &DepositTx{
 				BaseTx: BaseTx{BaseTx: avax.BaseTx{
 					NetworkID:    ctx.NetworkID,
 					BlockchainID: ctx.ChainID,
 				}},
 				RewardsOwner: &secp256k1fx.OutputOwners{},
+			},
+		},
+		"OK: v1": {
+			tx: &DepositTx{
+				UpgradeVersionID: codec.UpgradeVersion1,
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+				}},
+				RewardsOwner:          &secp256k1fx.OutputOwners{},
+				DepositCreatorAddress: ids.ShortID{1},
+				DepositCreatorAuth:    &secp256k1fx.Input{},
+				DepositOfferOwnerAuth: &secp256k1fx.Input{},
+			},
+		},
+		"OK: v1, empty creator addr": {
+			tx: &DepositTx{
+				UpgradeVersionID: codec.UpgradeVersion1,
+				BaseTx: BaseTx{BaseTx: avax.BaseTx{
+					NetworkID:    ctx.NetworkID,
+					BlockchainID: ctx.ChainID,
+				}},
+				RewardsOwner:          &secp256k1fx.OutputOwners{},
+				DepositCreatorAuth:    &secp256k1fx.Input{},
+				DepositOfferOwnerAuth: &secp256k1fx.Input{},
 			},
 		},
 	}

--- a/vms/platformvm/txs/camino_visitor.go
+++ b/vms/platformvm/txs/camino_visitor.go
@@ -12,4 +12,5 @@ type CaminoVisitor interface {
 	RewardsImportTx(*RewardsImportTx) error
 	BaseTx(*BaseTx) error
 	MultisigAliasTx(*MultisigAliasTx) error
+	AddDepositOfferTx(*AddDepositOfferTx) error
 }

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -121,6 +121,7 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&secp256k1fx.MultisigCredential{}),
 		targetCodec.RegisterCustomType(&multisig.AliasWithNonce{}),
 		targetCodec.RegisterCustomType(&secp256k1fx.CrossTransferOutput{}),
+		targetCodec.RegisterCustomType(&AddDepositOfferTx{}),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 
 	"github.com/ava-labs/avalanchego/chains/atomic"
-	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -35,45 +34,50 @@ var (
 	_ txs.Visitor = (*CaminoStandardTxExecutor)(nil)
 	_ txs.Visitor = (*CaminoProposalTxExecutor)(nil)
 
-	errNodeSignatureMissing           = errors.New("last signature is not nodeID's signature")
-	errWrongLockMode                  = errors.New("this tx can't be used with this caminoGenesis.LockModeBondDeposit")
-	errRecoverAddresses               = errors.New("cannot recover addresses from credentials")
-	errAddrStateNotPermitted          = errors.New("don't have permission to set address state bit")
-	errValidatorExists                = errors.New("node is already a validator")
-	errInvalidSystemTxBody            = errors.New("tx body doesn't match expected one")
-	errRemoveValidatorToEarly         = errors.New("attempting to remove validator before its end time")
-	errRemoveWrongValidator           = errors.New("attempting to remove wrong validator")
-	errDepositOfferNotActiveYet       = errors.New("deposit offer not active yet")
-	errDepositOfferInactive           = errors.New("deposit offer inactive")
-	errDepositToSmall                 = errors.New("deposit amount is less than deposit offer minimum amount")
-	errDepositToBig                   = errors.New("deposit amount is greater than deposit offer available amount")
-	errDepositDurationToSmall         = errors.New("deposit duration is less than deposit offer minmum duration")
-	errDepositDurationToBig           = errors.New("deposit duration is greater than deposit offer maximum duration")
-	errSupplyOverflow                 = errors.New("resulting total supply would be more than allowed maximum")
-	errNotConsortiumMember            = errors.New("address isn't consortium member")
-	errValidatorNotFound              = errors.New("validator not found")
-	errConsortiumMemberHasNode        = errors.New("consortium member already has registered node")
-	errSignatureMissing               = errors.New("wrong signature")
-	errNodeNotRegistered              = errors.New("no address registered for this node")
-	errNotNodeOwner                   = errors.New("node is registered for another address")
-	errNodeAlreadyRegistered          = errors.New("node is already registered")
-	errClaimableCredentialMismatch    = errors.New("claimable credential isn't matching")
-	errDepositNotFound                = errors.New("deposit not found")
-	errWrongCredentialsNumber         = errors.New("unexpected number of credentials")
-	errWrongOwnerType                 = errors.New("wrong owner type")
-	errImportedUTXOMismatch           = errors.New("imported input doesn't match expected utxo")
-	errInputAmountMismatch            = errors.New("utxo amount doesn't match input amount")
-	errInputsUTXOSMismatch            = errors.New("number of inputs is different from number of utxos")
-	errWrongClaimedAmount             = errors.New("claiming more than was available to claim")
-	errNoUnlock                       = errors.New("no tokens unlocked")
-	errAliasCredentialMismatch        = errors.New("alias credential isn't matching")
-	errAliasNotFound                  = errors.New("alias not found on state")
-	errUnlockedMoreThanAvailable      = errors.New("unlocked more deposited tokens than was available for unlock")
-	errMixedDeposits                  = errors.New("tx has expired deposit input and active-deposit/unlocked input")
-	errExpiredDepositNotFullyUnlocked = errors.New("unlocked only part of expired deposit")
-	errBurnedDepositUnlock            = errors.New("burned undeposited tokens")
-	errAdminCannotBeDeleted           = errors.New("admin cannot be deleted")
-	errNotSunrisePhase1               = errors.New("not allowed before SunrisePhase1")
+	errNodeSignatureMissing              = errors.New("last signature is not nodeID's signature")
+	errWrongLockMode                     = errors.New("this tx can't be used with this caminoGenesis.LockModeBondDeposit")
+	errRecoverAddresses                  = errors.New("cannot recover addresses from credentials")
+	errAddrStateNotPermitted             = errors.New("don't have permission to set address state bit")
+	errValidatorExists                   = errors.New("node is already a validator")
+	errInvalidSystemTxBody               = errors.New("tx body doesn't match expected one")
+	errRemoveValidatorToEarly            = errors.New("attempting to remove validator before its end time")
+	errRemoveWrongValidator              = errors.New("attempting to remove wrong validator")
+	errDepositOfferInactive              = errors.New("deposit offer is inactive")
+	errDepositToSmall                    = errors.New("deposit amount is less than deposit offer minimum amount")
+	errDepositToBig                      = errors.New("deposit amount is greater than deposit offer available amount")
+	errDepositDurationToSmall            = errors.New("deposit duration is less than deposit offer minmum duration")
+	errDepositDurationToBig              = errors.New("deposit duration is greater than deposit offer maximum duration")
+	errSupplyOverflow                    = errors.New("resulting total supply would be more than allowed maximum")
+	errNotConsortiumMember               = errors.New("address isn't consortium member")
+	errValidatorNotFound                 = errors.New("validator not found")
+	errConsortiumMemberHasNode           = errors.New("consortium member already has registered node")
+	errSignatureMissing                  = errors.New("wrong signature")
+	errNodeNotRegistered                 = errors.New("no address registered for this node")
+	errNotNodeOwner                      = errors.New("node is registered for another address")
+	errNodeAlreadyRegistered             = errors.New("node is already registered")
+	errClaimableCredentialMismatch       = errors.New("claimable credential isn't matching")
+	errDepositNotFound                   = errors.New("deposit not found")
+	errWrongCredentialsNumber            = errors.New("unexpected number of credentials")
+	errWrongOwnerType                    = errors.New("wrong owner type")
+	errImportedUTXOMismatch              = errors.New("imported input doesn't match expected utxo")
+	errInputAmountMismatch               = errors.New("utxo amount doesn't match input amount")
+	errInputsUTXOSMismatch               = errors.New("number of inputs is different from number of utxos")
+	errWrongClaimedAmount                = errors.New("claiming more than was available to claim")
+	errNoUnlock                          = errors.New("no tokens unlocked")
+	errAliasCredentialMismatch           = errors.New("alias credential isn't matching")
+	errAliasNotFound                     = errors.New("alias not found on state")
+	errUnlockedMoreThanAvailable         = errors.New("unlocked more deposited tokens than was available for unlock")
+	errMixedDeposits                     = errors.New("tx has expired deposit input and active-deposit/unlocked input")
+	errExpiredDepositNotFullyUnlocked    = errors.New("unlocked only part of expired deposit")
+	errBurnedDepositUnlock               = errors.New("burned undeposited tokens")
+	errAdminCannotBeDeleted              = errors.New("admin cannot be deleted")
+	errNotSunrisePhase1                  = errors.New("not allowed before SunrisePhase1")
+	errOfferCreatorCredentialMismatch    = errors.New("offer creator credential isn't matching")
+	errNotOfferCreator                   = errors.New("address isn't allowed to create deposit offers")
+	errDepositCreatorCredentialMismatch  = errors.New("deposit creator credential isn't matching")
+	errOfferPermissionCredentialMismatch = errors.New("offer-usage permission credential isn't matching")
+	errEmptyDepositCreatorAddress        = errors.New("empty deposit creator address, while offer owner isn't empty")
+	errWrongTxUpgradeVersion             = errors.New("wrong tx upgrade version")
 )
 
 type CaminoStandardTxExecutor struct {
@@ -624,14 +628,11 @@ func (e *CaminoStandardTxExecutor) DepositTx(tx *txs.DepositTx) error {
 	}
 
 	depositAmount := tx.DepositAmount()
-	currentChainTime := e.State.GetTimestamp()
+	chainTime := e.State.GetTimestamp()
+	sunrisePhase1 := e.Config.IsSunrisePhase1Activated(chainTime)
 
 	switch {
-	case depositOffer.Flags&deposits.OfferFlagLocked != 0:
-		return errDepositOfferInactive
-	case depositOffer.StartTime().After(currentChainTime):
-		return errDepositOfferNotActiveYet
-	case depositOffer.EndTime().Before(currentChainTime):
+	case !depositOffer.IsActiveAt(uint64(chainTime.Unix())):
 		return errDepositOfferInactive
 	case tx.DepositDuration < depositOffer.MinDuration:
 		return errDepositDurationToSmall
@@ -641,6 +642,68 @@ func (e *CaminoStandardTxExecutor) DepositTx(tx *txs.DepositTx) error {
 		return errDepositToSmall
 	case depositOffer.TotalMaxAmount > 0 && depositAmount > depositOffer.RemainingAmount():
 		return errDepositToBig
+	case !sunrisePhase1 && depositOffer.TotalMaxRewardAmount > 0:
+		return errNotSunrisePhase1
+	}
+
+	deposit := &deposits.Deposit{
+		DepositOfferID: tx.DepositOfferID,
+		Duration:       tx.DepositDuration,
+		Amount:         depositAmount,
+		Start:          uint64(chainTime.Unix()),
+		RewardOwner:    tx.RewardsOwner,
+	}
+	potentialReward := deposit.TotalReward(depositOffer)
+
+	if depositOffer.TotalMaxRewardAmount > 0 && potentialReward > depositOffer.RemainingReward() {
+		return errDepositToBig
+	}
+
+	baseTxCreds := e.Tx.Creds
+	if depositOffer.OwnerAddress != ids.ShortEmpty {
+		if !sunrisePhase1 {
+			return errNotSunrisePhase1
+		}
+
+		if tx.UpgradeVersionID.Version() == 0 {
+			return errWrongTxUpgradeVersion
+		}
+
+		if tx.DepositCreatorAddress == ids.ShortEmpty {
+			return errEmptyDepositCreatorAddress
+		}
+
+		if len(e.Tx.Creds) < 3 {
+			return errWrongCredentialsNumber
+		}
+
+		if err := e.Fx.VerifyMultisigMessage(
+			depositOffer.PermissionMsg(tx.DepositCreatorAddress),
+			tx.DepositOfferOwnerAuth,
+			e.Tx.Creds[len(e.Tx.Creds)-1], // offer usage permission credential created by offer owner
+			&secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{depositOffer.OwnerAddress},
+			},
+			e.State,
+		); err != nil {
+			return fmt.Errorf("%w: %s", errOfferPermissionCredentialMismatch, err)
+		}
+
+		if err := e.Fx.VerifyMultisigPermission(
+			tx,
+			tx.DepositCreatorAuth,
+			e.Tx.Creds[len(e.Tx.Creds)-2], // deposit creator credential
+			&secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{tx.DepositCreatorAddress},
+			},
+			e.State,
+		); err != nil {
+			return fmt.Errorf("%w: %s", errDepositCreatorCredentialMismatch, err)
+		}
+
+		baseTxCreds = e.Tx.Creds[:len(e.Tx.Creds)-2]
 	}
 
 	rewardOwner, ok := tx.RewardsOwner.(*secp256k1fx.OutputOwners)
@@ -661,7 +724,7 @@ func (e *CaminoStandardTxExecutor) DepositTx(tx *txs.DepositTx) error {
 		e.State,
 		tx.Ins,
 		tx.Outs,
-		e.Tx.Creds,
+		baseTxCreds,
 		0,
 		e.Config.TxFee,
 		e.Ctx.AVAXAssetID,
@@ -677,16 +740,6 @@ func (e *CaminoStandardTxExecutor) DepositTx(tx *txs.DepositTx) error {
 		return err
 	}
 
-	deposit := &deposits.Deposit{
-		DepositOfferID: tx.DepositOfferID,
-		Duration:       tx.DepositDuration,
-		Amount:         depositAmount,
-		Start:          uint64(currentChainTime.Unix()),
-		RewardOwner:    tx.RewardsOwner,
-	}
-
-	potentialReward := deposit.TotalReward(depositOffer)
-
 	newSupply, err := math.Add64(currentSupply, potentialReward)
 	if err != nil || newSupply > e.Config.RewardConfig.SupplyCap {
 		return errSupplyOverflow
@@ -696,9 +749,15 @@ func (e *CaminoStandardTxExecutor) DepositTx(tx *txs.DepositTx) error {
 		updatedOffer := *depositOffer
 		updatedOffer.DepositedAmount += depositAmount
 		e.State.SetDepositOffer(&updatedOffer)
+	} else if depositOffer.TotalMaxRewardAmount > 0 {
+		updatedOffer := *depositOffer
+		updatedOffer.RewardedAmount += potentialReward
+		e.State.SetDepositOffer(&updatedOffer)
 	}
 
-	e.State.SetCurrentSupply(constants.PrimaryNetworkID, newSupply)
+	if newSupply != currentSupply {
+		e.State.SetCurrentSupply(constants.PrimaryNetworkID, newSupply)
+	}
 	e.State.AddDeposit(txID, deposit)
 
 	avax.Consume(e.State, tx.Ins)
@@ -1480,6 +1539,103 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 	return nil
 }
 
+func (e *CaminoStandardTxExecutor) AddDepositOfferTx(tx *txs.AddDepositOfferTx) error {
+	if err := e.Tx.SyntacticVerify(e.Ctx); err != nil {
+		return err
+	}
+
+	chainTime := e.State.GetTimestamp()
+
+	if !e.Config.IsSunrisePhase1Activated(chainTime) {
+		return errNotSunrisePhase1
+	}
+
+	if len(e.Tx.Creds) < 2 {
+		return errWrongCredentialsNumber
+	}
+
+	// verify the flowcheck
+
+	if err := e.FlowChecker.VerifyLock(
+		tx,
+		e.State,
+		tx.Ins,
+		tx.Outs,
+		e.Tx.Creds[:len(e.Tx.Creds)-1], // base tx credentials
+		0,
+		e.Config.TxFee,
+		e.Ctx.AVAXAssetID,
+		locked.StateUnlocked,
+	); err != nil {
+		return fmt.Errorf("%w: %s", errFlowCheckFailed, err)
+	}
+
+	// check role
+
+	depositOfferCreatorAddressState, err := e.State.GetAddressStates(tx.DepositOfferCreatorAddress)
+	if err != nil {
+		return err
+	}
+
+	if depositOfferCreatorAddressState&txs.AddressStateRoleOffersCreator == 0 {
+		return errNotOfferCreator
+	}
+
+	if err := e.Backend.Fx.VerifyMultisigPermission(
+		e.Tx.Unsigned,
+		tx.DepositOfferCreatorAuth,
+		e.Tx.Creds[len(e.Tx.Creds)-1], // offer creator credential
+		&secp256k1fx.OutputOwners{
+			Threshold: 1,
+			Addrs:     []ids.ShortID{tx.DepositOfferCreatorAddress},
+		},
+		e.State,
+	); err != nil {
+		return fmt.Errorf("%w: %s", errOfferCreatorCredentialMismatch, err)
+	}
+
+	// validate offer
+
+	currentSupply, err := e.State.GetCurrentSupply(constants.PrimaryNetworkID)
+	if err != nil {
+		return err
+	}
+
+	allOffers, err := e.State.GetAllDepositOffers()
+	if err != nil {
+		return err
+	}
+
+	availableSupply := e.Config.RewardConfig.SupplyCap - currentSupply
+	chainTimestamp := uint64(chainTime.Unix())
+
+	for _, offer := range allOffers {
+		if offer.IsActiveAt(chainTimestamp) {
+			if offer.TotalMaxAmount != 0 {
+				availableSupply -= offer.MaxRemainingRewardByTotalMaxAmount()
+			} else if offer.TotalMaxRewardAmount != 0 {
+				availableSupply -= offer.RemainingReward()
+			}
+		}
+	}
+
+	if tx.DepositOffer.TotalMaxRewardAmount > availableSupply {
+		return errSupplyOverflow
+	}
+
+	// update state
+
+	txID := e.Tx.ID()
+
+	tx.DepositOffer.ID = txID
+	e.State.SetDepositOffer(tx.DepositOffer)
+
+	avax.Consume(e.State, tx.Ins)
+	avax.Produce(e.State, txID, tx.Outs)
+
+	return nil
+}
+
 func removeCreds(tx *txs.Tx, num int) []verify.Verifiable {
 	newCredsLen := len(tx.Creds) - num
 	removedCreds := tx.Creds[newCredsLen:len(tx.Creds)]
@@ -1500,7 +1656,7 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 	roles := txs.AddressStateEmpty
 	creds := e.Tx.Creds
 
-	if codec.GetUpgradeVersion(tx.UpgradeVersionID) > 0 {
+	if tx.UpgradeVersionID.Version() > 0 {
 		if !e.Config.IsSunrisePhase1Activated(e.State.GetTimestamp()) {
 			return errNotSunrisePhase1
 		}
@@ -1526,7 +1682,7 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 			return errAdminCannotBeDeleted
 		}
 	} else {
-		addresses, err := e.Fx.RecoverAddresses(tx, e.Tx.Creds)
+		addresses, err := e.Fx.RecoverAddresses(tx.Bytes(), e.Tx.Creds)
 		if err != nil {
 			return fmt.Errorf("%w: %s", errRecoverAddresses, err)
 		}
@@ -1626,6 +1782,7 @@ func verifyAccess(roles, state txs.AddressState) bool {
 	switch {
 	case roles&txs.AddressStateRoleAdmin != 0: // admin can do anything
 	case txs.AddressStateKYCAll&state != 0 && roles&txs.AddressStateRoleKYC != 0: // kyc role can change kyc status
+	case txs.AddressStateRoleOffersCreator&state != 0 && roles&txs.AddressStateRoleOffersAdmin != 0: // offers admin can assign offers creator role
 	default:
 		return false
 	}

--- a/vms/platformvm/txs/executor/camino_visitor.go
+++ b/vms/platformvm/txs/executor/camino_visitor.go
@@ -41,6 +41,10 @@ func (*StandardTxExecutor) MultisigAliasTx(*txs.MultisigAliasTx) error {
 	return errWrongTxType
 }
 
+func (*StandardTxExecutor) AddDepositOfferTx(*txs.AddDepositOfferTx) error {
+	return errWrongTxType
+}
+
 // Proposal
 
 func (*ProposalTxExecutor) AddressStateTx(*txs.AddressStateTx) error {
@@ -72,6 +76,10 @@ func (*ProposalTxExecutor) BaseTx(*txs.BaseTx) error {
 }
 
 func (*ProposalTxExecutor) MultisigAliasTx(*txs.MultisigAliasTx) error {
+	return errWrongTxType
+}
+
+func (*ProposalTxExecutor) AddDepositOfferTx(*txs.AddDepositOfferTx) error {
 	return errWrongTxType
 }
 
@@ -109,6 +117,10 @@ func (*AtomicTxExecutor) MultisigAliasTx(*txs.MultisigAliasTx) error {
 	return errWrongTxType
 }
 
+func (*AtomicTxExecutor) AddDepositOfferTx(*txs.AddDepositOfferTx) error {
+	return errWrongTxType
+}
+
 // MemPool
 
 func (v *MempoolTxVerifier) AddressStateTx(tx *txs.AddressStateTx) error {
@@ -140,5 +152,9 @@ func (v *MempoolTxVerifier) BaseTx(tx *txs.BaseTx) error {
 }
 
 func (v *MempoolTxVerifier) MultisigAliasTx(tx *txs.MultisigAliasTx) error {
+	return v.standardTx(tx)
+}
+
+func (v *MempoolTxVerifier) AddDepositOfferTx(tx *txs.AddDepositOfferTx) error {
 	return v.standardTx(tx)
 }

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -49,6 +49,11 @@ func (i *issuer) MultisigAliasTx(*txs.MultisigAliasTx) error {
 	return nil
 }
 
+func (i *issuer) AddDepositOfferTx(*txs.AddDepositOfferTx) error {
+	i.m.addDecisionTx(i.tx)
+	return nil
+}
+
 // Remover
 
 func (r *remover) AddressStateTx(*txs.AddressStateTx) error {
@@ -87,6 +92,11 @@ func (r *remover) BaseTx(*txs.BaseTx) error {
 }
 
 func (r *remover) MultisigAliasTx(*txs.MultisigAliasTx) error {
+	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
+	return nil
+}
+
+func (r *remover) AddDepositOfferTx(*txs.AddDepositOfferTx) error {
 	r.m.removeDecisionTxs([]*txs.Tx{r.tx})
 	return nil
 }

--- a/vms/platformvm/utxo/mock_verifier.go
+++ b/vms/platformvm/utxo/mock_verifier.go
@@ -101,7 +101,7 @@ func (mr *MockVerifierMockRecorder) VerifySpendUTXOs(arg0, arg1, arg2, arg3, arg
 }
 
 // VerifyUnlockDeposit mocks base method.
-func (m *MockVerifier) VerifyUnlockDeposit(arg0 avax.UTXOGetter, arg1 txs.UnsignedTx, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID, arg7 bool)  error {
+func (m *MockVerifier) VerifyUnlockDeposit(arg0 avax.UTXOGetter, arg1 txs.UnsignedTx, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID, arg7 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyUnlockDeposit", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)

--- a/vms/secp256k1fx/camino_fx_test.go
+++ b/vms/secp256k1fx/camino_fx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx
@@ -220,7 +220,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 				copy(cred.Sigs[i][:], sig)
 			}
 
-			err := fx.verifyMultisigCredentials(tx, tt.in, cred, tt.owners, tt.msig(ctrl))
+			err := fx.verifyMultisigCredentials(tx.Bytes(), tt.in, cred, tt.owners, tt.msig(ctrl))
 			require.ErrorIs(t, err, tt.expectedError)
 		})
 	}

--- a/wallet/chain/p/camino_visitor.go
+++ b/wallet/chain/p/camino_visitor.go
@@ -42,6 +42,10 @@ func (b *backendVisitor) MultisigAliasTx(tx *txs.MultisigAliasTx) error {
 	return b.baseTx(&tx.BaseTx)
 }
 
+func (b *backendVisitor) AddDepositOfferTx(tx *txs.AddDepositOfferTx) error {
+	return b.baseTx(&tx.BaseTx)
+}
+
 // signer
 
 func (s *signerVisitor) AddressStateTx(tx *txs.AddressStateTx) error {
@@ -97,6 +101,14 @@ func (s *signerVisitor) BaseTx(tx *txs.BaseTx) error {
 }
 
 func (s *signerVisitor) MultisigAliasTx(tx *txs.MultisigAliasTx) error {
+	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
+	if err != nil {
+		return err
+	}
+	return sign(s.tx, false, txSigners)
+}
+
+func (s *signerVisitor) AddDepositOfferTx(tx *txs.AddDepositOfferTx) error {
 	txSigners, err := s.getSigners(constants.PlatformChainID, tx.Ins)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Why this should be merged
This PR extends existing types with upgradeVersion (see https://github.com/chain4travel/caminogo/pull/262):
- Extends deposit offers with new fields.
- Extends DepositTx with new fields in order to support new offers.

It also adds:
- New transaction AddDepositOfferTx, which allows to add new deposit offers. This transaction must be signed by an address that has address state "offer creator".
- Two new address state roles: offerAdmin (can assign offerCreator) and offerCreator (can create deposit offers).
- New test cases for affected code, updated existing tests.

One of the new offer features is "owned offers". If a deposit offer "owner" field isn't empty, then in order to use that offer, DepositTx will need to provide additional credentials and specify "deposit creator" fields.
## How this works
#### Upgraded types
Extended type methods will check either the value of UpgradeVersionID field or some of the new fields for a non-zero value. If conditions are met, new logic is executed.
#### Owned offers
"Owned offer" owner is defined by an address (could be multisig alias as well). This offer can be used for depositing only by addresses that will be "whitelisted by offer owner. For each whitelisted address, owner must construct permission message (offerID+allowedAddress), sign it with its key (or keys) and send this signature(s) to whitelisted address. This signature then must be used by deposit creator in DepositTx.
## How this was tested
Unit-tests.