### PR TITLE
[WORKFLOWS] Reduce diff with avax and revert e2e changes from 0792e0af

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: "1.19" # The Go version to download (if necessary) and use.
       - name: build_test
         shell: bash
-        run: scripts/build_and_test.sh --race
+        run: scripts/build_and_test.sh
       - name: fuzz_test
         shell: bash
         if: matrix.os == 'ubuntu-22.04' # Only run on Ubuntu 22.04

--- a/.github/workflows/test.e2e.yml
+++ b/.github/workflows/test.e2e.yml
@@ -1,10 +1,12 @@
 name: Test e2e
 
 on:
-  workflow_run:
-    workflows: ["CNR - Build + test + release"]
-    types:
-      - completed
+  pull_request:
+    tags-ignore: ["*"]
+    branches: [chain4travel, dev]
+  push:
+    branches: [chain4travel, dev]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,7 +14,6 @@ permissions:
 jobs:
   test_e2e:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v3

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -15,4 +15,4 @@ if [[ -z $(git status -s) ]]; then
     # TODO: Revise this check once we can reliably build without changes
     # exit 1
 fi
-"$CAMINOGO_PATH"/scripts/build_test.sh ${1-}
+"$CAMINOGO_PATH"/scripts/build_test.sh

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -9,4 +9,4 @@ CAMINOGO_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 # Load the constants
 source "$CAMINOGO_PATH"/scripts/constants.sh
 
-go test -shuffle=on ${1-} -timeout="120s" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v /mocks | grep -v proto | grep -v tests)
+go test -shuffle=on -race -timeout="120s" -coverprofile="coverage.out" -covermode="atomic" $(go list ./... | grep -v /mocks | grep -v proto | grep -v tests)


### PR DESCRIPTION
## Why this should be merged
--race flag was moved directly to script as avax did.
Reverted https://github.com/chain4travel/caminogo/commit/0792e0af858e7d986a23d03abe0e82e180627762 changes, cause e2e workflow wasn't running at all.
## How this was tested
Unit-tests and e2e tests.