### PR TITLE
[Codec] Allow versioned updates of struct

### DIFF
--- a/codec/camino_codec.go
+++ b/codec/camino_codec.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package codec
+
+const UpgradePrefix = uint64(0xFFFFFFFFFFFF0000)
+
+func BuildUpgradeVersionID(version uint16) uint64 {
+	return UpgradePrefix | uint64(version)
+}
+
+func GetUpgradeVersion(id uint64) uint16 {
+	return uint16(id & 0xFFFF)
+}

--- a/codec/camino_test_codec.go
+++ b/codec/camino_test_codec.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package codec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var VersionTests = []func(c GeneralCodec, t testing.TB){
+	TestUpgrade,
+}
+
+type UpgradeStruct struct {
+	UpgradeVersionID uint64
+	Field1           uint32 `serialize:"true"`
+	Field2           uint32 `serialize:"true"`
+	Version1         uint32 `serialize:"true" upgradeVersion:"1"`
+	Version2         uint32 `serialize:"true" upgradeVersion:"2"`
+}
+
+type UpgradeStructOld struct {
+	UpgradeVersionID uint64
+	Field1           uint32 `serialize:"true"`
+	Field2           uint32 `serialize:"true"`
+	Version1         uint32 `serialize:"true" upgradeVersion:"1"`
+}
+
+// Test version upgrade. Optional UpgradeVersionID field is only
+// marshalled if it matches the UpgradePrefix pattern defined in codec.
+// If the struct bytes start with 48 set bits, and if the struct has
+// the first member called UpgradeVersionID, it is treated as 48 bit magic
+// and 16 bit version (low 16 bits). Refer to codec.BuildUpgradeVersionID()
+func TestUpgrade(codec GeneralCodec, t testing.TB) {
+	input := UpgradeStruct{
+		UpgradeVersionID: 0,
+		Field1:           100,
+		Field2:           200,
+		Version1:         1,
+		Version2:         2,
+	}
+
+	manager := NewDefaultManager()
+	require := require.New(t)
+
+	err := manager.RegisterCodec(0, codec)
+	require.NoError(err)
+
+	bytes, err := manager.Marshal(0, &input)
+	require.NoError(err)
+	// Because UpgradeVersionID doesn't match UpgradeVersionPrefix,
+	// UpgradeVersionID will not be marshalled
+	require.Equal(10, len(bytes))
+
+	output := UpgradeStruct{}
+	_, err = manager.Unmarshal(bytes, &output)
+	require.NoError(err)
+	require.Equal(input.UpgradeVersionID, output.UpgradeVersionID)
+	require.Equal(input.Field1, output.Field1)
+	require.Equal(input.Field2, output.Field2)
+	require.Equal(uint32(0), output.Version1)
+
+	input.UpgradeVersionID = BuildUpgradeVersionID(1)
+	bytes, err = manager.Marshal(0, &input)
+	require.NoError(err)
+	// Because UpgradeVersionID does match UpgradeVersionPrefix,
+	// UpgradeVersionID will be marshalled and upgradeVersion 1 is used
+	require.Equal(22, len(bytes))
+
+	output = UpgradeStruct{}
+	_, err = manager.Unmarshal(bytes, &output)
+	require.NoError(err)
+	require.Equal(input.UpgradeVersionID, output.UpgradeVersionID)
+	require.Equal(input.Field1, output.Field1)
+	require.Equal(input.Field2, output.Field2)
+	require.Equal(input.Version1, output.Version1)
+	require.Equal(uint32(0), output.Version2)
+
+	input.UpgradeVersionID = BuildUpgradeVersionID(2)
+	bytes, err = manager.Marshal(0, &input)
+	require.NoError(err)
+	// Because UpgradeVersionID does match UpgradeVersionPrefix,
+	// UpgradeVersionID will be marshalled and upgradeVersion 2 is used
+	require.Equal(26, len(bytes))
+
+	// This should fail because we try to unmarshal version2 but struct only knows version 1
+	outputOld := UpgradeStructOld{}
+	_, err = manager.Unmarshal(bytes, &outputOld)
+	require.ErrorContains(err, "incompatible")
+}

--- a/codec/linearcodec/camino_codec_test.go
+++ b/codec/linearcodec/camino_codec_test.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package linearcodec
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/codec"
+)
+
+func TestVectorsCamino(t *testing.T) {
+	for _, test := range codec.Tests {
+		c := NewCaminoDefault()
+		test(c, t)
+	}
+}
+
+func TestMultipleTagsCamino(t *testing.T) {
+	for _, test := range codec.MultipleTagsTests {
+		c := NewCamino([]string{"tag1", "tag2"}, defaultMaxSliceLength)
+		test(c, t)
+	}
+}
+
+func TestVersionCamino(t *testing.T) {
+	for _, test := range codec.VersionTests {
+		c := NewCaminoDefault()
+		test(c, t)
+	}
+}

