### PR TITLE
[PVM, Spend] Allow spend to deposit unlocked tokens for different owner

### DIFF
--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -274,7 +274,7 @@ func (h *handler) Lock(
 	insAmounts := make(map[ids.ID]OwnerAmounts)
 
 	var toOwnerID *ids.ID
-	if to != nil && appliedLockState == locked.StateUnlocked {
+	if to != nil && (appliedLockState == locked.StateUnlocked || appliedLockState == locked.StateDeposited) {
 		id, err := txs.GetOwnerID(to)
 		if err != nil {
 			return nil, nil, nil, nil, err

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -430,6 +430,29 @@ func TestLock(t *testing.T) {
 				}
 			},
 		},
+		"OK: deposit for new owner": {
+			args: args{
+				totalAmountToSpend: 1,
+				totalAmountToBurn:  1,
+				appliedLockState:   locked.StateDeposited,
+				recipient:          &recipientOwners,
+				change:             &changeOwners,
+			},
+			utxos: []*avax.UTXO{
+				generateTestUTXO(ids.ID{8, 8}, ctx.AVAXAssetID, 5, outputOwners, ids.Empty, ids.Empty),
+			},
+			generateWant: func(utxos []*avax.UTXO) want {
+				return want{
+					ins: []*avax.TransferableInput{
+						generateTestInFromUTXO(utxos[0], []uint32{0}),
+					},
+					outs: []*avax.TransferableOutput{
+						generateTestOut(ctx.AVAXAssetID, 1, recipientOwners, locked.ThisTxID, ids.Empty),
+						generateTestOut(ctx.AVAXAssetID, 3, changeOwners, ids.Empty, ids.Empty),
+					},
+				}
+			},
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Why this should be merged
This PR allows spend method to create deposited outs with new owner. This is required, when owner of the tokens, who also has the right to create deposit with specific offer, wants to create deposit that will be owned by someone else.

## How this works
Add `|| appliedLockState == locked.StateDeposited` to if block that defines new owner. 

## How this was tested
Manually and with unit tests.