### PR TITLE
[PVM, DAC] Fee distribution proposal

### DIFF
--- a/database/camino_helpers.go
+++ b/database/camino_helpers.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package database
+
+import (
+	"encoding/binary"
+)
+
+func PutUInt64Slice(db KeyValueWriter, key []byte, val []uint64) error {
+	b := PackUInt64Slice(val)
+	return db.Put(key, b)
+}
+
+func GetUInt64Slice(db KeyValueReader, key []byte) ([]uint64, error) {
+	b, err := db.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUInt64Slice(b)
+}
+
+func PackUInt64Slice(val []uint64) []byte {
+	bytes := make([]byte, Uint64Size*len(val))
+	for i := 0; i < len(val); i++ {
+		binary.BigEndian.PutUint64(bytes[Uint64Size*i:Uint64Size*(i+1)], val[i])
+	}
+	return bytes
+}
+
+func ParseUInt64Slice(b []byte) ([]uint64, error) {
+	n := len(b) / Uint64Size
+	if len(b) != n*Uint64Size {
+		return nil, errWrongSize
+	}
+	slice := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		slice[i] = binary.BigEndian.Uint64(b[Uint64Size*i : Uint64Size*(i+1)])
+	}
+	return slice, nil
+}

--- a/genesis/genesis_camino.go
+++ b/genesis/genesis_camino.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/platformvm/caminoconfig"
+	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
@@ -41,6 +42,7 @@ var (
 			},
 			CaminoConfig: caminoconfig.Config{
 				DACProposalBondAmount: 1 * units.KiloAvax,
+				FeeDistribution:       [dac.FeeDistributionFractionsCount]uint64{30, 30, 40}, // 30% validators, 30% grant program, 40% burned
 			},
 		},
 	}

--- a/genesis/genesis_columbus.go
+++ b/genesis/genesis_columbus.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/platformvm/caminoconfig"
+	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
@@ -41,6 +42,7 @@ var (
 			},
 			CaminoConfig: caminoconfig.Config{
 				DACProposalBondAmount: 100 * units.Avax,
+				FeeDistribution:       [dac.FeeDistributionFractionsCount]uint64{30, 30, 40}, // 30% validators, 30% grant program, 40% burned
 			},
 		},
 	}

--- a/genesis/genesis_kopernikus.go
+++ b/genesis/genesis_kopernikus.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/vms/platformvm/caminoconfig"
+	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
@@ -47,6 +48,7 @@ var (
 			},
 			CaminoConfig: caminoconfig.Config{
 				DACProposalBondAmount: 100 * units.Avax,
+				FeeDistribution:       [dac.FeeDistributionFractionsCount]uint64{30, 30, 40}, // 30% validators, 30% grant program, 40% burned
 			},
 		},
 	}

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.
@@ -23,6 +23,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/avalanchego/vms/platformvm/caminoconfig"
+	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 )
 
@@ -74,6 +75,7 @@ var (
 			},
 			CaminoConfig: caminoconfig.Config{
 				DACProposalBondAmount: 100 * units.Avax,
+				FeeDistribution:       [dac.FeeDistributionFractionsCount]uint64{30, 30, 40}, // 30% validators, 30% grant program, 40% burned
 			},
 		},
 	}

--- a/vms/platformvm/caminoconfig/camino_config.go
+++ b/vms/platformvm/caminoconfig/camino_config.go
@@ -3,6 +3,10 @@
 
 package caminoconfig
 
+import "github.com/ava-labs/avalanchego/vms/platformvm/dac"
+
 type Config struct {
 	DACProposalBondAmount uint64
+	// Fractions of transaction fee distribution
+	FeeDistribution [dac.FeeDistributionFractionsCount]uint64 `json:"feeDistribution"`
 }