--- a/codec/reflectcodec/struct_fielder.go
+++ b/codec/reflectcodec/struct_fielder.go
@@ -16,13 +16,23 @@ const (
 
 	// TagValue is the value the tag must have to be serialized.
 	TagValue = "true"
+
+	UpgradeVersionIDFieldName = "UpgradeVersionID"
+	UpgradeVersionTagName     = "upgradeVersion"
 )
 
 var _ StructFielder = (*structFielder)(nil)
 
 type FieldDesc struct {
-	Index       int
-	MaxSliceLen uint32
+	Index          int
+	MaxSliceLen    uint32
+	UpgradeVersion uint16
+}
+
+type SerializedFields struct {
+	Fields            []FieldDesc
+	CheckUpgrade      bool
+	MaxUpgradeVersion uint16
 }
 
 // StructFielder handles discovery of serializable fields in a struct.
@@ -34,14 +44,14 @@ type StructFielder interface {
 	// is un-exported.
 	// GetSerializedField(Foo) --> [1,5,8] means Foo.Field(1), Foo.Field(5),
 	// Foo.Field(8) are to be serialized/deserialized.
-	GetSerializedFields(t reflect.Type) ([]FieldDesc, error)
+	GetSerializedFields(t reflect.Type) (*SerializedFields, error)
 }
 
 func NewStructFielder(tagNames []string, maxSliceLen uint32) StructFielder {
 	return &structFielder{
 		tags:                   tagNames,
 		maxSliceLen:            maxSliceLen,
-		serializedFieldIndices: make(map[reflect.Type][]FieldDesc),
+		serializedFieldIndices: make(map[reflect.Type]*SerializedFields),
 	}
 }
 
@@ -59,22 +69,30 @@ type structFielder struct {
 	// that is serialized/deserialized e.g. Foo --> [1,5,8] means Foo.Field(1),
 	// etc. are to be serialized/deserialized. We assume this cache is pretty
 	// small (a few hundred keys at most) and doesn't take up much memory.
-	serializedFieldIndices map[reflect.Type][]FieldDesc
+	serializedFieldIndices map[reflect.Type]*SerializedFields
 }
 
