### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ WORKDIR /build
 # Copy and download caminogo dependencies using go mod
 COPY go.mod .
 COPY go.sum .
-COPY dependencies dependencies/
 RUN go mod download
 
 # Copy the code into the container

--- a/scripts/build_camino.sh
+++ b/scripts/build_camino.sh
@@ -55,7 +55,7 @@ mkdir -p $plugin_dir
 
 # Exit build successfully if the binaries are created
 if [[ -f "$caminogo_path" ]]; then
-    ln -s caminogo $camino_node_symlink_path
+    ln -sf caminogo $camino_node_symlink_path
     echo "Build Successful"
     exit 0
 else


### PR DESCRIPTION
## Why this should be merged
caminogo has no dependencies folder anymore

## How this works
by removing the line which copies dependencies folder in dockerfile

## How this was tested
built docker image locally