--- a/vms/platformvm/dac/camino_base_fee_proposal_test.go
+++ b/vms/platformvm/dac/camino_base_fee_proposal_test.go
@@ -612,7 +612,7 @@ func TestBaseFeeProposalStateCanBeFinished(t *testing.T) {
 		expectedCanBeFinished    bool
 		expectedOriginalProposal *BaseFeeProposalState
 	}{
-		"Can not be finished: most voted weight is less than 50% of total allowed voters and not everyone had voted": {
+		"Can not be finished: most voted weight is less than 50% of total allowed voters, not everyone had voted and some options could still reach 50%+ of votes": {
 			proposal: &BaseFeeProposalState{
 				SimpleVoteOptions: SimpleVoteOptions[uint64]{
 					Options: []SimpleVoteOption[uint64]{

--- a/vms/platformvm/dac/camino_codec.go
+++ b/vms/platformvm/dac/camino_codec.go
@@ -27,6 +27,7 @@ func init() {
 			c.RegisterCustomType(&BaseFeeProposalState{}),
 			c.RegisterCustomType(&AddMemberProposalState{}),
 			c.RegisterCustomType(&ExcludeMemberProposalState{}),
+			c.RegisterCustomType(&FeeDistributionProposalState{}),
 		)
 	}
 	errs.Add(

--- a/vms/platformvm/dac/camino_fee_distribution_proposal_test.go
+++ b/vms/platformvm/dac/camino_fee_distribution_proposal_test.go
@@ -1,0 +1,719 @@
+// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package dac
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeeDistributionProposalVerify(t *testing.T) {
+	tests := map[string]struct {
+		proposal         *FeeDistributionProposal
+		expectedProposal *FeeDistributionProposal
+		expectedErr      error
+	}{
+		"No options": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{},
+			},
+			expectedErr: errNoOptions,
+		},
+		"To many options": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {300000, 300000, 400000}, {400000, 400000, 200000}},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {300000, 300000, 400000}, {400000, 400000, 200000}},
+			},
+			expectedErr: errWrongOptionsCount,
+		},
+		"End-time is equal to start-time": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     100,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {300000, 300000, 400000}},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     100,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {300000, 300000, 400000}},
+			},
+			expectedErr: errEndNotAfterStart,
+		},
+		"End-time is less than start-time": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     99,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {300000, 300000, 400000}},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     99,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {300000, 300000, 400000}},
+			},
+			expectedErr: errEndNotAfterStart,
+		},
+		"Fee distribution sum is less, than 100%": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{400000}, {200000}, {390000}},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{400000}, {200000}, {390000}},
+			},
+			expectedErr: errWrongFeeDistribution,
+		},
+		"Fee distribution sum is greater, than 100%": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{400000}, {220000}, {390000}},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{400000}, {220000}, {390000}},
+			},
+			expectedErr: errWrongFeeDistribution,
+		},
+		"Not unique fee option": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {100000, 100000, 800000}},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {100000, 100000, 800000}},
+			},
+			expectedErr: errNotUniqueOption,
+		},
+		"OK: 1 option": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}},
+			},
+		},
+		"OK: 3 options": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {300000, 300000, 400000}},
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{100000, 100000, 800000}, {200000, 200000, 600000}, {300000, 300000, 400000}},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, tt.proposal.Verify(), tt.expectedErr)
+			require.Equal(t, tt.expectedProposal, tt.proposal)
+		})
+	}
+}
+
+func TestFeeDistributionProposalCreateProposalState(t *testing.T) {
+	tests := map[string]struct {
+		proposal              *FeeDistributionProposal
+		allowedVoters         []ids.ShortID
+		expectedProposalState ProposalState
+		expectedProposal      *FeeDistributionProposal
+	}{
+		"OK: even number of allowed voters": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}, {0, 100, 0}},
+			},
+			allowedVoters: []ids.ShortID{{1}, {2}, {3}, {4}},
+			expectedProposalState: &FeeDistributionProposalState{
+				Start:         100,
+				End:           101,
+				AllowedVoters: []ids.ShortID{{1}, {2}, {3}, {4}},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{40, 30, 30}},
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}},
+						{Value: [FeeDistributionFractionsCount]uint64{0, 100, 0}},
+					},
+				},
+				TotalAllowedVoters: 4,
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}, {0, 100, 0}},
+			},
+		},
+		"OK: odd number of allowed voters": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}, {0, 100, 0}},
+			},
+			allowedVoters: []ids.ShortID{{1}, {2}, {3}, {4}, {5}},
+			expectedProposalState: &FeeDistributionProposalState{
+				Start:         100,
+				End:           101,
+				AllowedVoters: []ids.ShortID{{1}, {2}, {3}, {4}, {5}},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{40, 30, 30}},
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}},
+						{Value: [FeeDistributionFractionsCount]uint64{0, 100, 0}},
+					},
+				},
+				TotalAllowedVoters: 5,
+			},
+			expectedProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}, {0, 100, 0}},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			proposalState := tt.proposal.CreateProposalState(tt.allowedVoters)
+			require.Equal(t, tt.expectedProposal, tt.proposal)
+			require.Equal(t, tt.expectedProposalState, proposalState)
+		})
+	}
+}
+
+func TestFeeDistributionProposalStateAddVote(t *testing.T) {
+	voterAddr1 := ids.ShortID{1}
+	voterAddr2 := ids.ShortID{2}
+	voterAddr3 := ids.ShortID{3}
+
+	tests := map[string]struct {
+		proposal                 *FeeDistributionProposalState
+		voterAddr                ids.ShortID
+		vote                     Vote
+		expectedUpdatedProposal  ProposalState
+		expectedOriginalProposal *FeeDistributionProposalState
+		expectedErr              error
+	}{
+		"Wrong vote type": {
+			proposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			voterAddr: voterAddr1,
+			vote:      &DummyVote{}, // not *SimpleVote
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			expectedErr: ErrWrongVote,
+		},
+		"Wrong vote option index": {
+			proposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			voterAddr: ids.ShortID{3},
+			vote:      &SimpleVote{OptionIndex: 3},
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			expectedErr: ErrWrongVote,
+		},
+		"Not allowed to vote on this proposal": {
+			proposal: &FeeDistributionProposalState{
+				AllowedVoters: []ids.ShortID{{1}, {2}},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{{Value: [FeeDistributionFractionsCount]uint64{100, 0, 0}}},
+				},
+			},
+			voterAddr: ids.ShortID{3},
+			vote:      &SimpleVote{OptionIndex: 0},
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				AllowedVoters: []ids.ShortID{{1}, {2}},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{{Value: [FeeDistributionFractionsCount]uint64{100, 0, 0}}},
+				},
+			},
+			expectedErr: ErrNotAllowedToVoteOnProposal,
+		},
+		"OK: adding vote to not voted option": {
+			proposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			voterAddr: voterAddr1,
+			vote:      &SimpleVote{OptionIndex: 1},
+			expectedUpdatedProposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 1}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+				},
+			},
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+		},
+		"OK: adding vote to already voted option": {
+			proposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+			voterAddr: voterAddr1,
+			vote:      &SimpleVote{OptionIndex: 2},
+			expectedUpdatedProposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 2}, // 2
+					},
+				},
+			},
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{10, 10, 80}, Weight: 2}, // 0
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 0}, // 1
+						{Value: [FeeDistributionFractionsCount]uint64{30, 30, 40}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+			},
+		},
+		"OK: voter addr in the middle of allowedVoters array": {
+			proposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1, voterAddr2, voterAddr3},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{{Value: [FeeDistributionFractionsCount]uint64{100, 0, 0}}},
+				},
+			},
+			voterAddr: voterAddr2,
+			vote:      &SimpleVote{OptionIndex: 0},
+			expectedUpdatedProposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1, voterAddr3},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{{Value: [FeeDistributionFractionsCount]uint64{100, 0, 0}, Weight: 1}},
+				},
+			},
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1, voterAddr2, voterAddr3},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{{Value: [FeeDistributionFractionsCount]uint64{100, 0, 0}}},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote)
+			require.ErrorIs(t, err, tt.expectedErr)
+			require.Equal(t, tt.expectedUpdatedProposal, updatedProposal)
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
+		})
+	}
+}
+
+func TestFeeDistributionProposalCreateFinishedProposalState(t *testing.T) {
+	tests := map[string]struct {
+		proposal                 *FeeDistributionProposal
+		optionIndex              uint32
+		expectedProposalState    ProposalState
+		expectedOriginalProposal *FeeDistributionProposal
+		expectedErr              error
+	}{
+		"Fail: option 2 out of bounds": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}},
+			},
+			optionIndex: 2,
+			expectedOriginalProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}},
+			},
+			expectedErr: errWrongOptionIndex,
+		},
+		"OK: option 0": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}, {0, 100, 0}},
+			},
+			optionIndex: 0,
+			expectedProposalState: &FeeDistributionProposalState{
+				Start:         100,
+				End:           101,
+				AllowedVoters: []ids.ShortID{},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{40, 30, 30}, Weight: 1},
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}},
+						{Value: [FeeDistributionFractionsCount]uint64{0, 100, 0}},
+					},
+				},
+			},
+			expectedOriginalProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}, {0, 100, 0}},
+			},
+		},
+		"OK: option 1": {
+			proposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}, {0, 100, 0}},
+			},
+			optionIndex: 1,
+			expectedProposalState: &FeeDistributionProposalState{
+				Start:         100,
+				End:           101,
+				AllowedVoters: []ids.ShortID{},
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{40, 30, 30}},
+						{Value: [FeeDistributionFractionsCount]uint64{20, 20, 60}, Weight: 1},
+						{Value: [FeeDistributionFractionsCount]uint64{0, 100, 0}},
+					},
+				},
+			},
+			expectedOriginalProposal: &FeeDistributionProposal{
+				Start:   100,
+				End:     101,
+				Options: [][FeeDistributionFractionsCount]uint64{{40, 30, 30}, {20, 20, 60}, {0, 100, 0}},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			proposalState, err := tt.proposal.CreateFinishedProposalState(tt.optionIndex)
+			require.ErrorIs(t, err, tt.expectedErr)
+			require.Equal(t, tt.expectedProposalState, proposalState)
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
+			if tt.expectedErr == nil {
+				require.True(t, proposalState.CanBeFinished())
+				require.True(t, proposalState.IsSuccessful())
+			}
+		})
+	}
+}
+
+func TestFeeDistributionProposalStateIsSuccessful(t *testing.T) {
+	tests := map[string]struct {
+		proposal                 *FeeDistributionProposalState
+		expectedSuccessful       bool
+		expectedOriginalProposal *FeeDistributionProposalState
+	}{
+		"Not successful: most voted weight is less, than 50% of votes": {
+			proposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 20},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 21},
+						{Value: [FeeDistributionFractionsCount]uint64{3}, Weight: 10},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedSuccessful: false,
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 20},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 21},
+						{Value: [FeeDistributionFractionsCount]uint64{3}, Weight: 10},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+		"Not successful: total voted weight is less, than 50% of total allowed voters": {
+			proposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 25},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 26},
+					},
+				},
+				TotalAllowedVoters: 102,
+			},
+			expectedSuccessful: false,
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 25},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 26},
+					},
+				},
+				TotalAllowedVoters: 102,
+			},
+		},
+		"Successful": {
+			proposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 25},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 26},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedSuccessful: true,
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 25},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 26},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.expectedSuccessful, tt.proposal.IsSuccessful())
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
+		})
+	}
+}
+
+func TestFeeDistributionProposalStateCanBeFinished(t *testing.T) {
+	tests := map[string]struct {
+		proposal                 *FeeDistributionProposalState
+		expectedCanBeFinished    bool
+		expectedOriginalProposal *FeeDistributionProposalState
+	}{
+		"Can not be finished: most voted weight is less than 50% of total allowed voters, not everyone had voted and some options could still reach 50%+ of votes": {
+			proposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedCanBeFinished: false,
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+		"Can be finished: everyone had voted": {
+			proposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 50},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 50},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 50},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+		"Can be finished: most voted weight is greater than 50% of total allowed voters": {
+			proposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 51},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 51},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+		"Can be finished: no option can reach 50%+ of votes": {
+			proposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 30},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 30},
+						{Value: [FeeDistributionFractionsCount]uint64{3}, Weight: 30},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+			expectedCanBeFinished: true,
+			expectedOriginalProposal: &FeeDistributionProposalState{
+				SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
+					Options: []SimpleVoteOption[[FeeDistributionFractionsCount]uint64]{
+						{Value: [FeeDistributionFractionsCount]uint64{1}, Weight: 30},
+						{Value: [FeeDistributionFractionsCount]uint64{2}, Weight: 30},
+						{Value: [FeeDistributionFractionsCount]uint64{3}, Weight: 30},
+					},
+				},
+				TotalAllowedVoters: 100,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.expectedCanBeFinished, tt.proposal.CanBeFinished())
+			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)
+		})
+	}
+}

