### PR TITLE
 D-Phase fix for cortina 18 bug

### DIFF
--- a/network/p2p/gossip/gossip_test.go
+++ b/network/p2p/gossip/gossip_test.go
@@ -358,6 +358,8 @@ func TestPushGossiper(t *testing.T) {
 // Tests that gossip to a peer should forward the gossip if it was not
 // previously known
 func TestPushGossipE2E(t *testing.T) {
+	t.SkipNow()
+
 	require := require.New(t)
 
 	// tx known by both the sender and the receiver which should not be

--- a/network/p2p/gossip/handler.go
+++ b/network/p2p/gossip/handler.go
@@ -97,7 +97,7 @@ func (h Handler[T]) AppRequest(_ context.Context, _ ids.NodeID, _ time.Time, req
 	return MarshalAppResponse(gossipBytes)
 }
 
-func (h Handler[_]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipBytes []byte) {
+func (h Handler[_]) AppGossip(_ context.Context, nodeID ids.NodeID, gossipBytes []byte) {
 	gossip, err := ParseAppGossip(gossipBytes)
 	if err != nil {
 		h.log.Debug("failed to unmarshal gossip", zap.Error(err))
@@ -123,16 +123,7 @@ func (h Handler[_]) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipByte
 				zap.Stringer("id", gossipable.GossipID()),
 				zap.Error(err),
 			)
-			continue
 		}
-
-		// continue gossiping messages we have not seen to other peers
-		h.accumulator.Add(gossipable)
-	}
-
-	if err := h.accumulator.Gossip(ctx); err != nil {
-		h.log.Error("failed to forward gossip", zap.Error(err))
-		return
 	}
 
 	receivedCountMetric, err := h.metrics.receivedCount.GetMetricWith(pushLabels)


### PR DESCRIPTION
## Why this should be merged
This PR addresses the avalanche blockchain stall issue introduced by cortina 18 (v1.10.18).

## How this works
Cherry picks avax commit: https://github.com/ava-labs/avalanchego/pull/2766/commits/9d01c519e53ae7b0bd85233ea435e4b83e9cbb32
which was the only commit of https://github.com/ava-labs/avalanchego/releases/tag/v1.11.1

### Merge conflicts 
on all 3 conflicts, avax changes have been ignored.
- `compatibility.json` (cause we re actually skipping 2 releases so it's quite weird/complicated at least in my mind)
- `version/constants.go` (cause we re actually skipping 2 releases so it's quite weird/complicated at least in my mind)
- `RELEASES.MD`

## How this was tested
only ci