### PR TITLE
[PVM, DAC] General proposal

### DIFF
--- a/vms/platformvm/dac/camino_codec.go
+++ b/vms/platformvm/dac/camino_codec.go
@@ -27,6 +27,7 @@ func init() {
 			c.RegisterCustomType(&BaseFeeProposalState{}),
 			c.RegisterCustomType(&AddMemberProposalState{}),
 			c.RegisterCustomType(&ExcludeMemberProposalState{}),
+			c.RegisterCustomType(&GeneralProposalState{}),
 			c.RegisterCustomType(&FeeDistributionProposalState{}),
 		)
 	}

--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -1,0 +1,297 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package dac
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
+	"github.com/ava-labs/avalanchego/vms/types"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	generalProposalMaxOptionsCount = 3
+	generalProposalMaxOptionSize   = 256
+	generalProposalMinDuration     = uint64(time.Hour * 24 / time.Second)      // 1 day
+	generalProposalMaxDuration     = uint64(time.Hour * 24 * 30 / time.Second) // 1 month
+)
+
+var (
+	_ Proposal      = (*GeneralProposal)(nil)
+	_ ProposalState = (*GeneralProposalState)(nil)
+
+	errGeneralProposalOptionIsToBig = errors.New("option size is to big")
+	errNotImplemented               = errors.New("not implemented, should never be called")
+)
+
+type GeneralProposal struct {
+	Options [][]byte `serialize:"true"` // Arbitrary options
+	Start   uint64   `serialize:"true"` // Start time of proposal
+	End     uint64   `serialize:"true"` // End time of proposal
+
+	// In order to be successful, proposal must have number of votes greater than threshold, which is calculated as:
+	//
+	// len(allowedVoters) * p.TotalVotedThresholdNominator / fractionDenominatorBig
+	TotalVotedThresholdNominator uint64 `serialize:"true"`
+
+	// In order to be successful, most voted option must have more weight than threshold, which is calculated as:
+	//
+	// voted * MostVotedThresholdNominator / FractionDenominator.
+	MostVotedThresholdNominator uint64 `serialize:"true"`
+
+	// Allow this proposal to finish early if it has unambiguos result that cannot be altered by future votes.
+	AllowEarlyFinish bool `serialize:"true"`
+}
+
+func (p *GeneralProposal) StartTime() time.Time {
+	return time.Unix(int64(p.Start), 0)
+}
+
+func (p *GeneralProposal) EndTime() time.Time {
+	return time.Unix(int64(p.End), 0)
+}
+
+func (p *GeneralProposal) GetOptions() any {
+	return p.Options
+}
+
+// This proposal type cannot be admin proposal
+func (*GeneralProposal) AdminProposer() as.AddressState {
+	return as.AddressStateEmpty
+}
+
+func (p *GeneralProposal) Verify() error {
+	switch {
+	case len(p.Options) == 0:
+		return errNoOptions
+	case len(p.Options) > generalProposalMaxOptionsCount:
+		return fmt.Errorf("%w (expected: no more than %d, actual: %d)", errWrongOptionsCount, generalProposalMaxOptionsCount, len(p.Options))
+	case p.Start >= p.End:
+		return errEndNotAfterStart
+	case p.End-p.Start < generalProposalMinDuration:
+		return fmt.Errorf("%w (expected: minimum duration %d, actual: %d)", errWrongDuration, generalProposalMinDuration, p.End-p.Start)
+	case p.End-p.Start > generalProposalMaxDuration:
+		return fmt.Errorf("%w (expected: maximum duration %d, actual: %d)", errWrongDuration, generalProposalMaxDuration, p.End-p.Start)
+	}
+	for i := 0; i < len(p.Options); i++ {
+		if len(p.Options[i]) > generalProposalMaxOptionSize {
+			return fmt.Errorf("%w (expected: no more than %d, actual: %d, option index: %d)",
+				errGeneralProposalOptionIsToBig, generalProposalMaxOptionSize, len(p.Options[i]), i)
+		}
+		for j := i + 1; j < len(p.Options); j++ {
+			if bytes.Equal(p.Options[i], p.Options[j]) {
+				return errNotUniqueOption
+			}
+		}
+	}
+	return nil
+}
+
+func (p *GeneralProposal) CreateProposalState(allowedVoters []ids.ShortID) ProposalState {
+	// totalVotedThreshold = len(allowedVoters) * p.TotalVotedThresholdNominator / fractionDenominatorBig
+	totalAllowedVoters := big.NewInt(int64(len(allowedVoters)))
+	totalVotedThreshold := big.NewInt(int64(p.TotalVotedThresholdNominator))
+	totalVotedThreshold.Mul(totalVotedThreshold, totalAllowedVoters)
+	totalVotedThreshold.Div(totalVotedThreshold, fractionDenominatorBig)
+
+	stateProposal := &GeneralProposalState{
+		SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+			Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
+		},
+		Start:                       p.Start,
+		End:                         p.End,
+		AllowedVoters:               allowedVoters,
+		TotalAllowedVoters:          uint32(len(allowedVoters)),
+		TotalVotedThreshold:         uint32(totalVotedThreshold.Uint64()),
+		MostVotedThresholdNominator: p.MostVotedThresholdNominator,
+		AllowEarlyFinish:            p.AllowEarlyFinish,
+	}
+	for i := range p.Options {
+		stateProposal.Options[i].Value = p.Options[i]
+	}
+	return stateProposal
+}
+
+func (*GeneralProposal) CreateFinishedProposalState(uint32) (ProposalState, error) {
+	return nil, errNotImplemented
+}
+
+func (p *GeneralProposal) VerifyWith(verifier Verifier) error {
+	return verifier.GeneralProposal(p)
+}
+
+type GeneralProposalState struct {
+	// New base fee options
+	SimpleVoteOptions[[]byte] `serialize:"true"`
+
+	// Start time of proposal
+	Start uint64 `serialize:"true"`
+
+	// End time of proposal
+	End uint64 `serialize:"true"`
+
+	// Addresses that are allowed to vote for this proposal
+	AllowedVoters []ids.ShortID `serialize:"true"`
+
+	// Number of addresses that were initially allowed to vote for this proposal.
+	// This is used to calculate thresholds like "half of total voters".
+	TotalAllowedVoters uint32 `serialize:"true"`
+
+	// Proposal must have number of votes greater than this threshold in order to be successful.
+	TotalVotedThreshold uint32 `serialize:"true"`
+
+	// In order to be successful, most voted option must have more weight than threshold, which is calculated as:
+	//
+	// voted * MostVotedThresholdNominator / FractionDenominator.
+	MostVotedThresholdNominator uint64 `serialize:"true"`
+
+	// Allow this proposal to finish early if it has unambiguos result that cannot be altered by future votes.
+	AllowEarlyFinish bool `serialize:"true"`
+}
+
+func (p *GeneralProposalState) StartTime() time.Time {
+	return time.Unix(int64(p.Start), 0)
+}
+
+func (p *GeneralProposalState) EndTime() time.Time {
+	return time.Unix(int64(p.End), 0)
+}
+
+func (p *GeneralProposalState) IsActiveAt(time time.Time) bool {
+	timestamp := uint64(time.Unix())
+	return p.Start <= timestamp && timestamp <= p.End
+}
+
+func (p *GeneralProposalState) CanBeFinished() bool {
+	if !p.AllowEarlyFinish {
+		return false
+	}
+
+	mostVotedWeight, mostVotedIndex, unambiguous := p.GetMostVoted()
+	voted := p.Voted()
+	remainingVotes := p.TotalAllowedVoters - voted
+
+	secondMostVotedWeight := uint32(0)
+	if len(p.Options) > 1 {
+		for index, option := range p.Options {
+			if option.Weight > secondMostVotedWeight && index != int(mostVotedIndex) {
+				secondMostVotedWeight = option.Weight
+			}
+		}
+	}
+
+	// mostVotedThreshold = voted * p.MostVotedThresholdNominator / fractionDenominatorBig
+	mostVotedThresholdNominator := big.NewInt(int64(p.MostVotedThresholdNominator))
+	mostVotedThresholdBig := big.NewInt(int64(voted))
+	mostVotedThresholdBig.Mul(mostVotedThresholdBig, mostVotedThresholdNominator)
+	mostVotedThresholdBig.Div(mostVotedThresholdBig, fractionDenominatorBig)
+	mostVotedThreshold := uint32(mostVotedThresholdBig.Uint64())
+
+	return remainingVotes+mostVotedWeight < mostVotedThreshold+1 || // no option can win
+		voted == p.TotalAllowedVoters || // everyone had voted
+		unambiguous && // option will inevitably win, because
+			(mostVotedWeight > remainingVotes+secondMostVotedWeight || len(p.Options) == 1) && // it has more votes than any other option + remaining votes or its the only option
+			mostVotedWeight > mostVotedThreshold && // it has already surpassed mostVotedThreshold
+			voted > p.TotalVotedThreshold // it has already surpassed totalVotedThreshold
+}
+
+func (p *GeneralProposalState) IsSuccessful() bool {
+	mostVotedWeight, _, unambiguous := p.GetMostVoted()
+	voted := p.Voted()
+
+	// mostVotedThreshold = voted * p.MostVotedThresholdNominator / fractionDenominatorBig
+	mostVotedThresholdNominator := big.NewInt(int64(p.MostVotedThresholdNominator))
+	mostVotedThreshold := big.NewInt(int64(voted))
+	mostVotedThreshold.Mul(mostVotedThreshold, mostVotedThresholdNominator)
+	mostVotedThreshold.Div(mostVotedThreshold, fractionDenominatorBig)
+
+	return unambiguous && voted > p.TotalVotedThreshold && uint64(mostVotedWeight) > mostVotedThreshold.Uint64()
+}
+
+func (p *GeneralProposalState) Outcome() any {
+	_, mostVotedOptionIndex, unambiguous := p.GetMostVoted()
+	if !unambiguous {
+		return -1
+	}
+	return mostVotedOptionIndex
+}
+
+func (p *GeneralProposalState) Result() (types.JSONByteSlice, uint32, bool) {
+	mostVotedWeight, mostVotedOptionIndex, unambiguous := p.GetMostVoted()
+	return p.Options[mostVotedOptionIndex].Value, mostVotedWeight, unambiguous
+}
+
+// Will return modified proposal with added vote, original proposal will not be modified!
+func (p *GeneralProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote) (ProposalState, error) {
+	vote, ok := voteIntf.(*SimpleVote)
+	if !ok {
+		return nil, ErrWrongVote
+	}
+	if int(vote.OptionIndex) >= len(p.Options) {
+		return nil, ErrWrongVote
+	}
+
+	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
+		return bytes.Compare(id[:], other[:])
+	})
+	if !allowedToVote {
+		return nil, ErrNotAllowedToVoteOnProposal
+	}
+
+	updatedProposal := &GeneralProposalState{
+		Start:         p.Start,
+		End:           p.End,
+		AllowedVoters: make([]ids.ShortID, len(p.AllowedVoters)-1),
+		SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+			Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
+		},
+		TotalAllowedVoters: p.TotalAllowedVoters,
+	}
+	// we can't use the same slice, cause we need to change its elements
+	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
+	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
+	// we can't use the same slice, cause we need to change its element
+	copy(updatedProposal.Options, p.Options)
+	updatedProposal.Options[vote.OptionIndex].Weight++
+	return updatedProposal, nil
+}
+
+// Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
+func (p *GeneralProposalState) ForceAddVote(voteIntf Vote) (ProposalState, error) {
+	vote, ok := voteIntf.(*SimpleVote)
+	if !ok {
+		return nil, ErrWrongVote
+	}
+	if int(vote.OptionIndex) >= len(p.Options) {
+		return nil, ErrWrongVote
+	}
+
+	updatedProposal := &GeneralProposalState{
+		Start:         p.Start,
+		End:           p.End,
+		AllowedVoters: p.AllowedVoters,
+		SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+			Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
+		},
+		TotalAllowedVoters: p.TotalAllowedVoters,
+	}
+	// we can't use the same slice, cause we need to change its element
+	copy(updatedProposal.Options, p.Options)
+	updatedProposal.Options[vote.OptionIndex].Weight++
+	return updatedProposal, nil
+}
+
+func (p *GeneralProposalState) ExecuteWith(executor Executor) error {
+	return executor.GeneralProposal(p)
+}
+
+func (p *GeneralProposalState) GetBondTxIDsWith(bondTxIDsGetter BondTxIDsGetter) ([]ids.ID, error) {
+	return bondTxIDsGetter.GeneralProposal(p)
+}

