### PR TITLE
[PVM] fixed nil state in VerifySpendUTXOs, added GetBlockAtHeight api

### DIFF
--- a/vms/platformvm/txs/executor/standard_tx_executor.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor.go
@@ -176,7 +176,7 @@ func (e *StandardTxExecutor) ImportTx(tx *txs.ImportTx) error {
 		copy(ins[len(tx.Ins):], tx.ImportedInputs)
 
 		if err := e.FlowChecker.VerifySpendUTXOs(
-			nil,
+			e.State,
 			tx,
 			utxos,
 			ins,

--- a/vms/platformvm/utxo/camino_handler.go
+++ b/vms/platformvm/utxo/camino_handler.go
@@ -132,7 +132,7 @@ func (h *caminoHandler) VerifySpendUTXOs(
 			locked.StateUnlocked,
 		)
 	}
-	return h.handler.VerifySpendUTXOs(nil, tx, utxos, ins, outs, creds, unlockedProduced)
+	return h.handler.VerifySpendUTXOs(utxoDB, tx, utxos, ins, outs, creds, unlockedProduced)
 }
 
 func (h *caminoHandler) toAVAXBurnedAmount(unlockedProduced map[ids.ID]uint64) (uint64, error) {

--- a/vms/platformvm/utxo/handler.go
+++ b/vms/platformvm/utxo/handler.go
@@ -461,7 +461,7 @@ func (h *handler) VerifySpend(
 		utxos[index] = utxo
 	}
 
-	return h.VerifySpendUTXOs(nil, tx, utxos, ins, outs, creds, unlockedProduced)
+	return h.VerifySpendUTXOs(utxoDB, tx, utxos, ins, outs, creds, unlockedProduced)
 }
 
 func (h *handler) VerifySpendUTXOs(


### PR DESCRIPTION
## Why this should be merged
- Bugfix: VerifySpendUTXOs got nil in place of state arg, now it gets correct state arg.
- Adds new pvm api method `getBlockAtHeight`
## How this works
API method is quite unoptimal and should be used for development purpose only. It iterates over all blocks starting from last accepted and going to its parent till it reaches required height.
## How this was tested
Manually