### PR TITLE
[PVM] Forbid nested msig aliases

### DIFF
--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -31,4 +31,7 @@ type CaminoFx interface {
 
 	// CollectMultisigAliases returns an array of OutputOwners part of the owner
 	CollectMultisigAliases(ownerIntf, msigIntf interface{}) ([]interface{}, error)
+
+	// Checks if [ownerIntf] contains msig alias
+	IsNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
 }

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -210,6 +210,21 @@ func (mr *MockFxMockRecorder) VerifyTransfer(arg0, arg1, arg2, arg3 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyTransfer", reflect.TypeOf((*MockFx)(nil).VerifyTransfer), arg0, arg1, arg2, arg3)
 }
 
+// IsNestedMultisig mocks base method.
+func (m *MockFx) IsNestedMultisig(arg0, arg1 interface{}) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsNestedMultisig", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsNestedMultisig indicates an expected call of IsNestedMultisig.
+func (mr *MockFxMockRecorder) IsNestedMultisig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNestedMultisig", reflect.TypeOf((*MockFx)(nil).IsNestedMultisig), arg0, arg1)
+}
+
 // MockOwner is a mock of Owner interface.
 type MockOwner struct {
 	ctrl     *gomock.Controller

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -617,7 +617,7 @@ func expectLock(s *state.MockState, allUTXOs map[ids.ShortID][]*avax.UTXO) {
 		s.EXPECT().UTXOIDs(addr.Bytes(), ids.Empty, math.MaxInt).Return(utxoids, nil)
 		for _, utxo := range utxos {
 			s.EXPECT().GetUTXO(utxo.InputID()).Return(utxo, nil)
-			s.EXPECT().GetMultisigAlias(addr).Return(nil, database.ErrNotFound)
+			s.EXPECT().GetMultisigAlias(addr).Return(nil, database.ErrNotFound).Times(2)
 		}
 	}
 }


### PR DESCRIPTION
## Why this should be merged
We want don't want to support nested multisig aliases. This PR forbids adding new nested multisig aliases or adding multisig alias addresses to existing multisig aliases.
## How this works
MultisigAliasesTx checks each multisig alias address that its not existing multisig alias.
## How this was tested
Unit-tests.