--- a/vms/platformvm/dac/camino_general_proposal_test.go
+++ b/vms/platformvm/dac/camino_general_proposal_test.go
@@ -1,0 +1,916 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package dac
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneralProposalVerify(t *testing.T) {
+	tests := map[string]struct {
+		proposal         *GeneralProposal
+		expectedProposal *GeneralProposal
+		expectedErr      error
+	}{
+		"No options": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     101,
+				Options: [][]byte{},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     101,
+				Options: [][]byte{},
+			},
+			expectedErr: errNoOptions,
+		},
+		"To many options": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     101,
+				Options: [][]byte{{1}, {2}, {3}, {4}},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     101,
+				Options: [][]byte{{1}, {2}, {3}, {4}},
+			},
+			expectedErr: errWrongOptionsCount,
+		},
+		"End-time is equal to start-time": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     100,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     100,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedErr: errEndNotAfterStart,
+		},
+		"End-time is less than start-time": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     99,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     99,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedErr: errEndNotAfterStart,
+		},
+		"To small duration": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration - 1,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration - 1,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedErr: errWrongDuration,
+		},
+		"To big duration": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMaxDuration + 1,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMaxDuration + 1,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedErr: errWrongDuration,
+		},
+		"Option is bigger than allowed": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration,
+				Options: [][]byte{make([]byte, generalProposalMaxOptionSize+1)},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration,
+				Options: [][]byte{make([]byte, generalProposalMaxOptionSize+1)},
+			},
+			expectedErr: errGeneralProposalOptionIsToBig,
+		},
+		"Not unique option": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration,
+				Options: [][]byte{{1}, {2}, {1}},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration,
+				Options: [][]byte{{1}, {2}, {1}},
+			},
+			expectedErr: errNotUniqueOption,
+		},
+		"OK: 1 option": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration,
+				Options: [][]byte{make([]byte, generalProposalMaxOptionSize)},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration,
+				Options: [][]byte{make([]byte, generalProposalMaxOptionSize)},
+			},
+		},
+		"OK: 3 options": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     100 + generalProposalMinDuration,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, tt.proposal.Verify(), tt.expectedErr)
+			require.Equal(t, tt.expectedProposal, tt.proposal)
+		})
+	}
+}
+
+func TestGeneralProposalCreateProposalState(t *testing.T) {
+	tests := map[string]struct {
+		proposal              *GeneralProposal
+		allowedVoters         []ids.ShortID
+		expectedProposalState ProposalState
+		expectedProposal      *GeneralProposal
+	}{
+		"OK: even number of allowed voters": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     101,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			allowedVoters: []ids.ShortID{{1}, {2}, {3}, {4}},
+			expectedProposalState: &GeneralProposalState{
+				Start:         100,
+				End:           101,
+				AllowedVoters: []ids.ShortID{{1}, {2}, {3}, {4}},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}},
+						{Value: []byte{2}},
+						{Value: []byte{3}},
+					},
+				},
+				TotalAllowedVoters: 4,
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     101,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+		},
+		"OK: odd number of allowed voters": {
+			proposal: &GeneralProposal{
+				Start:   100,
+				End:     101,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+			allowedVoters: []ids.ShortID{{1}, {2}, {3}, {4}, {5}},
+			expectedProposalState: &GeneralProposalState{
+				Start:         100,
+				End:           101,
+				AllowedVoters: []ids.ShortID{{1}, {2}, {3}, {4}, {5}},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}},
+						{Value: []byte{2}},
+						{Value: []byte{3}},
+					},
+				},
+				TotalAllowedVoters: 5,
+			},
+			expectedProposal: &GeneralProposal{
+				Start:   100,
+				End:     101,
+				Options: [][]byte{{1}, {2}, {3}},
+			},
+		},
+		"OK: configured thresholds and early finish": {
+			proposal: &GeneralProposal{
+				Start:                        100,
+				End:                          101,
+				Options:                      [][]byte{{1}, {2}, {3}},
+				TotalVotedThresholdNominator: 390000,
+				MostVotedThresholdNominator:  680000,
+				AllowEarlyFinish:             true,
+			},
+			allowedVoters: make([]ids.ShortID, 100),
+			expectedProposalState: &GeneralProposalState{
+				Start: 100,
+				End:   101,
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}},
+						{Value: []byte{2}},
+						{Value: []byte{3}},
+					},
+				},
+				AllowedVoters:               make([]ids.ShortID, 100),
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         39,
+				MostVotedThresholdNominator: 680000,
+				AllowEarlyFinish:            true,
+			},
+			expectedProposal: &GeneralProposal{
+				Start:                        100,
+				End:                          101,
+				Options:                      [][]byte{{1}, {2}, {3}},
+				TotalVotedThresholdNominator: 390000,
+				MostVotedThresholdNominator:  680000,
+				AllowEarlyFinish:             true,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			proposalState := tt.proposal.CreateProposalState(tt.allowedVoters)
+			require.Equal(t, tt.expectedProposal, tt.proposal)
+			require.Equal(t, tt.expectedProposalState, proposalState)
+		})
+	}
+}
+
+func TestGeneralProposalStateAddVote(t *testing.T) {
+	voterAddr1 := ids.ShortID{1}
+	voterAddr2 := ids.ShortID{2}
+	voterAddr3 := ids.ShortID{3}
+
+	tests := map[string]struct {
+		proposal                 *GeneralProposalState
+		voterAddr                ids.ShortID
+		vote                     Vote
+		expectedUpdatedProposal  ProposalState
+		expectedOriginalProposal *GeneralProposalState
+		expectedErr              error
+	}{
+		"Wrong vote type": {
+			proposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			voterAddr: voterAddr1,
+			vote:      &DummyVote{}, // not *SimpleVote
+			expectedOriginalProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			expectedErr: ErrWrongVote,
+		},
+		"Wrong vote option index": {
+			proposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			voterAddr: ids.ShortID{3},
+			vote:      &SimpleVote{OptionIndex: 3},
+			expectedOriginalProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			expectedErr: ErrWrongVote,
+		},
+		"Not allowed to vote on this proposal": {
+			proposal: &GeneralProposalState{
+				AllowedVoters: []ids.ShortID{{1}, {2}},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
+				},
+			},
+			voterAddr: ids.ShortID{3},
+			vote:      &SimpleVote{OptionIndex: 0},
+			expectedOriginalProposal: &GeneralProposalState{
+				AllowedVoters: []ids.ShortID{{1}, {2}},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
+				},
+			},
+			expectedErr: ErrNotAllowedToVoteOnProposal,
+		},
+		"OK: adding vote to not voted option": {
+			proposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			voterAddr: voterAddr1,
+			vote:      &SimpleVote{OptionIndex: 1},
+			expectedUpdatedProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 1}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+				},
+			},
+			expectedOriginalProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+		},
+		"OK: adding vote to already voted option": {
+			proposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			voterAddr: voterAddr1,
+			vote:      &SimpleVote{OptionIndex: 2},
+			expectedUpdatedProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 2}, // 2
+					},
+				},
+			},
+			expectedOriginalProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+		},
+		"OK: voter addr in the middle of allowedVoters array": {
+			proposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1, voterAddr2, voterAddr3},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
+				},
+			},
+			voterAddr: voterAddr2,
+			vote:      &SimpleVote{OptionIndex: 0},
+			expectedUpdatedProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1, voterAddr3},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}, Weight: 1}},
+				},
+			},
+			expectedOriginalProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1, voterAddr2, voterAddr3},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote)
+			require.ErrorIs(t, err, tt.expectedErr)
+			require.Equal(t, tt.expectedUpdatedProposal, updatedProposal)
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
+		})
+	}
+}
+
+func TestGeneralProposalStateIsSuccessful(t *testing.T) {
+	tests := map[string]struct {
+		proposal                 *GeneralProposalState
+		expectedSuccessful       bool
+		expectedOriginalProposal *GeneralProposalState
+	}{
+		"Not successful: most voted weight is less, than most voted threshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 25},
+						{Value: []byte{2}, Weight: 26},
+					},
+				},
+				TotalVotedThreshold:         50,
+				MostVotedThresholdNominator: 510000, // 50%
+			},
+			expectedSuccessful: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 25},
+						{Value: []byte{2}, Weight: 26},
+					},
+				},
+				TotalVotedThreshold:         50,
+				MostVotedThresholdNominator: 510000, // 50%
+			},
+		},
+		"Not successful: total voted weight is less, than total voted threshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 25},
+						{Value: []byte{2}, Weight: 26},
+					},
+				},
+				TotalVotedThreshold:         51,
+				MostVotedThresholdNominator: 500000, // 50%
+			},
+			expectedSuccessful: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 25},
+						{Value: []byte{2}, Weight: 26},
+					},
+				},
+				TotalVotedThreshold:         51,
+				MostVotedThresholdNominator: 500000, // 50%
+			},
+		},
+		"Successful": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 25},
+						{Value: []byte{2}, Weight: 26},
+					},
+				},
+				TotalVotedThreshold:         50,
+				MostVotedThresholdNominator: 500000, // 50%
+			},
+			expectedSuccessful: true,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 25},
+						{Value: []byte{2}, Weight: 26},
+					},
+				},
+				TotalVotedThreshold:         50,
+				MostVotedThresholdNominator: 500000, // 50%
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.expectedSuccessful, tt.proposal.IsSuccessful())
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
+		})
+	}
+}
+
+func TestGeneralProposalStateCanBeFinished(t *testing.T) {
+	tests := map[string]struct {
+		proposal                 *GeneralProposalState
+		expectedCanBeFinished    bool
+		expectedOriginalProposal *GeneralProposalState
+	}{
+		"No: mostVotedWeight <= remainingVotes + secondMostVotedWeight, while mostVotedWeight > mostVotedThreshold AND voted > p.TotalVotedThreshold; not everyone had voted and some option can reach mostVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 18},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         78,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            true,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 18},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         78,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            true,
+			},
+		},
+		"No: mostVotedWeight <= mostVotedThreshold, while mostVotedWeight > remainingVotes + secondMostVotedWeight AND voted > p.TotalVotedThreshold; not everyone had voted and some option can reach mostVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 20},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				}, // 81 * k = 41
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         80,
+				MostVotedThresholdNominator: 506173,
+				AllowEarlyFinish:            true,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 20},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         80,
+				MostVotedThresholdNominator: 506173,
+				AllowEarlyFinish:            true,
+			},
+		},
+		"No: voted <= p.TotalVotedThreshold, while mostVotedWeight > remainingVotes + secondMostVotedWeight AND mostVotedWeight > mostVotedThreshold; not everyone had voted and some option can reach mostVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 20},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         81,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            true,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 20},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         81,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            true,
+			},
+		},
+		"No: just one option, but voted <= p.TotalVotedThreshold and not everyone had voted": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 21},
+					},
+				},
+				TotalAllowedVoters:  100,
+				TotalVotedThreshold: 21,
+				AllowEarlyFinish:    true,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 21},
+					},
+				},
+				TotalAllowedVoters:  100,
+				TotalVotedThreshold: 21,
+				AllowEarlyFinish:    true,
+			},
+		},
+		"Not allowed: no option can reach mostVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 29},
+						{Value: []byte{2}, Weight: 29},
+						{Value: []byte{3}, Weight: 29},
+					},
+				},
+				TotalAllowedVoters:          100,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            false,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 29},
+						{Value: []byte{2}, Weight: 29},
+						{Value: []byte{3}, Weight: 29},
+					},
+				},
+				TotalAllowedVoters:          100,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            false,
+			},
+		},
+		"Not allowed: everyone had voted": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 50},
+						{Value: []byte{2}, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+				AllowEarlyFinish:   false,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 50},
+						{Value: []byte{2}, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+				AllowEarlyFinish:   false,
+			},
+		},
+		"Not allowed: mostVotedWeight > remainingVotes + secondMostVotedWeight AND mostVotedWeight > mostVotedThreshold AND voted > p.TotalVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 20},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         80,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            false,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 20},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         80,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            false,
+			},
+		},
+		"Not allowed: just one option AND voted > p.TotalVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 21},
+					},
+				},
+				TotalAllowedVoters:  100,
+				TotalVotedThreshold: 20,
+				AllowEarlyFinish:    false,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 21},
+					},
+				},
+				TotalAllowedVoters:  100,
+				TotalVotedThreshold: 20,
+				AllowEarlyFinish:    false,
+			},
+		},
+		"Yes: no option can reach mostVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 29},
+						{Value: []byte{2}, Weight: 29},
+						{Value: []byte{3}, Weight: 29},
+					},
+				},
+				TotalAllowedVoters:          100,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            true,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 29},
+						{Value: []byte{2}, Weight: 29},
+						{Value: []byte{3}, Weight: 29},
+					},
+				},
+				TotalAllowedVoters:          100,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            true,
+			},
+		},
+		"Yes: everyone had voted": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 50},
+						{Value: []byte{2}, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+				AllowEarlyFinish:   true,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 50},
+						{Value: []byte{2}, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+				AllowEarlyFinish:   true,
+			},
+		},
+		"Yes: mostVotedWeight > remainingVotes + secondMostVotedWeight AND mostVotedWeight > mostVotedThreshold AND voted > p.TotalVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 20},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         80,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            true,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 20},
+						{Value: []byte{2}, Weight: 41},
+						{Value: []byte{3}, Weight: 20},
+					},
+				},
+				TotalAllowedVoters:          100,
+				TotalVotedThreshold:         80,
+				MostVotedThresholdNominator: 500000,
+				AllowEarlyFinish:            true,
+			},
+		},
+		"Yes: just one option AND voted > p.TotalVotedThreshold": {
+			proposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 21},
+					},
+				},
+				TotalAllowedVoters:  100,
+				TotalVotedThreshold: 20,
+				AllowEarlyFinish:    true,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &GeneralProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 21},
+					},
+				},
+				TotalAllowedVoters:  100,
+				TotalVotedThreshold: 20,
+				AllowEarlyFinish:    true,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.expectedCanBeFinished, tt.proposal.CanBeFinished())
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
+		})
+	}
+}

