### PR TITLE
[PVM] Small deposit offer bugfixes

### DIFF
--- a/vms/platformvm/deposit/camino_deposit_offer.go
+++ b/vms/platformvm/deposit/camino_deposit_offer.go
@@ -18,14 +18,14 @@ import (
 
 const (
 	interestRateBase               = 365 * 24 * 60 * 60
-	interestRateDenominator        = 1_000_000 * interestRateBase
+	InterestRateDenominator uint64 = 1_000_000 * interestRateBase
 	OfferMinDepositAmount   uint64 = 1 * units.MilliAvax
 )
 
 var (
-	bigInterestRateDenominator = (&big.Int{}).SetInt64(interestRateDenominator)
+	bigInterestRateDenominator = (&big.Int{}).SetInt64(int64(InterestRateDenominator))
 
-	errWrongLimitValues           = errors.New("can only use either TotalMaxAmount or TotalMaxRewardAmount")
+	errWrongLimitValues           = errors.New("can only use either TotalMaxAmount or TotalMaxRewardAmount, can't use neither of them")
 	errDepositedMoreThanMaxAmount = errors.New("offer deposited amount is more than offer total max amount")
 	errRewardedMoreThanMaxAmount  = errors.New("offer deposits total reward amount is more than offer total max reward amount")
 	errMinAmountTooSmall          = errors.New("offer minAmount is too small")
@@ -111,7 +111,7 @@ func (o *Offer) IsActiveAt(timestamp uint64) bool {
 }
 
 func (o *Offer) InterestRateFloat64() float64 {
-	return float64(o.InterestRateNominator) / float64(interestRateDenominator)
+	return float64(o.InterestRateNominator) / float64(InterestRateDenominator)
 }
 
 func (o *Offer) Verify() error {

--- a/vms/platformvm/deposit/camino_deposit_test.go
+++ b/vms/platformvm/deposit/camino_deposit_test.go
@@ -34,7 +34,7 @@ func TestTotalReward(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			rewardsPeriodDuration := tt.DepositDuration - uint64(tt.NoRewardsPeriodDuration)
-			expectedRewardAmount := (tt.Amount * tt.InterestRateNominator * rewardsPeriodDuration) / uint64(interestRateDenominator)
+			expectedRewardAmount := tt.Amount * tt.InterestRateNominator * rewardsPeriodDuration / InterestRateDenominator
 
 			dep := Deposit{
 				Amount:   tt.Amount,

--- a/vms/platformvm/txs/camino_add_deposit_offer_tx.go
+++ b/vms/platformvm/txs/camino_add_deposit_offer_tx.go
@@ -21,6 +21,8 @@ var (
 	errBadDepositOfferCreatorAuth      = errors.New("bad deposit offer creator auth")
 	errEmptyDepositOfferCreatorAddress = errors.New("deposit offer creator address is empty")
 	errWrongDepositOfferVersion        = errors.New("wrong deposit offer version")
+	errNotZeroDepositOfferAmounts      = errors.New("deposit offer rewardedAmount or depositedAmount isn't zero")
+	errZeroDepositOfferLimits          = errors.New("deposit offer TotalMaxAmount and TotalMaxRewardAmount are zero")
 )
 
 // AddDepositOfferTx is an unsigned depositTx
@@ -46,6 +48,10 @@ func (tx *AddDepositOfferTx) SyntacticVerify(ctx *snow.Context) error {
 		return errEmptyDepositOfferCreatorAddress
 	case tx.DepositOffer.UpgradeVersionID.Version() == 0:
 		return errWrongDepositOfferVersion
+	case tx.DepositOffer.RewardedAmount > 0 || tx.DepositOffer.DepositedAmount > 0:
+		return errNotZeroDepositOfferAmounts
+	case tx.DepositOffer.TotalMaxAmount == 0 && tx.DepositOffer.TotalMaxRewardAmount == 0:
+		return errZeroDepositOfferLimits
 	}
 
 	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {

--- a/vms/platformvm/txs/camino_add_deposit_offer_tx_test.go
+++ b/vms/platformvm/txs/camino_add_deposit_offer_tx_test.go
@@ -27,6 +27,7 @@ func TestAddDepositOfferTxSyntacticVerify(t *testing.T) {
 		MinDuration:      1,
 		MaxDuration:      1,
 		MinAmount:        deposit.OfferMinDepositAmount,
+		TotalMaxAmount:   1,
 	}
 
 	baseTx := BaseTx{BaseTx: avax.BaseTx{
@@ -47,11 +48,43 @@ func TestAddDepositOfferTxSyntacticVerify(t *testing.T) {
 			},
 			expectedErr: errEmptyDepositOfferCreatorAddress,
 		},
+		"Non-zero RewardedAmount": {
+			tx: &AddDepositOfferTx{
+				BaseTx:                     baseTx,
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer: &deposit.Offer{
+					UpgradeVersionID: codec.UpgradeVersion1,
+					RewardedAmount:   1,
+				},
+			},
+			expectedErr: errNotZeroDepositOfferAmounts,
+		},
+		"Non-zero DepositedAmount": {
+			tx: &AddDepositOfferTx{
+				BaseTx:                     baseTx,
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer: &deposit.Offer{
+					UpgradeVersionID: codec.UpgradeVersion1,
+					DepositedAmount:  1,
+				},
+			},
+			expectedErr: errNotZeroDepositOfferAmounts,
+		},
+		"Zero TotalMaxAmount and TotalMaxRewardAmount": {
+			tx: &AddDepositOfferTx{
+				BaseTx:                     baseTx,
+				DepositOfferCreatorAddress: creatorAddress,
+				DepositOffer: &deposit.Offer{
+					UpgradeVersionID: codec.UpgradeVersion1,
+				},
+			},
+			expectedErr: errZeroDepositOfferLimits,
+		},
 		"Bad deposit offer": {
 			tx: &AddDepositOfferTx{
 				BaseTx:                     baseTx,
 				DepositOfferCreatorAddress: creatorAddress,
-				DepositOffer:               &deposit.Offer{UpgradeVersionID: codec.UpgradeVersion1},
+				DepositOffer:               &deposit.Offer{UpgradeVersionID: codec.UpgradeVersion1, TotalMaxAmount: 1},
 			},
 			expectedErr: errBadDepositOffer,
 		},

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1673,7 +1673,7 @@ func (e *CaminoStandardTxExecutor) AddDepositOfferTx(tx *txs.AddDepositOfferTx) 
 	chainTimestamp := uint64(chainTime.Unix())
 
 	for _, offer := range allOffers {
-		if offer.IsActiveAt(chainTimestamp) {
+		if chainTimestamp <= offer.End && offer.Flags&deposits.OfferFlagLocked == 0 {
 			if offer.TotalMaxAmount != 0 {
 				availableSupply -= offer.MaxRemainingRewardByTotalMaxAmount()
 			} else if offer.TotalMaxRewardAmount != 0 {

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -5717,40 +5717,56 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 						End:                  uint64(chainTime.Add(-1 * time.Second).Unix()),
 						TotalMaxRewardAmount: 101,
 					},
-					{ // [1], not started
+					{ // [1], not started yet with TotalMaxAmount
+						UpgradeVersionID:      1,
+						Start:                 uint64(chainTime.Add(1 * time.Second).Unix()),
+						End:                   uint64(chainTime.Add(2 * time.Second).Unix()),
+						MaxDuration:           100,
+						TotalMaxAmount:        102,
+						InterestRateNominator: deposit.InterestRateDenominator / 2,
+					},
+					{ // [2], not started yet with TotalMaxRewardAmount
 						UpgradeVersionID:     1,
 						Start:                uint64(chainTime.Add(1 * time.Second).Unix()),
 						End:                  uint64(chainTime.Add(2 * time.Second).Unix()),
-						TotalMaxRewardAmount: 102,
+						TotalMaxRewardAmount: 103,
 					},
-					{ // [2], disabled
+					{ // [3], disabled
 						UpgradeVersionID:     1,
 						Start:                uint64(chainTime.Unix()),
 						End:                  uint64(chainTime.Add(1 * time.Second).Unix()),
 						Flags:                deposit.OfferFlagLocked,
-						TotalMaxRewardAmount: 103,
+						TotalMaxRewardAmount: 104,
 					},
-					{ // [3]
+					{ // [4] active // shouldn't be possible, cause offers must always have one of the limits
 						Start: uint64(chainTime.Unix()),
 						End:   uint64(chainTime.Add(1 * time.Second).Unix()),
 					},
-					{ // [4] with TotalMaxAmount
+					{ // [5] active, no interest rate
+						UpgradeVersionID: 1,
+						Start:            uint64(chainTime.Unix()),
+						End:              uint64(chainTime.Add(1 * time.Second).Unix()),
+						MaxDuration:      100,
+						TotalMaxAmount:   102,
+					},
+					{ // [6] active with TotalMaxAmount
 						MaxDuration:           100,
 						InterestRateNominator: 100,
 						Start:                 uint64(chainTime.Unix()),
 						End:                   uint64(chainTime.Add(1 * time.Second).Unix()),
-						TotalMaxAmount:        104,
+						TotalMaxAmount:        105,
 						DepositedAmount:       50,
 					},
-					{ // [5] with TotalMaxRewardAmount
+					{ // [7] active with TotalMaxRewardAmount
 						UpgradeVersionID:     1,
 						Start:                uint64(chainTime.Add(-1 * time.Second).Unix()),
 						End:                  uint64(chainTime.Add(1 * time.Second).Unix()),
-						TotalMaxRewardAmount: 105,
+						TotalMaxRewardAmount: 106,
 						RewardedAmount:       50,
 					},
 				}
-				promisedSupply := existingOffers[4].MaxRemainingRewardByTotalMaxAmount() + existingOffers[5].RemainingReward()
+				promisedSupply := existingOffers[1].MaxRemainingRewardByTotalMaxAmount() + existingOffers[2].RemainingReward() +
+					existingOffers[6].MaxRemainingRewardByTotalMaxAmount() + existingOffers[7].RemainingReward()
 				currentSupply := cfg.RewardConfig.SupplyCap - promisedSupply - offer1.TotalMaxRewardAmount + 1
 
 				s := state.NewMockDiff(c)


### PR DESCRIPTION
## Why this should be merged
### AddDepositOfferTx syntactic
Prohibit adding new offers with
- Both totalMaxReward and totalMaxAmt are 0
- DepositedAmt > 0 or rewardedAmt > 0
### AddDepositOfferTx execution
When creating deposit offer, node checks that new offer reward will not exceed sum of total supply and active offer potential rewards. But this is wrong, cause it should also take into account offers that will become active in a future. PR fixes that.
### Service API
Overrides avax GetCurrentSupply with new one in camino-service, so it will also take into account existing offers potential reward (rewards for deposits that can be created with this offer).
Current supply already includes rewards for existing deposits.

Update GetDeposits logic to return amount that can be unlocked at the time.Now() on node side (timestamp is already returned in response).
## How this works
Just adds corresponding checks to AddDepositOfferTx syntactic verify and execution, updates GetDeposits and adds overriden GetCurrentSupply.
## How this was tested
Unit-tests