### PR TITLE
[GENESIS] Make camino part of genesis fully optional

### DIFF
--- a/genesis/camino_genesis.go
+++ b/genesis/camino_genesis.go
@@ -226,8 +226,11 @@ func validateCaminoConfig(config *Config) error {
 	return nil
 }
 
-func caminoArgFromConfig(config *Config) api.Camino {
-	return api.Camino{
+func caminoArgFromConfig(config *Config) *api.Camino {
+	if config.Camino == nil {
+		return nil
+	}
+	return &api.Camino{
 		VerifyNodeSignature: config.Camino.VerifyNodeSignature,
 		LockModeBondDeposit: config.Camino.LockModeBondDeposit,
 		InitialAdmin:        config.Camino.InitialAdmin,

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -98,7 +98,7 @@ type Config struct {
 	InitialStakeDurationOffset uint64        `json:"initialStakeDurationOffset"`
 	InitialStakedFunds         []ids.ShortID `json:"initialStakedFunds"`
 	InitialStakers             []Staker      `json:"initialStakers"`
-	Camino                     Camino        `json:"camino"`
+	Camino                     *Camino       `json:"camino"`
 
 	CChainGenesis string `json:"cChainGenesis"`
 
@@ -142,10 +142,12 @@ func (c Config) Unparse() (UnparsedConfig, error) {
 		}
 		uc.InitialStakers[i] = uis
 	}
-	var err error
-	uc.Camino, err = c.Camino.Unparse(c.NetworkID, c.StartTime)
-	if err != nil {
-		return uc, err
+	if c.Camino != nil {
+		caminoUnparsedConfig, err := c.Camino.Unparse(c.NetworkID, c.StartTime)
+		if err != nil {
+			return uc, err
+		}
+		uc.Camino = &caminoUnparsedConfig
 	}
 
 	return uc, nil
@@ -167,14 +169,16 @@ func (c *Config) InitialSupply() (uint64, error) {
 		initialSupply = newInitialSupply
 	}
 
-	caminoInitialSupply, err := c.Camino.InitialSupply()
-	if err != nil {
-		return 0, err
-	}
+	if c.Camino != nil {
+		caminoInitialSupply, err := c.Camino.InitialSupply()
+		if err != nil {
+			return 0, err
+		}
 
-	initialSupply, err = math.Add64(initialSupply, caminoInitialSupply)
-	if err != nil {
-		return 0, err
+		initialSupply, err = math.Add64(initialSupply, caminoInitialSupply)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	return initialSupply, nil

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -156,13 +156,15 @@ func validateConfig(networkID uint32, config *Config, stakingCfg *StakingConfig)
 		return errNoCChainGenesis
 	}
 
-	if err := validateCaminoConfig(config); err != nil {
-		return err
-	}
+	if config.Camino != nil {
+		if err := validateCaminoConfig(config); err != nil {
+			return err
+		}
 
-	// the rest of the checks are only for LockModeBondDeposit == false
-	if config.Camino.LockModeBondDeposit {
-		return nil
+		// the rest of the checks are only for LockModeBondDeposit == false
+		if config.Camino.LockModeBondDeposit {
+			return nil
+		}
 	}
 
 	// We don't impose any restrictions on the minimum
@@ -290,7 +292,7 @@ func FromFlag(networkID uint32, genesisContent string, stakingCfg *StakingConfig
 func FromConfig(config *Config) ([]byte, ids.ID, error) {
 	hrp := constants.GetHRP(config.NetworkID)
 
-	if config.Camino.LockModeBondDeposit {
+	if config.Camino != nil && config.Camino.LockModeBondDeposit {
 		return buildCaminoGenesis(config, hrp)
 	}
 
@@ -377,6 +379,7 @@ func FromConfig(config *Config) ([]byte, ids.ID, error) {
 		Encoding:      defaultEncoding,
 		Camino:        caminoArgFromConfig(config),
 	}
+
 	for _, allocation := range config.Allocations {
 		if initiallyStaked.Contains(allocation.AVAXAddr) {
 			skippedAllocations = append(skippedAllocations, allocation)

--- a/genesis/genesis_local.json
+++ b/genesis/genesis_local.json
@@ -71,11 +71,6 @@
       "delegationFee": 62500
     }
   ],
-  "camino": {
-    "verifyNodeSignature": false,
-    "lockModeBondDeposit": false,
-    "initialAdmin": "X-local1g65uqn6t77p656w64023nh8nd9updzmxyymev2"
-  },
   "cChainGenesis": "{\"config\":{\"chainId\":43112,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC\":{\"balance\":\"0x295BE96E64066972000000\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
   "message": "{{ fun_quote }}"
 }

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -369,11 +369,11 @@ func TestGenesis(t *testing.T) {
 	}{
 		{
 			networkID:  constants.MainnetID,
-			expectedID: "2eP2teFA41Pb61nQyQYJY38onkCqkrJDPSVeQz8v9ahbEma18S",
+			expectedID: "2uwgsacDoMYttQLfRsPQf9WcfZnpC4nVVHoMd5zkdMheKKqbuj",
 		},
 		{
 			networkID:  constants.FujiID,
-			expectedID: "2fAKF9ph6o4jxr12QVWmbww8dVfkNKepBt547QFEJ5eyD9x2Z9",
+			expectedID: "ijL3TnG4omtuTSsoMBN2gsvZ9P4bNeBqdLBGsxxqTN97VJiPy",
 		},
 		{
 			networkID:  constants.CaminoID,
@@ -389,7 +389,7 @@ func TestGenesis(t *testing.T) {
 		},
 		{
 			networkID:  constants.LocalID,
-			expectedID: "294HrmVEniYX2mrvLjww9AmpV9NZnFhEi6eRrCsAzxZ2PkvdVb",
+			expectedID: "yxYqABea8kNeLqgh59wprEAYPQ7KqCatCBRGT5MWAUQ9fdDEr",
 		},
 	}
 	for _, test := range tests {

--- a/genesis/unparsed_config.go
+++ b/genesis/unparsed_config.go
@@ -98,7 +98,7 @@ type UnparsedConfig struct {
 	InitialStakeDurationOffset uint64           `json:"initialStakeDurationOffset"`
 	InitialStakedFunds         []string         `json:"initialStakedFunds"`
 	InitialStakers             []UnparsedStaker `json:"initialStakers"`
-	Camino                     UnparsedCamino   `json:"camino"`
+	Camino                     *UnparsedCamino  `json:"camino"`
 
 	CChainGenesis string `json:"cChainGenesis"`
 
@@ -142,10 +142,13 @@ func (uc UnparsedConfig) Parse() (Config, error) {
 		}
 		c.InitialStakers[i] = is
 	}
-	parsedCaminoConfig, err := uc.Camino.Parse(uc.StartTime)
-	if err != nil {
-		return c, err
+
+	if uc.Camino != nil {
+		parsedCaminoConfig, err := uc.Camino.Parse(uc.StartTime)
+		if err != nil {
+			return c, err
+		}
+		c.Camino = parsedCaminoConfig
 	}
-	c.Camino = *parsedCaminoConfig
 	return c, nil
 }

--- a/vms/platformvm/api/camino.go
+++ b/vms/platformvm/api/camino.go
@@ -48,7 +48,10 @@ type Camino struct {
 	MultisigAliases            []*multisig.Alias      `json:"multisigAliases"`
 }
 
-func (c Camino) ParseToGenesis() genesis.Camino {
+func (c *Camino) ParseToGenesis() genesis.Camino {
+	if c == nil {
+		return genesis.Camino{}
+	}
 	return genesis.Camino{
 		VerifyNodeSignature: c.VerifyNodeSignature,
 		LockModeBondDeposit: c.LockModeBondDeposit,

--- a/vms/platformvm/api/camino_test.go
+++ b/vms/platformvm/api/camino_test.go
@@ -78,7 +78,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 					}},
 				}},
 				Chains: []Chain{},
-				Camino: Camino{
+				Camino: &Camino{
 					VerifyNodeSignature:        true,
 					LockModeBondDeposit:        true,
 					ValidatorConsortiumMembers: []ids.ShortID{addr},
@@ -365,7 +365,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 					},
 				},
 				Chains: []Chain{},
-				Camino: Camino{
+				Camino: &Camino{
 					VerifyNodeSignature: true,
 					LockModeBondDeposit: false,
 					ValidatorConsortiumMembers: []ids.ShortID{
@@ -410,7 +410,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				Validators: []PermissionlessValidator{},
 				Time:       5,
 				Encoding:   formatting.Hex,
-				Camino: Camino{
+				Camino: &Camino{
 					VerifyNodeSignature: true,
 					LockModeBondDeposit: true,
 					UTXODeposits: []UTXODeposit{
@@ -454,7 +454,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				},
 				Time:     5,
 				Encoding: formatting.Hex,
-				Camino: Camino{
+				Camino: &Camino{
 					VerifyNodeSignature: true,
 					LockModeBondDeposit: true,
 					ValidatorDeposits: [][]UTXODeposit{
@@ -499,7 +499,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 				},
 				Time:     5,
 				Encoding: formatting.Hex,
-				Camino: Camino{
+				Camino: &Camino{
 					VerifyNodeSignature: true,
 					LockModeBondDeposit: true,
 					ValidatorConsortiumMembers: []ids.ShortID{
@@ -548,7 +548,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 					},
 				},
 				Chains: []Chain{},
-				Camino: Camino{
+				Camino: &Camino{
 					VerifyNodeSignature: true,
 					LockModeBondDeposit: true,
 					ValidatorConsortiumMembers: []ids.ShortID{

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -186,7 +186,7 @@ type BuildGenesisArgs struct {
 	UTXOs         []UTXO                    `json:"utxos"`
 	Validators    []PermissionlessValidator `json:"validators"`
 	Chains        []Chain                   `json:"chains"`
-	Camino        Camino                    `json:"camino"`
+	Camino        *Camino                   `json:"camino"`
 	Time          json.Uint64               `json:"time"`
 	InitialSupply json.Uint64               `json:"initialSupply"`
 	Message       string                    `json:"message"`
@@ -212,7 +212,7 @@ func bech32ToID(addrStr string) (ids.ShortID, error) {
 func (*StaticService) BuildGenesis(_ *http.Request, args *BuildGenesisArgs, reply *BuildGenesisReply) error {
 	// Specify the UTXOs on the Platform chain that exist at genesis.
 	var vdrs txheap.TimedHeap
-	if args.Camino.LockModeBondDeposit {
+	if args.Camino != nil && args.Camino.LockModeBondDeposit {
 		return buildCaminoGenesis(args, reply)
 	}
 

--- a/vms/platformvm/camino_helpers_test.go
+++ b/vms/platformvm/camino_helpers_test.go
@@ -201,7 +201,7 @@ func newCaminoGenesisWithUTXOs(caminoGenesisConfig api.Camino, genesisUTXOs []ap
 		Chains:        nil,
 		Time:          json.Uint64(defaultGenesisTime.Unix()),
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
-		Camino:        caminoGenesisConfig,
+		Camino:        &caminoGenesisConfig,
 	}
 
 	buildGenesisResponse := api.BuildGenesisReply{}

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -385,7 +385,7 @@ func testGenesisConfig(lockModeBondDeposit bool, validator, deposit bool) *root_
 		InitialStakeDurationOffset: 10,
 		InitialStakedFunds:         avaxInitialStakerFunds,
 		InitialStakers:             avaxInitialStakers,
-		Camino: root_genesis.Camino{
+		Camino: &root_genesis.Camino{
 			VerifyNodeSignature: true,
 			LockModeBondDeposit: lockModeBondDeposit,
 			InitialAdmin:        initialAdmin,

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -455,7 +455,7 @@ func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf api.Camino) []b
 		Validators:    genesisValidators,
 		Chains:        nil,
 		Time:          json.Uint64(defaultGenesisTime.Unix()),
-		Camino:        caminoGenesisConf,
+		Camino:        &caminoGenesisConf,
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
 		Encoding:      formatting.Hex,
 	}

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -328,7 +328,7 @@ func buildCaminoGenesisTest(ctx *snow.Context, caminoGenesisConf api.Camino) []b
 		Validators:    genesisValidators,
 		Chains:        nil,
 		Time:          json.Uint64(defaultGenesisTime.Unix()),
-		Camino:        caminoGenesisConf,
+		Camino:        &caminoGenesisConf,
 		InitialSupply: json.Uint64(360 * units.MegaAvax),
 		Encoding:      formatting.Hex,
 	}


### PR DESCRIPTION
## Why this should be merged
In genesis json we have `camino` field which contains camino-specific data. Initial idea was that we'll keep all avax logic and introduce our own in addition to that, so both camino and avax tests can work with existing code. But there are still still some inconsistency in that.

If we'll try to run node with custom genesis json, which doesn't have `camino` field at all, like normal avax genesis, genesis parsing will fail cause of invalid initial admin address. This PR solves it by making whole `camino` field logic optional.
## How this works
Make `camino` field pointer, so default value will be nil. Check for not nil before doing something with this field.
## How this was tested
Existing unit-tests and e2e tests.
Manual start of local node with custom genesis without camino field.
