### PR TITLE
add workflow to test docker building

### DIFF
--- a/.github/workflows/test_build_docker.yml
+++ b/.github/workflows/test_build_docker.yml
@@ -1,11 +1,11 @@
-name: Build + Publish Docker Image
+name: Build Docker Image
 
 on:
   pull_request:  
     branches: [chain4travel, dev]
 
 jobs:
-  build_publish_image:
+  build_image:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_build_docker.yml
+++ b/.github/workflows/test_build_docker.yml
@@ -1,0 +1,15 @@
+name: Build + Publish Docker Image
+
+on:
+  pull_request:  
+    branches: [chain4travel, dev]
+
+jobs:
+  build_publish_image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build docker image
+        run: scripts/build_local_image.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@
 # go.mod
 # ============= Compilation Stage ================
 FROM golang:1.20.8-bullseye AS builder
-RUN apt-get update && apt-get install -y --no-install-recommends bash=5.0-4 git=1:2.20.1-2+deb10u8 make=4.2.1-1.2 gcc=4:8.3.0-1 musl-dev=1.1.21-2 ca-certificates=20200601~deb10u2 linux-headers-amd64
 WORKDIR /build
 # Copy and download caminogo dependencies using go mod
 COPY go.mod .

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -24,7 +24,7 @@ current_branch=${current_branch_temp////-}
 
 # caminogo and caminoethvm git tag and sha
 git_commit=${CAMINO_NODE_COMMIT:-$(git rev-parse --short HEAD)}
-git_tag=${CAMINO_NODE_TAG:-$(git describe --tags --abbrev=0 || echo unknown)}
+git_tag=${CAMINO_NODE_TAG:-$(git describe --tags --abbrev=0 --always || echo unknown)}
 caminoethvm_tag=${CAMINO_ETHVM_VERSION:-'v1.1.7-rc0'}
 caminoethvm_commit=${CAMINOETHVM_COMMIT:-'383f4172f51a5dd6bc0dba1c1407fc4b1b0b06ad'}
 

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -18,8 +18,9 @@ plugin_dir="$build_dir/plugins"
 camino_node_dockerhub_repo=${DOCKER_REPO:-"c4tplatform"}"/camino-node"
 
 # Current branch
-# TODO: fix "fatal: No names found, cannot describe anything" in github CI
-current_branch=$(git symbolic-ref -q --short HEAD || git describe --tags || echo unknown)
+current_branch_temp=$(git symbolic-ref -q --short HEAD || git describe --tags --always || echo unknown)
+# replace / with - to be a docker tag compatible
+current_branch=${current_branch_temp////-}
 
 # caminogo and caminoethvm git tag and sha
 git_commit=${CAMINO_NODE_COMMIT:-$(git rev-parse --short HEAD)}


### PR DESCRIPTION
## Why this should be merged
- to fix docker build
- to test docker build in a PR
- to remove the warning "fatal: No names found, cannot describe anything"

## How this works
- when a PR is created , a workflow will run to test docker build
- no more  "fatal: No names found, cannot describe anything" warning


## How this was tested
tested locally