### PR TITLE
[PVM] Returns pre-Athens rewardsImportTx logic for pre-Athens txs

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.19
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v5
         with:
           version: v1.51
       - name: Run static analysis tests


### PR DESCRIPTION
## Why this should be merged
Before Athens, rewardsImportTx were distributing validator rewards to consortium members that owns current validators instead of distributing it to addValidatorTx.RewardOwner. With Athens, this was fixed without proper phase logic, cause of assumption that there is currently no addValidatorTx.RewardOwner != consortium-member. That was correct for camino main-net, but appeared to be wrong for columbus network. Because of that, columbus network nodes that bootstrapped after Athens, they executed before-Athens rewardsImportTx for this odd addValidatorTx with Athens logic making their chain-state inconsistent with old majority of nodes that were running from before Athens.

Now colubmus network before-Athens majority accepted claimTx that should fail for after-Athens majority with their inconsistent state, so all new nodes will fail to execute this tx and will fail to bootstrap.

This PR fixes that by introducing proper Athens phase logic for rewardsImportTx.

PR also updates `.github/workflows/static-analysis.yml` `golangci/golangci-lint-action@v2` to `golangci/golangci-lint-action@v5`, cause v2 is now deprecated and will make ci fail.

## How this works
Instead of just replacing old rewardsImportTx distribution logic with new, this PR keeps old logic and runs new only if timestamp is after-Athens.

## How this was tested
With unit-tests and manually on camino and columbus networks.