### PR TITLE
update golangci-lint github action

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,11 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
+          cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51
       - name: Run static analysis tests


### PR DESCRIPTION
## Why this should be merged
to fix static analysis workflow issue
golangci-lint github action has a new version release v3 https://github.com/golangci/golangci-lint-action
it solves the issue of failed lint on github runners

## How this works
updating github actions version which are used in the workflow

## How this was tested
by running the workflow