### PR TITLE
[PVM, DAC] Bugfixes, tests, early-exit by fail

### DIFF
--- a/vms/platformvm/camino_helpers_test.go
+++ b/vms/platformvm/camino_helpers_test.go
@@ -181,7 +181,7 @@ func newCaminoGenesisWithUTXOs(caminoGenesisConfig api.Camino, genesisUTXOs []ap
 				Addresses: []string{addr},
 			},
 			Staked: []api.UTXO{{
-				Amount:  json.Uint64(defaultWeight),
+				Amount:  json.Uint64(defaultCaminoValidatorWeight),
 				Address: addr,
 			}},
 		}

--- a/vms/platformvm/dac/camino_add_member_proposal.go
+++ b/vms/platformvm/dac/camino_add_member_proposal.go
@@ -108,7 +108,9 @@ func (p *AddMemberProposalState) IsActiveAt(time time.Time) bool {
 func (p *AddMemberProposalState) CanBeFinished() bool {
 	mostVotedWeight, _, unambiguous := p.GetMostVoted()
 	voted := p.Voted()
-	return voted == p.TotalAllowedVoters || unambiguous && mostVotedWeight > p.TotalAllowedVoters/2
+	// We don't check for 'no option can reach 50%+ of votes' for this proposal type, cause its impossible with just 2 options
+	return voted == p.TotalAllowedVoters ||
+		unambiguous && mostVotedWeight > p.TotalAllowedVoters/2
 }
 
 func (p *AddMemberProposalState) IsSuccessful() bool {

--- a/vms/platformvm/dac/camino_add_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_add_member_proposal_test.go
@@ -10,6 +10,75 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAddMemberProposalVerify(t *testing.T) {
+	tests := map[string]struct {
+		proposal         *AddMemberProposal
+		expectedProposal *AddMemberProposal
+		expectedErr      error
+	}{
+		"End-time is equal to start-time": {
+			proposal: &AddMemberProposal{
+				Start: 100,
+				End:   100,
+			},
+			expectedProposal: &AddMemberProposal{
+				Start: 100,
+				End:   100,
+			},
+			expectedErr: errEndNotAfterStart,
+		},
+		"End-time is less than start-time": {
+			proposal: &AddMemberProposal{
+				Start: 100,
+				End:   99,
+			},
+			expectedProposal: &AddMemberProposal{
+				Start: 100,
+				End:   99,
+			},
+			expectedErr: errEndNotAfterStart,
+		},
+		"To small duration": {
+			proposal: &AddMemberProposal{
+				Start: 100,
+				End:   100 + AddMemberProposalDuration - 1,
+			},
+			expectedProposal: &AddMemberProposal{
+				Start: 100,
+				End:   100 + AddMemberProposalDuration - 1,
+			},
+			expectedErr: errWrongDuration,
+		},
+		"To big duration": {
+			proposal: &AddMemberProposal{
+				Start: 100,
+				End:   100 + AddMemberProposalDuration + 1,
+			},
+			expectedProposal: &AddMemberProposal{
+				Start: 100,
+				End:   100 + AddMemberProposalDuration + 1,
+			},
+			expectedErr: errWrongDuration,
+		},
+		"OK": {
+			proposal: &AddMemberProposal{
+				Start: 100,
+				End:   100 + AddMemberProposalDuration,
+			},
+			expectedProposal: &AddMemberProposal{
+				Start: 100,
+				End:   100 + AddMemberProposalDuration,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, tt.proposal.Verify(), tt.expectedErr)
+			require.Equal(t, tt.expectedProposal, tt.proposal)
+		})
+	}
+}
+
 func TestAddMemberProposalCreateProposalState(t *testing.T) {
 	tests := map[string]struct {
 		proposal              *AddMemberProposal
@@ -75,8 +144,8 @@ func TestAddMemberProposalCreateProposalState(t *testing.T) {
 
 func TestAddMemberProposalStateAddVote(t *testing.T) {
 	voterAddr1 := ids.ShortID{1}
-	voterAddr2 := ids.ShortID{1}
-	voterAddr3 := ids.ShortID{1}
+	voterAddr2 := ids.ShortID{2}
+	voterAddr3 := ids.ShortID{3}
 
 	tests := map[string]struct {
 		proposal                 *AddMemberProposalState
@@ -392,6 +461,144 @@ func TestAddMemberProposalCreateFinishedProposalState(t *testing.T) {
 				require.True(t, proposalState.CanBeFinished())
 				require.True(t, proposalState.IsSuccessful())
 			}
+		})
+	}
+}
+
+func TestAddMemberProposalStateIsSuccessful(t *testing.T) {
+	tests := map[string]struct {
+		proposal                 *AddMemberProposalState
+		expectedSuccessful       bool
+		expectedOriginalProposal *AddMemberProposalState
+	}{
+		// Case, when most voted weight is less, than 50% of votes is impossible, cause proposal only has 2 options
+		"Not successful: total voted weight is less, than 50% of total allowed voters": {
+			proposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 25},
+						{Value: false, Weight: 26},
+					},
+				},
+				TotalAllowedVoters: 102,
+			},
+			expectedSuccessful: false,
+			expectedOriginalProposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 25},
+						{Value: false, Weight: 26},
+					},
+				},
+				TotalAllowedVoters: 102,
+			},
+		},
+		"Successful": {
+			proposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 25},
+						{Value: false, Weight: 26},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedSuccessful: true,
+			expectedOriginalProposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 25},
+						{Value: false, Weight: 26},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.expectedSuccessful, tt.proposal.IsSuccessful())
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
+		})
+	}
+}
+
+func TestAddMemberProposalStateCanBeFinished(t *testing.T) {
+	tests := map[string]struct {
+		proposal                 *AddMemberProposalState
+		expectedCanBeFinished    bool
+		expectedOriginalProposal *AddMemberProposalState
+	}{
+		"Can not be finished: most voted weight is less than 50% of total allowed voters and not everyone had voted": {
+			proposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 50},
+						{Value: false},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 50},
+						{Value: false},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+		"Can be finished: everyone had voted": {
+			proposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 50},
+						{Value: false, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 50},
+						{Value: false, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+		"Can be finished: most voted weight is greater than 50% of total allowed voters": {
+			proposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 51},
+						{Value: false},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &AddMemberProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[bool]{
+					Options: []SimpleVoteOption[bool]{
+						{Value: true, Weight: 51},
+						{Value: false},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+		// We don't have test-case 'no option can reach 50%+ of votes' for this proposal type, cause its impossible with just 2 options
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.expectedCanBeFinished, tt.proposal.CanBeFinished())
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
 		})
 	}
 }

