### PR TITLE
[PVM, EVM] Fixed collectRewardsTx cross-chain request/response handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -162,4 +162,4 @@ require (
 
 replace github.com/ava-labs/avalanche-ledger-go => github.com/chain4travel/camino-ledger-go v0.0.13-c4t
 
-replace github.com/ava-labs/coreth => github.com/chain4travel/caminoethvm v1.1.19-rc0
+replace github.com/ava-labs/coreth => github.com/chain4travel/caminoethvm v1.1.19-rc0.0.20240531135009-bdfd4b14895d

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chain4travel/caminoethvm v1.1.19-rc0 h1:HfthNcZLyL9HS2f2Sv529lCvdmlzY6hThRnCtzcXRN0=
-github.com/chain4travel/caminoethvm v1.1.19-rc0/go.mod h1:F2be/crCphktEOCKfR4P7r0rV0fppOsFMj0mR3kvVqQ=
+github.com/chain4travel/caminoethvm v1.1.19-rc0.0.20240531135009-bdfd4b14895d h1:9oiRa8iok+lNZ/KDBiF4egEjd3SB4AkO4bpliLpOaOY=
+github.com/chain4travel/caminoethvm v1.1.19-rc0.0.20240531135009-bdfd4b14895d/go.mod h1:FKdH7I1vai1oYkhuU0au1FnE5Rkt2dTm1k4Q8AJBV0I=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Why this should be merged
Before this PR, cross-chain CaminoRewardMessage request handler weren't doing any response, which resulted in errors in log.

This PR and https://github.com/chain4travel/caminoethvm/pull/99 fixes that.

## How this works
Sends proper response in case of non-fatal errors and if tx were issued.

## How this was tested
Manually.