### PR TITLE
[Client] add unmarshaling logic to JSONByteSlice

### DIFF
--- a/vms/types/blob_data.go
+++ b/vms/types/blob_data.go
@@ -19,6 +19,7 @@ func (b JSONByteSlice) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(hexData)
 }
+
 func (b *JSONByteSlice) UnmarshalJSON(data []byte) error {
 	var hexData string
 

--- a/vms/types/blob_data.go
+++ b/vms/types/blob_data.go
@@ -19,3 +19,17 @@ func (b JSONByteSlice) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(hexData)
 }
+func (b *JSONByteSlice) UnmarshalJSON(data []byte) error {
+	var hexData string
+
+	if err := json.Unmarshal(data, &hexData); err != nil {
+		return err
+	}
+	decoded, err := formatting.Decode(formatting.HexNC, hexData)
+	if err != nil {
+		return err
+	}
+
+	*b = decoded
+	return nil
+}


### PR DESCRIPTION
## Why this should be merged
Unmarshaling JSONBYteSlices is necessary in the case of node client functions that interact with services. In order to use the original interfaces for these service requests/responses you need to be able to unmarshal all data/fields involved.

## How this works
It adds unmarshaling logic to the JSONByteSlice type.

## How this was tested
Manually