--- a/vms/platformvm/dac/camino_exclude_member_proposal.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal.go
@@ -117,7 +117,9 @@ func (p *ExcludeMemberProposalState) IsActiveAt(time time.Time) bool {
 func (p *ExcludeMemberProposalState) CanBeFinished() bool {
 	mostVotedWeight, _, unambiguous := p.GetMostVoted()
 	voted := p.Voted()
-	return voted == p.TotalAllowedVoters || unambiguous && mostVotedWeight > p.TotalAllowedVoters/2
+	// We don't check for 'no option can reach 50%+ of votes' for this proposal type, cause its impossible with just 2 options
+	return voted == p.TotalAllowedVoters ||
+		unambiguous && mostVotedWeight > p.TotalAllowedVoters/2
 }
 
 func (p *ExcludeMemberProposalState) IsSuccessful() bool {

--- a/vms/platformvm/dac/camino_proposal.go
+++ b/vms/platformvm/dac/camino_proposal.go
@@ -13,6 +13,8 @@ import (
 )
 
 var (
+	errNoOptions                  = errors.New("no options")
+	errNotUniqueOption            = errors.New("not unique option")
 	errWrongOptionIndex           = errors.New("wrong option index")
 	errEndNotAfterStart           = errors.New("proposal end-time is not after start-time")
 	errWrongDuration              = errors.New("wrong proposal duration")
@@ -61,11 +63,9 @@ type Proposal interface {
 }
 
 type ProposalState interface {
-	verify.Verifiable
-
 	EndTime() time.Time
 	IsActiveAt(time time.Time) bool
-	// Once a proposal has become Finishable, it cannot be undone by adding more votes.
+	// Once a proposal has become Finishable, it cannot be undone by adding more votes. Should only return true, when future votes cannot change the outcome of proposal.
 	CanBeFinished() bool
 	IsSuccessful() bool // should be called only for finished proposals
 	Outcome() any       // should be called only for finished successful proposals

--- a/vms/platformvm/dac/camino_simple_vote.go
+++ b/vms/platformvm/dac/camino_simple_vote.go
@@ -3,18 +3,7 @@
 
 package dac
 
-import (
-	"errors"
-
-	"github.com/ava-labs/avalanchego/utils/set"
-)
-
-var (
-	_ Vote = (*SimpleVote)(nil)
-
-	errNoOptions       = errors.New("no options")
-	errNotUniqueOption = errors.New("not unique option")
-)
+var _ Vote = (*SimpleVote)(nil)
 
 type SimpleVote struct {
 	OptionIndex uint32 `serialize:"true"` // Index of voted option
@@ -33,25 +22,11 @@ type SimpleVoteOption[T any] struct {
 	Weight uint32 `serialize:"true"` // How much this option was voted
 }
 
-type SimpleVoteOptions[T comparable] struct {
+type SimpleVoteOptions[T any] struct {
 	Options              []SimpleVoteOption[T] `serialize:"true"`
 	mostVotedWeight      uint32                // Weight of most voted option
 	mostVotedOptionIndex uint32                // Index of most voted option
 	unambiguous          bool                  // True, if there is an option with weight > then other options weight
-}
-
-func (p *SimpleVoteOptions[T]) Verify() error {
-	if len(p.Options) == 0 {
-		return errNoOptions
-	}
-	unique := set.NewSet[T](len(p.Options))
-	for _, option := range p.Options {
-		if unique.Contains(option.Value) {
-			return errNotUniqueOption
-		}
-		unique.Add(option.Value)
-	}
-	return nil
 }
 
 func (p SimpleVoteOptions[T]) GetMostVoted() (

--- a/vms/platformvm/txs/camino_add_proposal_tx_test.go
+++ b/vms/platformvm/txs/camino_add_proposal_tx_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/avalanchego/vms/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +41,12 @@ func TestAddProposalTxSyntacticVerify(t *testing.T) {
 	}{
 		"Nil tx": {
 			expectedErr: ErrNilTx,
+		},
+		"Too big proposal description": {
+			tx: &AddProposalTx{
+				ProposalDescription: make(types.JSONByteSlice, maxProposalDescriptionSize+1),
+			},
+			expectedErr: errTooBigProposalDescription,
 		},
 		"Fail to unmarshal proposal": {
 			tx: &AddProposalTx{
@@ -91,11 +98,19 @@ func TestAddProposalTxSyntacticVerify(t *testing.T) {
 			},
 			expectedErr: locked.ErrWrongOutType,
 		},
-		"OK": {
+		"OK: no proposal description": {
 			tx: &AddProposalTx{
 				BaseTx:          baseTx,
 				ProposalPayload: proposalBytes,
 				ProposerAuth:    &secp256k1fx.Input{},
+			},
+		},
+		"OK": {
+			tx: &AddProposalTx{
+				BaseTx:              baseTx,
+				ProposalDescription: make(types.JSONByteSlice, maxProposalDescriptionSize),
+				ProposalPayload:     proposalBytes,
+				ProposerAuth:        &secp256k1fx.Input{},
 			},
 		},
 	}

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1765,7 +1765,7 @@ func (e *CaminoStandardTxExecutor) AddProposalTx(tx *txs.AddProposalTx) error {
 		return fmt.Errorf("%w: %s", errProposerCredentialMismatch, err)
 	}
 
-	if err := txProposal.VerifyWith(dac.NewProposalVerifier(e.State, e.Fx, e.Tx, tx)); err != nil {
+	if err := txProposal.VerifyWith(dac.NewProposalVerifier(e.State, e.Fx, e.Tx, tx, isAdminProposal)); err != nil {
 		return fmt.Errorf("%w: %s", errInvalidProposal, err)
 	}
 

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -6194,7 +6194,7 @@ func TestCaminoStandardTxExecutorAddProposalTx(t *testing.T) {
 				proposalsIterator.EXPECT().Release()
 				proposalsIterator.EXPECT().Error().Return(nil)
 
-				s.EXPECT().GetAddressStates(applicantAddress).Return(as.AddressStateEmpty, nil)
+				s.EXPECT().GetAddressStates(applicantAddress).Return(as.AddressStateKYCVerified, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				// *
 


### PR DESCRIPTION
## Why this should be merged
### Bugfixes
Fixes following bugs:
- addMember proposal could add not KYC-verified address
- excludeMember proposal can be created by not consortium members or without having active validator
- baseFee proposal could contain not-unique options
### Tests
PR also adds unit tests for proposal Verify, IsSuccessful, CanBeFinished implementations and slightly improves camino service GetBalance test.
### AddProposalTx changes
PR adds new field to tx:
```go
	// Contains arbitrary bytes, up to maxProposalDescriptionSize
	ProposalDescription types.JSONByteSlice `serialize:"true" json:"proposalDescription"`
```
This field is limited to 2048 bytes, corresponding checks in syntactic verify, tests updated
### Early-exit by fail
PR adds new early exit condition for base fee proposal:
```
mostVotedWeight + totalAllowedVoters - voted < mostVotedTheshold
mostVotedThreshold = voted / 2 + 1
```
Basically, this means, that if proposal most voted option can't get enough votes even if all not-yet casted votes would be casted for this option, than proposal is already failed and can be finished.

This is irrelevant for add/exclude member proposals, cause they have just 2 options and its impossible to not reach mostVotedTheshold without at least 3 options.
## How this works
Regarding add/exclude member proposals bugs, PR adds corresponding checks to proposal verifier methods:
- checks that addMemberProposal applicant address is kyc-verified
- checks that excludeMemberProposal proposer address is consortium member and has active validator, but only if its not admin proposal - admin can bypass this requirements

Regarding `baseFeeProposal`, corresponding checks were in `simpleVoteOptions` - generic struct that was part of `ProposalState`. `ProposalState` is created by node on `addProposalTx` execution and should always be valid, so `proposalState.Verify` was never called. PR removes this function and moves its logic to `baseFeeProposal.Verify` (other existing proposal types doesn't have options, e.g. add/exclude member), which is implementation of `proposal.Verify` and is called on `addProposalTx` execution before `proposalState` is created.

## How this was tested
Unit tests, integration tests