--- a/vms/platformvm/dac/camino_mock.go
+++ b/vms/platformvm/dac/camino_mock.go
@@ -78,3 +78,18 @@ func (mr *MockBondTxIDsGetterMockRecorder) ExcludeMemberProposal(arg0 interface{
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExcludeMemberProposal", reflect.TypeOf((*MockBondTxIDsGetter)(nil).ExcludeMemberProposal), arg0)
 }
+
+// FeeDistributionProposal mocks base method.
+func (m *MockBondTxIDsGetter) FeeDistributionProposal(arg0 *FeeDistributionProposalState) ([]ids.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FeeDistributionProposal", arg0)
+	ret0, _ := ret[0].([]ids.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FeeDistributionProposal indicates an expected call of FeeDistributionProposal.
+func (mr *MockBondTxIDsGetterMockRecorder) FeeDistributionProposal(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FeeDistributionProposal", reflect.TypeOf((*MockBondTxIDsGetter)(nil).FeeDistributionProposal), arg0)
+}

--- a/vms/platformvm/dac/camino_proposal.go
+++ b/vms/platformvm/dac/camino_proposal.go
@@ -12,10 +12,14 @@ import (
 	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
 )
 
+// FractionDenominator is the denominator used to calculate percentages
+const FractionDenominator = 1_000_000
+
 var (
 	errNoOptions                  = errors.New("no options")
 	errNotUniqueOption            = errors.New("not unique option")
 	errWrongOptionIndex           = errors.New("wrong option index")
+	errWrongOptionsCount          = errors.New("wrong options count")
 	errEndNotAfterStart           = errors.New("proposal end-time is not after start-time")
 	errWrongDuration              = errors.New("wrong proposal duration")
 	ErrWrongVote                  = errors.New("this proposal can't be voted with this vote")
@@ -28,18 +32,21 @@ type Verifier interface {
 	BaseFeeProposal(*BaseFeeProposal) error
 	AddMemberProposal(*AddMemberProposal) error
 	ExcludeMemberProposal(*ExcludeMemberProposal) error
+	FeeDistributionProposal(*FeeDistributionProposal) error
 }
 
 type Executor interface {
 	BaseFeeProposal(*BaseFeeProposalState) error
 	AddMemberProposal(*AddMemberProposalState) error
 	ExcludeMemberProposal(*ExcludeMemberProposalState) error
+	FeeDistributionProposal(*FeeDistributionProposalState) error
 }
 
 type BondTxIDsGetter interface {
 	BaseFeeProposal(*BaseFeeProposalState) ([]ids.ID, error)
 	AddMemberProposal(*AddMemberProposalState) ([]ids.ID, error)
 	ExcludeMemberProposal(*ExcludeMemberProposalState) ([]ids.ID, error)
+	FeeDistributionProposal(*FeeDistributionProposalState) ([]ids.ID, error)
 }
 
 type Proposal interface {

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -634,6 +634,23 @@ func (d *diff) SetBaseFee(baseFee uint64) {
 	d.caminoDiff.modifiedBaseFee = &baseFee
 }
 
+func (d *diff) GetFeeDistribution() ([dac.FeeDistributionFractionsCount]uint64, error) {
+	if d.caminoDiff.modifiedFeeDistribution != nil {
+		return *d.caminoDiff.modifiedFeeDistribution, nil
+	}
+
+	parentState, ok := d.stateVersions.GetState(d.parentID)
+	if !ok {
+		return [dac.FeeDistributionFractionsCount]uint64{}, fmt.Errorf("%w: %s", ErrMissingParentState, d.parentID)
+	}
+
+	return parentState.GetFeeDistribution()
+}
+
+func (d *diff) SetFeeDistribution(feeDistribution [dac.FeeDistributionFractionsCount]uint64) {
+	d.caminoDiff.modifiedFeeDistribution = &feeDistribution
+}
+
 // Finally apply all changes
 func (d *diff) ApplyCaminoState(baseState State) {
 	if d.caminoDiff.modifiedNotDistributedValidatorReward != nil {
@@ -641,6 +658,9 @@ func (d *diff) ApplyCaminoState(baseState State) {
 	}
 	if d.caminoDiff.modifiedBaseFee != nil {
 		baseState.SetBaseFee(*d.caminoDiff.modifiedBaseFee)
+	}
+	if d.caminoDiff.modifiedFeeDistribution != nil {
+		baseState.SetFeeDistribution(*d.caminoDiff.modifiedFeeDistribution)
 	}
 
 	for k, v := range d.caminoDiff.modifiedAddressStates {

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -189,3 +189,11 @@ func (s *state) GetBaseFee() (uint64, error) {
 func (s *state) SetBaseFee(baseFee uint64) {
 	s.caminoState.SetBaseFee(baseFee)
 }
+
+func (s *state) GetFeeDistribution() ([dac.FeeDistributionFractionsCount]uint64, error) {
+	return s.caminoState.GetFeeDistribution()
+}
+
+func (s *state) SetFeeDistribution(feeDistribution [dac.FeeDistributionFractionsCount]uint64) {
+	s.caminoState.SetFeeDistribution(feeDistribution)
+}

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -312,6 +312,21 @@ func (mr *MockChainMockRecorder) GetBaseFee() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBaseFee", reflect.TypeOf((*MockChain)(nil).GetBaseFee))
 }
 
+// GetFeeDistribution mocks base method.
+func (m *MockChain) GetFeeDistribution() ([dac.FeeDistributionFractionsCount]uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFeeDistribution")
+	ret0, _ := ret[0].([dac.FeeDistributionFractionsCount]uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFeeDistribution indicates an expected call of GetFeeDistribution.
+func (mr *MockChainMockRecorder) GetFeeDistribution() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeeDistribution", reflect.TypeOf((*MockChain)(nil).GetFeeDistribution))
+}
+
 // GetCurrentDelegatorIterator mocks base method.
 func (m *MockChain) GetCurrentDelegatorIterator(arg0 ids.ID, arg1 ids.NodeID) (StakerIterator, error) {
 	m.ctrl.T.Helper()
@@ -885,6 +900,18 @@ func (m *MockChain) SetBaseFee(arg0 uint64) {
 func (mr *MockChainMockRecorder) SetBaseFee(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBaseFee", reflect.TypeOf((*MockChain)(nil).SetBaseFee), arg0)
+}
+
+// SetFeeDistribution mocks base method.
+func (m *MockChain) SetFeeDistribution(arg0 [dac.FeeDistributionFractionsCount]uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetFeeDistribution", arg0)
+}
+
+// SetFeeDistribution indicates an expected call of SetFeeDistribution.
+func (mr *MockChainMockRecorder) SetFeeDistribution(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFeeDistribution", reflect.TypeOf((*MockChain)(nil).SetFeeDistribution), arg0)
 }
 
 // SetCurrentSupply mocks base method.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -336,6 +336,21 @@ func (mr *MockDiffMockRecorder) GetBaseFee() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBaseFee", reflect.TypeOf((*MockDiff)(nil).GetBaseFee))
 }
 
+// GetFeeDistribution mocks base method.
+func (m *MockDiff) GetFeeDistribution() ([dac.FeeDistributionFractionsCount]uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFeeDistribution")
+	ret0, _ := ret[0].([dac.FeeDistributionFractionsCount]uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFeeDistribution indicates an expected call of GetFeeDistribution.
+func (mr *MockDiffMockRecorder) GetFeeDistribution() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeeDistribution", reflect.TypeOf((*MockDiff)(nil).GetFeeDistribution))
+}
+
 // GetCurrentDelegatorIterator mocks base method.
 func (m *MockDiff) GetCurrentDelegatorIterator(arg0 ids.ID, arg1 ids.NodeID) (StakerIterator, error) {
 	m.ctrl.T.Helper()
@@ -909,6 +924,18 @@ func (m *MockDiff) SetBaseFee(arg0 uint64) {
 func (mr *MockDiffMockRecorder) SetBaseFee(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBaseFee", reflect.TypeOf((*MockDiff)(nil).SetBaseFee), arg0)
+}
+
+// SetFeeDistribution mocks base method.
+func (m *MockDiff) SetFeeDistribution(arg0 [dac.FeeDistributionFractionsCount]uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetFeeDistribution", arg0)
+}
+
+// SetFeeDistribution indicates an expected call of SetFeeDistribution.
+func (mr *MockDiffMockRecorder) SetFeeDistribution(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFeeDistribution", reflect.TypeOf((*MockDiff)(nil).SetFeeDistribution), arg0)
 }
 
 // SetCurrentSupply mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -384,6 +384,21 @@ func (mr *MockStateMockRecorder) GetBaseFee() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBaseFee", reflect.TypeOf((*MockState)(nil).GetBaseFee))
 }
 
+// GetFeeDistribution mocks base method.
+func (m *MockState) GetFeeDistribution() ([dac.FeeDistributionFractionsCount]uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFeeDistribution")
+	ret0, _ := ret[0].([dac.FeeDistributionFractionsCount]uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFeeDistribution indicates an expected call of GetFeeDistribution.
+func (mr *MockStateMockRecorder) GetFeeDistribution() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeeDistribution", reflect.TypeOf((*MockState)(nil).GetFeeDistribution))
+}
+
 // GetCurrentDelegatorIterator mocks base method.
 func (m *MockState) GetCurrentDelegatorIterator(arg0 ids.ID, arg1 ids.NodeID) (StakerIterator, error) {
 	m.ctrl.T.Helper()
@@ -1050,6 +1065,18 @@ func (m *MockState) SetBaseFee(arg0 uint64) {
 func (mr *MockStateMockRecorder) SetBaseFee(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBaseFee", reflect.TypeOf((*MockState)(nil).SetBaseFee), arg0)
+}
+
+// SetFeeDistribution mocks base method.
+func (m *MockState) SetFeeDistribution(arg0 [dac.FeeDistributionFractionsCount]uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetFeeDistribution", arg0)
+}
+
+// SetFeeDistribution indicates an expected call of SetFeeDistribution.
+func (mr *MockStateMockRecorder) SetFeeDistribution(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFeeDistribution", reflect.TypeOf((*MockState)(nil).SetFeeDistribution), arg0)
 }
 
 // SetCurrentSupply mocks base method.

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -132,6 +132,7 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&dac.AddMemberProposal{}),
 		targetCodec.RegisterCustomType(&dac.AdminProposal{}),
 		targetCodec.RegisterCustomType(&dac.ExcludeMemberProposal{}),
+		targetCodec.RegisterCustomType(&dac.FeeDistributionProposal{}),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/executor/dac/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/dac/camino_helpers_test.go
@@ -48,7 +48,7 @@ type mutableSharedMemory struct {
 	atomic.SharedMemory
 }
 
-func defaultCtx(db database.Database) *snow.Context {
+func defaultCtx(db database.Database) *snow.Context { //nolint:unparam
 	ctx := snow.DefaultContextTest()
 	ctx.NetworkID = 10
 	ctx.XChainID = xChainID
@@ -160,7 +160,7 @@ func generateTestUTXOWithIndex(txID ids.ID, outIndex uint32, assetID ids.ID, amo
 	return testUTXO
 }
 
-func generateTestOut(assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.TransferableOutput {
+func generateTestOut(assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.TransferableOutput { //nolint:unparam
 	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
 		Amt:          amount,
 		OutputOwners: outputOwners,


### PR DESCRIPTION
## Why this should be merged
This PR adds new proposal type: feeDistributionProposal. This proposal contains options of fee distribution. If proposal is successful, then most voted option fee distribution is stored in state.
## How this works
### Proposal
Adds new proposal type and corresponding logic utilizing previously added dac-proposals feature.
Fee distribution proposal can have up to 3 options.
### Fee distribution
Fee distribution is array of 3 uint64. Each uint64 is nominator from distribution fraction, where denominator is `1 000 000`.
Example distribution:
`[300 000, 300 000, 400 000]` => `[30%, 30%, 40%]`
Sum of each distribution values must always be equal to 100%.
## How this was tested
Unit-tests