-func (s *structFielder) GetSerializedFields(t reflect.Type) ([]FieldDesc, error) {
+func (s *structFielder) GetSerializedFields(t reflect.Type) (*SerializedFields, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	if s.serializedFieldIndices == nil {
-		s.serializedFieldIndices = make(map[reflect.Type][]FieldDesc)
+		s.serializedFieldIndices = make(map[reflect.Type]*SerializedFields)
 	}
 	if serializedFields, ok := s.serializedFieldIndices[t]; ok { // use pre-computed result
 		return serializedFields, nil
 	}
 	numFields := t.NumField()
-	serializedFields := make([]FieldDesc, 0, numFields)
-	for i := 0; i < numFields; i++ { // Go through all fields of this struct
+	checkUpgrade := false
+	startIndex := 0
+	if numFields > 0 && t.Field(0).Type.Kind() == reflect.Uint64 &&
+		t.Field(0).Name == UpgradeVersionIDFieldName {
+		checkUpgrade = true
+		startIndex = 1
+	}
+	serializedFields := &SerializedFields{Fields: make([]FieldDesc, 0, numFields), CheckUpgrade: checkUpgrade}
+	maxUpgradeVersion := uint16(0)
+	for i := startIndex; i < numFields; i++ { // Go through all fields of this struct
 		field := t.Field(i)
 
 		// Multiple tags per fields can be specified.
@@ -93,17 +111,30 @@ func (s *structFielder) GetSerializedFields(t reflect.Type) ([]FieldDesc, error)
 		if !field.IsExported() { // Can only marshal exported fields
 			return nil, fmt.Errorf("can't marshal un-exported field %s", field.Name)
 		}
+
+		upgradeVersionTag := field.Tag.Get(UpgradeVersionTagName)
+		upgradeVersion := uint16(0)
+		if upgradeVersionTag != "" {
+			v, err := strconv.ParseUint(upgradeVersionTag, 10, 8)
+			if err != nil {
+				return nil, fmt.Errorf("can't parse %s (%s)", UpgradeVersionTagName, upgradeVersionTag)
+			}
+			upgradeVersion = uint16(v)
+			maxUpgradeVersion = upgradeVersion
+		}
 		sliceLenField := field.Tag.Get(SliceLenTagName)
 		maxSliceLen := s.maxSliceLen
 
 		if newLen, err := strconv.ParseUint(sliceLenField, 10, 31); err == nil {
 			maxSliceLen = uint32(newLen)
 		}
-		serializedFields = append(serializedFields, FieldDesc{
-			Index:       i,
-			MaxSliceLen: maxSliceLen,
+		serializedFields.Fields = append(serializedFields.Fields, FieldDesc{
+			Index:          i,
+			MaxSliceLen:    maxSliceLen,
+			UpgradeVersion: upgradeVersion,
 		})
 	}
+	serializedFields.MaxUpgradeVersion = maxUpgradeVersion
 	s.serializedFieldIndices[t] = serializedFields // cache result
 	return serializedFields, nil
 }

--- a/utils/wrappers/packing.go
+++ b/utils/wrappers/packing.go
@@ -1,3 +1,13 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+//
+// This file is a derived work, based on ava-labs code whose
+// original notices appear below.
+//
+// It is distributed under the same license conditions as the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********************************************************
 // Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -142,6 +152,14 @@ func (p *Packer) UnpackLong() uint64 {
 	val := binary.BigEndian.Uint64(p.Bytes[p.Offset:])
 	p.Offset += LongLen
 	return val
+}
+
+func (p *Packer) RevertLong() {
+	if p.Offset < LongLen {
+		p.Add(errBadLength)
+		return
+	}
+	p.Offset -= LongLen
 }
 
 // PackBool packs a bool into the byte array

--- a/version/constants.go
+++ b/version/constants.go
@@ -112,6 +112,9 @@ var (
 	}
 	BanffDefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
+	SunrisePhase1Times       = map[uint32]time.Time{}
+	SunrisePhase1DefaultTime = time.Date(2022, time.May, 1, 0, 0, 0, 0, time.UTC)
+
 	// TODO: update this before release
 	CortinaTimes = map[uint32]time.Time{
 		constants.MainnetID: time.Date(10000, time.December, 1, 0, 0, 0, 0, time.UTC),
@@ -188,6 +191,13 @@ func GetBanffTime(networkID uint32) time.Time {
 		return upgradeTime
 	}
 	return BanffDefaultTime
+}
+
+func GetSunrisePhase1Time(networkID uint32) time.Time {
+	if upgradeTime, exists := SunrisePhase1Times[networkID]; exists {
+		return upgradeTime
+	}
+	return SunrisePhase1DefaultTime
 }
 
 func GetCortinaTime(networkID uint32) time.Time {

--- a/vms/platformvm/config/config.go
+++ b/vms/platformvm/config/config.go
@@ -109,6 +109,9 @@ type Config struct {
 	// Time of the Banff network upgrade
 	BanffTime time.Time
 
+	// Time of the SP1 network upgrade
+	SunrisePhase1Time time.Time
+
 	// Subnet ID --> Minimum portion of the subnet's stake this node must be
 	// connected to in order to report healthy.
 	// [constants.PrimaryNetworkID] is always a key in this map.
@@ -140,6 +143,10 @@ func (c *Config) IsApricotPhase5Activated(timestamp time.Time) bool {
 
 func (c *Config) IsBanffActivated(timestamp time.Time) bool {
 	return !timestamp.Before(c.BanffTime)
+}
+
+func (c *Config) IsSunrisePhase1Activated(timestamp time.Time) bool {
+	return !timestamp.Before(c.SunrisePhase1Time)
 }
 
 func (c *Config) GetCreateBlockchainTxFee(timestamp time.Time) uint64 {


### PR DESCRIPTION
## Why this should be merged
We have currently 3 TX types which must be improved by adding new fields (AddressStateTx / DepositTx / DeositOfferTx).
Go makes it not really easy to extend a struct, because of this we implement an upgrade logic for serializing structs.
This allows us to add new fields to an existing struct with maintaining downgrade compatibility

To have a real world example with this PR there are 2 additional commits:
- Implement SunrisePhase1
- Upgrade AddressStateTx, and allow upgrades only after SP1 (AddressStateTx is now MultiSigAlias ready)

## How this works
```
type VersionStruct struct {
	UpgradeVersionID uint64
	ExistingField uint32 `serialize:"true"`
	NewField1      uint32 `serialize:"true" upgradeVersion:"1"`
	NewField2      uint32 `serialize:"true" upgradeVersion:"2"`
}
```
To get it work: 
- add a new field `UpgradeVersionID` as first field in the struct.
- If you want the struct be serialized with `NewField1`, get the `UpgradeVersionID` by calling `codec.BuildUpgradeVersionID(1)`
- If you want that the non-upgraded struct is serialized, set `UpgradeVersionID` to 0. In this case `UpgradeVersionID`  will not be serialized and because structs upgradeVersion is 0 `NewField1` will also not be serialized
- To get NewField1 and NewField2 serialized, `codec.BuildUpgradeVersionID(2)` must be called

#### Rules
- `UpgradeVersionID` field must be the first struct member
- It is not required to pass the `serialize` tag for `UpgradeVersionID` because this field's serialization is done automatic.
- New fields with upgradeVersion tag set must be increasing

### Note
It must be made sure, that the first 48Bit (== 6 Bytes) of a not yet upgraded struct (not containing serialized `UpgradeVersionID` must not be 0xFFFFFFFFFFFF. This value is the identifier if the first uint64 is a UpgradeVersion or not.

## How this was tested
Unit Tests