### PR TITLE
[Client] Add client getter for deposit offers

### DIFF
--- a/vms/platformvm/camino_client.go
+++ b/vms/platformvm/camino_client.go
@@ -16,6 +16,8 @@ type CaminoClient interface {
 
 	// GetMultisigAlias returns the alias definition of the given multisig address
 	GetMultisigAlias(ctx context.Context, multisigAddress string, options ...rpc.Option) (*GetMultisigAliasReply, error)
+
+	GetAllDepositOffers(ctx context.Context, getAllDepositOffersArgs *GetAllDepositOffersArgs, options ...rpc.Option) (*GetAllDepositOffersReply, error)
 }
 
 func (c *client) GetConfiguration(ctx context.Context, options ...rpc.Option) (*GetConfigurationReply, error) {
@@ -29,5 +31,11 @@ func (c *client) GetMultisigAlias(ctx context.Context, multisigAddress string, o
 	err := c.requester.SendRequest(ctx, "platform.getMultisigAlias", &api.JSONAddress{
 		Address: multisigAddress,
 	}, res, options...)
+	return res, err
+}
+
+func (c *client) GetAllDepositOffers(ctx context.Context, getAllDepositOffersArgs *GetAllDepositOffersArgs, options ...rpc.Option) (*GetAllDepositOffersReply, error) {
+	res := &GetAllDepositOffersReply{}
+	err := c.requester.SendRequest(ctx, "platform.getAllDepositOffers", &getAllDepositOffersArgs, res, options...)
 	return res, err
 }


### PR DESCRIPTION
## Why this should be merged
A new method for retrieving all deposit offers is need in other systems using the camino client. See https://github.com/chain4travel/camino-signavault/pull/58

## How this works
Adds a new method in the camino client for retrieving all deposit offers.

## How this was tested
Via camino-signavault