--- a/vms/platformvm/dac/camino_mock.go
+++ b/vms/platformvm/dac/camino_mock.go
@@ -93,3 +93,18 @@ func (mr *MockBondTxIDsGetterMockRecorder) FeeDistributionProposal(arg0 interfac
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FeeDistributionProposal", reflect.TypeOf((*MockBondTxIDsGetter)(nil).FeeDistributionProposal), arg0)
 }
+
+// GeneralProposal mocks base method.
+func (m *MockBondTxIDsGetter) GeneralProposal(arg0 *GeneralProposalState) ([]ids.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GeneralProposal", arg0)
+	ret0, _ := ret[0].([]ids.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GeneralProposal indicates an expected call of GeneralProposal.
+func (mr *MockBondTxIDsGetterMockRecorder) GeneralProposal(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GeneralProposal", reflect.TypeOf((*MockBondTxIDsGetter)(nil).GeneralProposal), arg0)
+}

--- a/vms/platformvm/dac/camino_proposal.go
+++ b/vms/platformvm/dac/camino_proposal.go
@@ -5,6 +5,7 @@ package dac
 
 import (
 	"errors"
+	"math/big"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -16,6 +17,8 @@ import (
 const FractionDenominator = 1_000_000
 
 var (
+	fractionDenominatorBig = big.NewInt(FractionDenominator)
+
 	errNoOptions                  = errors.New("no options")
 	errNotUniqueOption            = errors.New("not unique option")
 	errWrongOptionIndex           = errors.New("wrong option index")
@@ -32,6 +35,7 @@ type Verifier interface {
 	BaseFeeProposal(*BaseFeeProposal) error
 	AddMemberProposal(*AddMemberProposal) error
 	ExcludeMemberProposal(*ExcludeMemberProposal) error
+	GeneralProposal(*GeneralProposal) error
 	FeeDistributionProposal(*FeeDistributionProposal) error
 }
 
@@ -39,6 +43,7 @@ type Executor interface {
 	BaseFeeProposal(*BaseFeeProposalState) error
 	AddMemberProposal(*AddMemberProposalState) error
 	ExcludeMemberProposal(*ExcludeMemberProposalState) error
+	GeneralProposal(*GeneralProposalState) error
 	FeeDistributionProposal(*FeeDistributionProposalState) error
 }
 
@@ -46,6 +51,7 @@ type BondTxIDsGetter interface {
 	BaseFeeProposal(*BaseFeeProposalState) ([]ids.ID, error)
 	AddMemberProposal(*AddMemberProposalState) ([]ids.ID, error)
 	ExcludeMemberProposal(*ExcludeMemberProposalState) ([]ids.ID, error)
+	GeneralProposal(*GeneralProposalState) ([]ids.ID, error)
 	FeeDistributionProposal(*FeeDistributionProposalState) ([]ids.ID, error)
 }
 

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -132,6 +132,7 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&dac.AddMemberProposal{}),
 		targetCodec.RegisterCustomType(&dac.AdminProposal{}),
 		targetCodec.RegisterCustomType(&dac.ExcludeMemberProposal{}),
+		targetCodec.RegisterCustomType(&dac.GeneralProposal{}),
 		targetCodec.RegisterCustomType(&dac.FeeDistributionProposal{}),
 	)
 	return errs.Err

--- a/vms/secp256k1fx/camino_fx_test.go
+++ b/vms/secp256k1fx/camino_fx_test.go
@@ -42,7 +42,7 @@ func TestVerifyMultisigCredentials(t *testing.T) {
 		msig          func(c *gomock.Controller) AliasGetter
 		expectedError error
 	}{
-		"OK: 2 addrs, theshold 2": {
+		"OK: 2 addrs, threshold 2": {
 			in:      &Input{SigIndices: []uint32{0, 1}},
 			signers: []*secp256k1.PrivateKey{key1, key2},
 			owners: &OutputOwners{


### PR DESCRIPTION
## Why this should be merged
This PR adds new proposal type: generalProposal. This proposal can have up to 3 options, proposal duration is between 1 day and 1 month and proposal has configurable mostVotedThreshold ("qualified majority") and totalVotedThreshold ("quorum").
Proposal options consists of arbitrary bytes, length is limited to 256 bytes. Regardless of proposal outcome, it doesn't affect state in any way.
## How this works
Adds new proposal type and corresponding logic utilizing previously added dac-proposals feature.
## How this was tested
Unit-tests