### PR TITLE
[PVM, Tests] Refactor deferred validator tests

### DIFF
--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -165,6 +165,14 @@ func (b *caminoBuilder) NewCaminoAddValidatorTx(
 		)
 	}
 
+	var changeOwner *secp256k1fx.OutputOwners
+	if changeAddr != ids.ShortEmpty {
+		changeOwner = &secp256k1fx.OutputOwners{
+			Threshold: 1,
+			Addrs:     []ids.ShortID{changeAddr},
+		}
+	}
+
 	ins, outs, signers, _, err := b.Lock(
 		b.state,
 		keys,
@@ -172,10 +180,7 @@ func (b *caminoBuilder) NewCaminoAddValidatorTx(
 		b.cfg.AddPrimaryNetworkValidatorFee,
 		locked.StateBonded,
 		nil,
-		&secp256k1fx.OutputOwners{
-			Threshold: 1,
-			Addrs:     []ids.ShortID{changeAddr},
-		},
+		changeOwner,
 		0,
 	)
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged
`TestRemoveDeferredValidator` and `TestRemoveReactivatedValidator` tests are directly making changes to chain state instead of making it with transactions and utilizing genesis. That seems rather unclean and leaves place for errors. This PR refactors those test.

Most of tx builder methods are accepting `secp256k1fx.OutputOwners` as change arg, while `CaminoAddValidatorTx` method accepts address in order to be compatible with avax tx builder `*AddValidatorTx` method.
All relevant camino builder methods are using utxo handler Lock method for producing ins and outs, which allows to pass nil as change arg, so it will ignore it and return change to original owner. And `CaminoAddValidatorTx` method with EmptyShortID as change arg was passing it as not-nil `secp256k1fx.OutputOwners` to `Lock` method, so it was actually returning change to EmptyShortID owner. This PR fixes that.
## How this works
- Replace direct state changes with transactions, add funds to genesis.
- Pass nil change arg to `Lock` if `CaminoAddValidatorTx` change arg is EmptyShortID.
## How this was tested
Existing unit tests and e2e tests.