### PR TITLE
[PVM] change offers creator addrs state bit, add upgradeVersion to offers api

### DIFF
--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -911,7 +911,8 @@ func (s *CaminoService) apiOwnerFromSECP(secpOwner *secp256k1fx.OutputOwners) (*
 }
 
 type APIDepositOffer struct {
-	ID                      ids.ID              `json:"id"`
+	UpgradeVersion          uint16              `json:"upgradeVersion"`          // codec upgrade version
+	ID                      ids.ID              `json:"id"`                      // offer id
 	InterestRateNominator   utilsjson.Uint64    `json:"interestRateNominator"`   // deposit.Amount * (interestRateNominator / interestRateDenominator) == reward for deposit with 1 year duration
 	Start                   utilsjson.Uint64    `json:"start"`                   // Unix time in seconds, when this offer becomes active (can be used to create new deposits)
 	End                     utilsjson.Uint64    `json:"end"`                     // Unix time in seconds, when this offer becomes inactive (can't be used to create new deposits)
@@ -958,6 +959,7 @@ func (s *CaminoService) GetAllDepositOffers(_ *http.Request, args *GetAllDeposit
 
 func apiOfferFromOffer(offer *deposit.Offer) *APIDepositOffer {
 	return &APIDepositOffer{
+		UpgradeVersion:          offer.UpgradeVersionID.Version(),
 		ID:                      offer.ID,
 		InterestRateNominator:   utilsjson.Uint64(offer.InterestRateNominator),
 		Start:                   utilsjson.Uint64(offer.Start),

--- a/vms/platformvm/txs/camino_address_state_tx.go
+++ b/vms/platformvm/txs/camino_address_state_tx.go
@@ -22,26 +22,25 @@ type (
 const (
 	// Bits
 
-	AddressStateBitRoleAdmin         AddressStateBit = 0
-	AddressStateBitRoleKYC           AddressStateBit = 1
-	AddressStateBitRoleOffersAdmin   AddressStateBit = 2
-	AddressStateBitRoleOffersCreator AddressStateBit = 3
+	AddressStateBitRoleAdmin       AddressStateBit = 0
+	AddressStateBitRoleKYC         AddressStateBit = 1
+	AddressStateBitRoleOffersAdmin AddressStateBit = 2
 
-	AddressStateBitKYCVerified  AddressStateBit = 32
-	AddressStateBitKYCExpired   AddressStateBit = 33
-	AddressStateBitConsortium   AddressStateBit = 38
-	AddressStateBitNodeDeferred AddressStateBit = 39
-	AddressStateBitMax          AddressStateBit = 63
+	AddressStateBitKYCVerified   AddressStateBit = 32
+	AddressStateBitKYCExpired    AddressStateBit = 33
+	AddressStateBitConsortium    AddressStateBit = 38
+	AddressStateBitNodeDeferred  AddressStateBit = 39
+	AddressStateBitOffersCreator AddressStateBit = 50
+	AddressStateBitMax           AddressStateBit = 63
 
 	// States
 
 	AddressStateEmpty AddressState = 0
 
-	AddressStateRoleAdmin         AddressState = AddressState(1) << AddressStateBitRoleAdmin                                                               // 0b1
-	AddressStateRoleKYC           AddressState = AddressState(1) << AddressStateBitRoleKYC                                                                 // 0b10
-	AddressStateRoleOffersAdmin   AddressState = AddressState(1) << AddressStateBitRoleOffersAdmin                                                         // 0b100
-	AddressStateRoleOffersCreator AddressState = AddressState(1) << AddressStateBitRoleOffersCreator                                                       // 0b1000
-	AddressStateRoleAll           AddressState = AddressStateRoleAdmin | AddressStateRoleKYC | AddressStateRoleOffersAdmin | AddressStateRoleOffersCreator // 0b1111
+	AddressStateRoleAdmin       AddressState = AddressState(1) << AddressStateBitRoleAdmin                               // 0b1
+	AddressStateRoleKYC         AddressState = AddressState(1) << AddressStateBitRoleKYC                                 // 0b10
+	AddressStateRoleOffersAdmin AddressState = AddressState(1) << AddressStateBitRoleOffersAdmin                         // 0b100
+	AddressStateRoleAll         AddressState = AddressStateRoleAdmin | AddressStateRoleKYC | AddressStateRoleOffersAdmin // 0b111
 
 	AddressStateKYCVerified AddressState = AddressState(1) << AddressStateBitKYCVerified    // 0b0100000000000000000000000000000000
 	AddressStateKYCExpired  AddressState = AddressState(1) << AddressStateBitKYCExpired     // 0b1000000000000000000000000000000000
@@ -51,7 +50,9 @@ const (
 	AddressStateNodeDeferred     AddressState = AddressState(1) << AddressStateBitNodeDeferred          // 0b1000000000000000000000000000000000000000
 	AddressStateVotableBits      AddressState = AddressStateConsortiumMember | AddressStateNodeDeferred // 0b1100000000000000000000000000000000000000
 
-	AddressStateValidBits = AddressStateRoleAll | AddressStateKYCAll | AddressStateVotableBits // 0b1100001100000000000000000000000000001111
+	AddressStateOffersCreator AddressState = AddressState(1) << AddressStateBitOffersCreator // 0b100000000000000000000000000000000000000000000000000
+
+	AddressStateValidBits = AddressStateRoleAll | AddressStateKYCAll | AddressStateVotableBits | AddressStateOffersCreator // 0b100000000001100001100000000000000000000000000000111
 )
 
 var (

--- a/vms/platformvm/txs/camino_deposit_tx.go
+++ b/vms/platformvm/txs/camino_deposit_tx.go
@@ -19,7 +19,7 @@ import (
 var (
 	_ UnsignedTx = (*DepositTx)(nil)
 
-	errToBigDeposit          = errors.New("to big deposit")
+	errTooBigDeposit         = errors.New("to big deposit")
 	errInvalidRewardOwner    = errors.New("invalid reward owner")
 	errBadOfferOwnerAuth     = errors.New("bad offer owner auth")
 	errBadDepositCreatorAuth = errors.New("bad deposit creator auth")
@@ -89,7 +89,7 @@ func (tx *DepositTx) SyntacticVerify(ctx *snow.Context) error {
 		if lockedOut, ok := out.Out.(*locked.Out); ok && lockedOut.IsNewlyLockedWith(locked.StateDeposited) {
 			newDepositAmount, err := math.Add64(depositAmount, lockedOut.Amount())
 			if err != nil {
-				return fmt.Errorf("%w: %s", errToBigDeposit, err)
+				return fmt.Errorf("%w: %s", errTooBigDeposit, err)
 			}
 			depositAmount = newDepositAmount
 		}

--- a/vms/platformvm/txs/camino_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_deposit_tx_test.go
@@ -48,7 +48,7 @@ func TestDepositTxSyntacticVerify(t *testing.T) {
 				}},
 				RewardsOwner: &secp256k1fx.OutputOwners{},
 			},
-			expectedErr: errToBigDeposit,
+			expectedErr: errTooBigDeposit,
 		},
 		"V1, bad deposit creator auth": {
 			tx: &DepositTx{

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -2175,7 +2175,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 				}
 			},
 			chaintime:   offer.StartTime(),
-			expectedErr: []error{errDepositDurationToSmall, errDepositDurationToSmall},
+			expectedErr: []error{errDepositDurationTooSmall, errDepositDurationTooSmall},
 		},
 		"Deposit duration is too big": {
 			state: func(c *gomock.Controller, utx *txs.DepositTx, txID ids.ID, cfg *config.Config, phaseIndex int) *state.MockDiff {
@@ -2197,7 +2197,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 				}
 			},
 			chaintime:   offer.StartTime(),
-			expectedErr: []error{errDepositDurationToBig, errDepositDurationToBig},
+			expectedErr: []error{errDepositDurationTooBig, errDepositDurationTooBig},
 		},
 		"Deposit amount is too small": {
 			state: func(c *gomock.Controller, utx *txs.DepositTx, txID ids.ID, cfg *config.Config, phaseIndex int) *state.MockDiff {
@@ -2222,7 +2222,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 				}
 			},
 			chaintime:   offer.StartTime(),
-			expectedErr: []error{errDepositToSmall, errDepositToSmall},
+			expectedErr: []error{errDepositTooSmall, errDepositTooSmall},
 		},
 		"Deposit amount is too big (offer.TotalMaxAmount)": {
 			state: func(c *gomock.Controller, utx *txs.DepositTx, txID ids.ID, cfg *config.Config, phaseIndex int) *state.MockDiff {
@@ -2248,7 +2248,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 				}
 			},
 			chaintime:   offerWithMaxAmount.StartTime(),
-			expectedErr: []error{errDepositToBig, errDepositToBig},
+			expectedErr: []error{errDepositTooBig, errDepositTooBig},
 		},
 		"Deposit amount is too big (offer.TotalMaxRewardAmount)": {
 			state: func(c *gomock.Controller, utx *txs.DepositTx, txID ids.ID, cfg *config.Config, phaseIndex int) *state.MockDiff {
@@ -2274,7 +2274,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 				}
 			},
 			chaintime:   offerWithMaxRewardAmount.StartTime(),
-			expectedErr: []error{errNotSunrisePhase1, errDepositToBig},
+			expectedErr: []error{errNotSunrisePhase1, errDepositTooBig},
 		},
 		"UTXO not found": {
 			state: func(c *gomock.Controller, utx *txs.DepositTx, txID ids.ID, cfg *config.Config, phaseIndex int) *state.MockDiff {
@@ -5582,7 +5582,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetTimestamp().Return(time.Unix(100, 0))
 				expectVerifyLock(s, utx.Ins, []*avax.UTXO{feeUTXO}, []ids.ShortID{feeOwnerAddr}, nil)
-				s.EXPECT().GetAddressStates(utx.DepositOfferCreatorAddress).Return(txs.AddressStateRoleOffersCreator, nil)
+				s.EXPECT().GetAddressStates(utx.DepositOfferCreatorAddress).Return(txs.AddressStateOffersCreator, nil)
 				expectVerifyMultisigPermission(s, []ids.ShortID{utx.DepositOfferCreatorAddress}, nil)
 				return s
 			},
@@ -5606,7 +5606,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetTimestamp().Return(chainTime)
 				expectVerifyLock(s, utx.Ins, []*avax.UTXO{feeUTXO}, []ids.ShortID{feeOwnerAddr}, nil)
-				s.EXPECT().GetAddressStates(utx.DepositOfferCreatorAddress).Return(txs.AddressStateRoleOffersCreator, nil)
+				s.EXPECT().GetAddressStates(utx.DepositOfferCreatorAddress).Return(txs.AddressStateOffersCreator, nil)
 				expectVerifyMultisigPermission(s, []ids.ShortID{utx.DepositOfferCreatorAddress}, nil)
 				s.EXPECT().GetCurrentSupply(constants.PrimaryNetworkID).
 					Return(cfg.RewardConfig.SupplyCap-offer1.TotalMaxRewardAmount+1, nil)
@@ -5676,7 +5676,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetTimestamp().Return(chainTime)
 				expectVerifyLock(s, utx.Ins, []*avax.UTXO{feeUTXO}, []ids.ShortID{feeOwnerAddr}, nil)
-				s.EXPECT().GetAddressStates(utx.DepositOfferCreatorAddress).Return(txs.AddressStateRoleOffersCreator, nil)
+				s.EXPECT().GetAddressStates(utx.DepositOfferCreatorAddress).Return(txs.AddressStateOffersCreator, nil)
 				expectVerifyMultisigPermission(s, []ids.ShortID{utx.DepositOfferCreatorAddress}, nil)
 				s.EXPECT().GetCurrentSupply(constants.PrimaryNetworkID).Return(currentSupply, nil)
 				s.EXPECT().GetAllDepositOffers().Return(existingOffers, nil)
@@ -5701,7 +5701,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetTimestamp().Return(time.Time{})
 				expectVerifyLock(s, utx.Ins, []*avax.UTXO{feeUTXO}, []ids.ShortID{feeOwnerAddr}, nil)
-				s.EXPECT().GetAddressStates(utx.DepositOfferCreatorAddress).Return(txs.AddressStateRoleOffersCreator, nil)
+				s.EXPECT().GetAddressStates(utx.DepositOfferCreatorAddress).Return(txs.AddressStateOffersCreator, nil)
 				expectVerifyMultisigPermission(s, []ids.ShortID{utx.DepositOfferCreatorAddress}, nil)
 				s.EXPECT().GetCurrentSupply(constants.PrimaryNetworkID).
 					Return(cfg.RewardConfig.SupplyCap-offer1.TotalMaxRewardAmount, nil)


### PR DESCRIPTION
- Changes offers creator role address state to just offers creator. Roles meant to have authority to change others address state, while offer creator won't do that. By this also change offers creator addr state bit from 3th to 50th.
- Add codec upgrade version to deposit offers API response
- Added check that offer min amount is no greater than deposit amount that would earn reward equal to offer total max reward amount (if its not zero)