### PR TITLE
[PVM] Add validator admin role, reduce root admin permissions

### DIFF
--- a/vms/platformvm/addrstate/camino_address_state.go
+++ b/vms/platformvm/addrstate/camino_address_state.go
@@ -9,50 +9,74 @@ type (
 const (
 	// Bits
 
-	AddressStateBitRoleAdmin AddressStateBit = 0 // super role
+	// Allow to set role bits
+	AddressStateBitRoleAdmin AddressStateBit = 0
+	// Allows to set KYC and KYB bits
+	AddressStateBitRoleKYCAdmin AddressStateBit = 1
+	// Allows to set OffersCreator bit
+	AddressStateBitRoleOffersAdmin AddressStateBit = 2
+	// Allows to create addMember and excludeMember admin-proposals
+	AddressStateBitRoleConsortiumSecretary AddressStateBit = 3
+	// Allows to set node deferred bit
+	AddressStateBitRoleValidatorAdmin AddressStateBit = 4
 
-	AddressStateBitRoleKYCAdmin                AddressStateBit = 1 // allows to set KYCVerified and KYCExpired
-	AddressStateBitRoleOffersAdmin             AddressStateBit = 2 // allows to set OffersCreator
-	AddressStateBitRoleConsortiumAdminProposer AddressStateBit = 3 // allows to create admin add/exclude member proposals
-
-	AddressStateBitKYCVerified    AddressStateBit = 32
-	AddressStateBitKYCExpired     AddressStateBit = 33
-	AddressStateBitConsortium     AddressStateBit = 38
-	AddressStateBitNodeDeferred   AddressStateBit = 39
-	AddressStateBitOffersCreator  AddressStateBit = 50
-	AddressStateBitCaminoProposer AddressStateBit = 51
+	// Indicates that address passed KYC verification
+	AddressStateBitKYCVerified AddressStateBit = 32
+	// Indicates that address KYC verification is expired. (not yet implemented)
+	AddressStateBitKYCExpired AddressStateBit = 33
+	// Indicates that address is member of consortium
+	AddressStateBitConsortium AddressStateBit = 38
+	// Indicates that a node owned by this address (as consortium member) is deferred
+	AddressStateBitNodeDeferred AddressStateBit = 39
+	// Allows to create deposit offers
+	AddressStateBitOffersCreator AddressStateBit = 50
+	// Allows to create baseFee and feeDistribution proposals
+	AddressStateBitFoundationAdmin AddressStateBit = 51
 
 	AddressStateBitMax AddressStateBit = 63
 
 	// States
 
+	// 0b0000000000000000000000000000000000000000000000000000000000000000
 	AddressStateEmpty AddressState = 0
 
-	AddressStateRoleAdmin                   = AddressState(1) << AddressStateBitRoleAdmin                   // 0b1
-	AddressStateRoleKYCAdmin                = AddressState(1) << AddressStateBitRoleKYCAdmin                // 0b10
-	AddressStateRoleOffersAdmin             = AddressState(1) << AddressStateBitRoleOffersAdmin             // 0b100
-	AddressStateRoleConsortiumAdminProposer = AddressState(1) << AddressStateBitRoleConsortiumAdminProposer // 0b1000
+	// 0b0000000000000000000000000000000000000000000000000000000000000001
+	AddressStateRoleAdmin = AddressState(1) << AddressStateBitRoleAdmin
+	// 0b0000000000000000000000000000000000000000000000000000000000000010
+	AddressStateRoleKYCAdmin = AddressState(1) << AddressStateBitRoleKYCAdmin
+	// 0b0000000000000000000000000000000000000000000000000000000000000100
+	AddressStateRoleOffersAdmin = AddressState(1) << AddressStateBitRoleOffersAdmin
+	// 0b0000000000000000000000000000000000000000000000000000000000001000
+	AddressStateRoleConsortiumSecretary = AddressState(1) << AddressStateBitRoleConsortiumSecretary
+	// 0b0000000000000000000000000000000000000000000000000000000000010000
+	AddressStateRoleValidatorAdmin = AddressState(1) << AddressStateBitRoleValidatorAdmin
 
-	AddressStateKYCVerified = AddressState(1) << AddressStateBitKYCVerified // 0b0100000000000000000000000000000000
-	AddressStateKYCExpired  = AddressState(1) << AddressStateBitKYCExpired  // 0b1000000000000000000000000000000000
-
-	AddressStateConsortium   = AddressState(1) << AddressStateBitConsortium   // 0b0100000000000000000000000000000000000000
-	AddressStateNodeDeferred = AddressState(1) << AddressStateBitNodeDeferred // 0b1000000000000000000000000000000000000000
-
-	AddressStateOffersCreator  = AddressState(1) << AddressStateBitOffersCreator  // 0b0100000000000000000000000000000000000000000000000000
-	AddressStateCaminoProposer = AddressState(1) << AddressStateBitCaminoProposer // 0b1000000000000000000000000000000000000000000000000000
+	// 0b0000000000000000000000000000000100000000000000000000000000000000
+	AddressStateKYCVerified = AddressState(1) << AddressStateBitKYCVerified
+	// 0b0000000000000000000000000000001000000000000000000000000000000000
+	AddressStateKYCExpired = AddressState(1) << AddressStateBitKYCExpired
+	// 0b0000000000000000000000000100000000000000000000000000000000000000
+	AddressStateConsortium = AddressState(1) << AddressStateBitConsortium
+	// 0b0000000000000000000000001000000000000000000000000000000000000000
+	AddressStateNodeDeferred = AddressState(1) << AddressStateBitNodeDeferred
+	// 0b0000000000000100000000000000000000000000000000000000000000000000
+	AddressStateOffersCreator = AddressState(1) << AddressStateBitOffersCreator
+	// 0b0000000000001000000000000000000000000000000000000000000000000000
+	AddressStateFoundationAdmin = AddressState(1) << AddressStateBitFoundationAdmin
 
 	// Bit groups (as AddressState)
 
-	AddressStateSunrisePhaseBits = AddressStateRoleAdmin | AddressStateRoleKYCAdmin | // 0b1100001100000000000000000000000000000011
+	// 0b0000000000000000000000001100001100000000000000000000000000000011
+	AddressStateSunrisePhaseBits = AddressStateRoleAdmin | AddressStateRoleKYCAdmin |
 		AddressStateKYCVerified | AddressStateKYCExpired | AddressStateConsortium |
 		AddressStateNodeDeferred
-
-	AddressStateAthensPhaseBits = AddressStateRoleOffersAdmin | AddressStateOffersCreator // 0b0100000000000000000000000000000000000000000000000100
-
-	AddressStateBerlinPhaseBits = AddressStateCaminoProposer | AddressStateRoleConsortiumAdminProposer // 0b1000000000000000000000000000000000000000000000001000
-
-	AddressStateValidBits = AddressStateSunrisePhaseBits | // 0b1100000000001100001100000000000000000000000000001111
+	// 0b0000000000000100000000000000000000000000000000000000000000000100
+	AddressStateAthensPhaseBits = AddressStateRoleOffersAdmin | AddressStateOffersCreator
+	// 0b0000000000001000000000000000000000000000000000000000000000001000
+	AddressStateBerlinPhaseBits = AddressStateFoundationAdmin | AddressStateRoleConsortiumSecretary |
+		AddressStateRoleValidatorAdmin
+	// 0b0000000000001100000000001100001100000000000000000000000000011111
+	AddressStateValidBits = AddressStateSunrisePhaseBits |
 		AddressStateAthensPhaseBits |
 		AddressStateBerlinPhaseBits
 )

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -44,7 +44,10 @@ func TestRemoveDeferredValidator(t *testing.T) {
 
 	nodeKey, nodeID := test.Keys[0], ids.NodeID(test.Keys[0].Address())
 	rootAdminKey := test.FundedKeys[0]
-	adminProposerKey := test.FundedKeys[0]
+	consortiumSecretaryKey := test.FundedKeys[0]
+	kycAdminKey := test.FundedKeys[0]
+	validatorAdminKey := test.FundedKeys[0]
+	fundsKey := test.FundedKeys[0]
 	consortiumMemberKey := test.Keys[1]
 
 	caminoGenesisConf := api.Camino{
@@ -61,11 +64,22 @@ func TestRemoveDeferredValidator(t *testing.T) {
 	defer vm.ctx.Lock.Unlock()
 
 	// Set consortium member
-	// add admin proposer role to root admin
+	// set ConsortiumSecretary role
 	tx, err := vm.txBuilder.NewAddressStateTx(
-		adminProposerKey.Address(),
+		consortiumSecretaryKey.Address(),
 		false,
-		as.AddressStateBitRoleConsortiumAdminProposer,
+		as.AddressStateBitRoleConsortiumSecretary,
+		rootAdminKey.Address(),
+		[]*secp256k1.PrivateKey{rootAdminKey},
+		nil,
+	)
+	require.NoError(err)
+	_ = buildAndAcceptBlock(t, vm, tx)
+	// set kyc admin role
+	tx, err = vm.txBuilder.NewAddressStateTx(
+		kycAdminKey.Address(),
+		false,
+		as.AddressStateBitRoleKYCAdmin,
 		rootAdminKey.Address(),
 		[]*secp256k1.PrivateKey{rootAdminKey},
 		nil,
@@ -77,15 +91,15 @@ func TestRemoveDeferredValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		false,
 		as.AddressStateBitKYCVerified,
-		test.FundedKeys[0].Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0]},
+		kycAdminKey.Address(),
+		[]*secp256k1.PrivateKey{kycAdminKey},
 		nil,
 	)
 	require.NoError(err)
 	_ = buildAndAcceptBlock(t, vm, addrStateTx)
 	// make admin proposal to add consortium member
-	proposalTx := buildAddMemberProposalTx(t, vm, test.FundedKeys[0], vm.Config.CaminoConfig.DACProposalBondAmount, defaultTxFee,
-		adminProposerKey, consortiumMemberKey.Address(), vm.clock.Time(), true)
+	proposalTx := buildAddMemberProposalTx(t, vm, consortiumSecretaryKey, vm.Config.CaminoConfig.DACProposalBondAmount, defaultTxFee,
+		consortiumSecretaryKey, consortiumMemberKey.Address(), vm.clock.Time(), true)
 	_, _, _, _ = makeProposalWithTx(t, vm, proposalTx) // add admin proposal
 	_ = buildAndAcceptBlock(t, vm, nil)                // execute admin proposal
 
@@ -94,7 +108,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 		ids.EmptyNodeID,
 		nodeID,
 		consortiumMemberKey.Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0], nodeKey, consortiumMemberKey},
+		[]*secp256k1.PrivateKey{fundsKey, nodeKey, consortiumMemberKey},
 		nil,
 	)
 	require.NoError(err)
@@ -111,7 +125,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		ids.ShortEmpty,
 		reward.PercentDenominator,
-		[]*secp256k1.PrivateKey{test.FundedKeys[0], consortiumMemberKey},
+		[]*secp256k1.PrivateKey{fundsKey, consortiumMemberKey},
 		ids.ShortEmpty,
 	)
 	require.NoError(err)
@@ -121,12 +135,24 @@ func TestRemoveDeferredValidator(t *testing.T) {
 	vm.clock.Set(startTime)
 
 	// Defer the validator
+	// set validator admin role
+	tx, err = vm.txBuilder.NewAddressStateTx(
+		validatorAdminKey.Address(),
+		false,
+		as.AddressStateBitRoleValidatorAdmin,
+		rootAdminKey.Address(),
+		[]*secp256k1.PrivateKey{rootAdminKey},
+		nil,
+	)
+	require.NoError(err)
+	_ = buildAndAcceptBlock(t, vm, tx)
+	// defer validator
 	tx, err = vm.txBuilder.NewAddressStateTx(
 		consortiumMemberKey.Address(),
 		false,
 		as.AddressStateBitNodeDeferred,
-		test.FundedKeys[0].Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0]},
+		validatorAdminKey.Address(),
+		[]*secp256k1.PrivateKey{validatorAdminKey},
 		nil,
 	)
 	require.NoError(err)
@@ -200,8 +226,11 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 	require := require.New(t)
 
 	nodeKey, nodeID := test.Keys[0], ids.NodeID(test.Keys[0].Address())
+	fundsKey := test.FundedKeys[0]
 	rootAdminKey := test.FundedKeys[0]
-	adminProposerKey := test.FundedKeys[0]
+	kycAdminKey := test.FundedKeys[0]
+	validatorAdminKey := test.FundedKeys[0]
+	consortiumSecretaryKey := test.FundedKeys[0]
 	consortiumMemberKey := test.Keys[1]
 
 	caminoGenesisConf := api.Camino{
@@ -221,31 +250,42 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 	defer vm.ctx.Lock.Unlock()
 
 	// Set consortium member
-	// add admin proposer role to root admin
+	// set consortium secretary role
 	tx, err := vm.txBuilder.NewAddressStateTx(
-		adminProposerKey.Address(),
+		consortiumSecretaryKey.Address(),
 		false,
-		as.AddressStateBitRoleConsortiumAdminProposer,
+		as.AddressStateBitRoleConsortiumSecretary,
 		rootAdminKey.Address(),
 		[]*secp256k1.PrivateKey{rootAdminKey},
 		nil,
 	)
 	require.NoError(err)
 	_ = buildAndAcceptBlock(t, vm, tx)
-	// set kyc flag for test consortium member (not member yet)
+	// set kyc admin role
 	addrStateTx, err := vm.txBuilder.NewAddressStateTx(
+		kycAdminKey.Address(),
+		false,
+		as.AddressStateBitRoleKYCAdmin,
+		rootAdminKey.Address(),
+		[]*secp256k1.PrivateKey{rootAdminKey},
+		nil,
+	)
+	require.NoError(err)
+	_ = buildAndAcceptBlock(t, vm, addrStateTx)
+	// set kyc flag for test consortium member (not member yet)
+	addrStateTx, err = vm.txBuilder.NewAddressStateTx(
 		consortiumMemberKey.Address(),
 		false,
 		as.AddressStateBitKYCVerified,
-		test.FundedKeys[0].Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0]},
+		kycAdminKey.Address(),
+		[]*secp256k1.PrivateKey{kycAdminKey},
 		nil,
 	)
 	require.NoError(err)
 	_ = buildAndAcceptBlock(t, vm, addrStateTx)
 	// make admin proposal to add consortium member
-	proposalTx := buildAddMemberProposalTx(t, vm, test.FundedKeys[0], vm.Config.CaminoConfig.DACProposalBondAmount, defaultTxFee,
-		adminProposerKey, consortiumMemberKey.Address(), vm.clock.Time(), true)
+	proposalTx := buildAddMemberProposalTx(t, vm, consortiumSecretaryKey, vm.Config.CaminoConfig.DACProposalBondAmount, defaultTxFee,
+		consortiumSecretaryKey, consortiumMemberKey.Address(), vm.clock.Time(), true)
 	_, _, _, _ = makeProposalWithTx(t, vm, proposalTx) // add admin proposal
 	_ = buildAndAcceptBlock(t, vm, nil)                // execute admin proposal
 
@@ -254,7 +294,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 		ids.EmptyNodeID,
 		nodeID,
 		consortiumMemberKey.Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0], nodeKey, consortiumMemberKey},
+		[]*secp256k1.PrivateKey{fundsKey, nodeKey, consortiumMemberKey},
 		nil,
 	)
 	require.NoError(err)
@@ -271,7 +311,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		ids.ShortEmpty,
 		reward.PercentDenominator,
-		[]*secp256k1.PrivateKey{test.FundedKeys[0], nodeKey, consortiumMemberKey},
+		[]*secp256k1.PrivateKey{fundsKey, nodeKey, consortiumMemberKey},
 		ids.ShortEmpty,
 	)
 	require.NoError(err)
@@ -280,13 +320,24 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 	// Fast-forward clock to time for validator to be moved from pending to current
 	vm.clock.Set(startTime)
 
+	// Set validator admin role
+	tx, err = vm.txBuilder.NewAddressStateTx(
+		validatorAdminKey.Address(),
+		false,
+		as.AddressStateBitRoleValidatorAdmin,
+		rootAdminKey.Address(),
+		[]*secp256k1.PrivateKey{rootAdminKey},
+		nil,
+	)
+	require.NoError(err)
+	_ = buildAndAcceptBlock(t, vm, tx)
 	// Defer the validator
 	tx, err = vm.txBuilder.NewAddressStateTx(
 		consortiumMemberKey.Address(),
 		false,
 		as.AddressStateBitNodeDeferred,
-		test.FundedKeys[0].Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0]},
+		validatorAdminKey.Address(),
+		[]*secp256k1.PrivateKey{validatorAdminKey},
 		nil,
 	)
 	require.NoError(err)
@@ -303,8 +354,8 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		true,
 		as.AddressStateBitNodeDeferred,
-		test.FundedKeys[0].Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0]},
+		validatorAdminKey.Address(),
+		[]*secp256k1.PrivateKey{validatorAdminKey},
 		nil,
 	)
 	require.NoError(err)
@@ -446,10 +497,6 @@ func TestDepositsAutoUnlock(t *testing.T) {
 
 func TestProposals(t *testing.T) {
 	proposerKey, proposerAddr := test.Keys[0], test.Keys[0].Address()
-	proposerAddrStr, err := address.FormatBech32(constants.UnitTestHRP, proposerAddr.Bytes())
-	require.NoError(t, err)
-	caminoPreFundedKey0AddrStr, err := address.FormatBech32(constants.UnitTestHRP, test.FundedKeys[0].Address().Bytes())
-	require.NoError(t, err)
 
 	defaultConfig := test.Config(t, test.PhaseLast)
 	proposalBondAmount := defaultConfig.CaminoConfig.DACProposalBondAmount
@@ -524,11 +571,11 @@ func TestProposals(t *testing.T) {
 			}, test.PhaseCairo, []api.UTXO{ // TODO @evlekht replace with PhaseLast when cairo is added
 				{
 					Amount:  json.Uint64(balance),
-					Address: proposerAddrStr,
+					Address: test.KeysBech32[0],
 				},
 				{
 					Amount:  json.Uint64(defaultTxFee),
-					Address: caminoPreFundedKey0AddrStr,
+					Address: test.FundedKeysBech32[0],
 				},
 			})
 			vm.ctx.Lock.Lock()
@@ -545,7 +592,7 @@ func TestProposals(t *testing.T) {
 			addrStateTx, err := vm.txBuilder.NewAddressStateTx(
 				proposerAddr,
 				false,
-				as.AddressStateBitCaminoProposer,
+				as.AddressStateBitFoundationAdmin,
 				test.FundedKeys[0].Address(),
 				[]*secp256k1.PrivateKey{test.FundedKeys[0]},
 				nil,
@@ -647,13 +694,10 @@ func TestProposals(t *testing.T) {
 func TestAdminProposals(t *testing.T) {
 	require := require.New(t)
 
-	proposerKey, proposerAddr := test.Keys[0], test.Keys[0].Address()
-	proposerAddrStr, err := address.FormatBech32(constants.UnitTestHRP, proposerAddr.Bytes())
-	require.NoError(err)
-	caminoPreFundedKey0AddrStr, err := address.FormatBech32(constants.UnitTestHRP, test.FundedKeys[0].Address().Bytes())
-	require.NoError(err)
-
-	applicantAddr := proposerAddr
+	rootAdminKey := test.FundedKeys[0]
+	kycAdminKey := test.FundedKeys[0]
+	consortiumSecretaryKey := test.Keys[0]
+	applicantAddr := consortiumSecretaryKey.Address()
 
 	defaultConfig := test.Config(t, test.PhaseLast)
 	proposalBondAmount := defaultConfig.CaminoConfig.DACProposalBondAmount
@@ -663,20 +707,20 @@ func TestAdminProposals(t *testing.T) {
 	vm := newCaminoVM(t, api.Camino{
 		VerifyNodeSignature: true,
 		LockModeBondDeposit: true,
-		InitialAdmin:        test.FundedKeys[0].Address(),
+		InitialAdmin:        rootAdminKey.Address(),
 	}, test.PhaseLast, []api.UTXO{
 		{
 			Amount:  json.Uint64(balance),
-			Address: proposerAddrStr,
+			Address: test.KeysBech32[0],
 		},
 		{
 			Amount:  json.Uint64(defaultTxFee * 2),
-			Address: caminoPreFundedKey0AddrStr,
+			Address: test.FundedKeysBech32[0],
 		},
 	})
 	vm.ctx.Lock.Lock()
 	defer vm.ctx.Lock.Unlock()
-	checkBalance(t, vm.state, proposerAddr,
+	checkBalance(t, vm.state, consortiumSecretaryKey.Address(),
 		balance,          // total
 		0, 0, 0, balance, // unlocked
 	)
@@ -686,11 +730,11 @@ func TestAdminProposals(t *testing.T) {
 
 	// Give proposer address role to make admin proposals
 	addrStateTx, err := vm.txBuilder.NewAddressStateTx(
-		proposerAddr,
+		consortiumSecretaryKey.Address(),
 		false,
-		as.AddressStateBitRoleConsortiumAdminProposer,
-		test.FundedKeys[0].Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0]},
+		as.AddressStateBitRoleConsortiumSecretary,
+		rootAdminKey.Address(),
+		[]*secp256k1.PrivateKey{rootAdminKey},
 		nil,
 	)
 	require.NoError(err)
@@ -701,13 +745,26 @@ func TestAdminProposals(t *testing.T) {
 	require.NoError(err)
 	require.True(applicantAddrState.IsNot(as.AddressStateConsortium))
 
+	// Set kyc admin role
+	addrStateTx, err = vm.txBuilder.NewAddressStateTx(
+		kycAdminKey.Address(),
+		false,
+		as.AddressStateBitRoleKYCAdmin,
+		rootAdminKey.Address(),
+		[]*secp256k1.PrivateKey{rootAdminKey},
+		nil,
+	)
+	require.NoError(err)
+	blk = buildAndAcceptBlock(t, vm, addrStateTx)
+	require.Len(blk.Txs(), 1)
+	checkTx(t, vm, blk.ID(), addrStateTx.ID())
 	// Make applicant (see admin proposal below) kyc-verified
 	addrStateTx, err = vm.txBuilder.NewAddressStateTx(
 		applicantAddr,
 		false,
 		as.AddressStateBitKYCVerified,
-		test.FundedKeys[0].Address(),
-		[]*secp256k1.PrivateKey{test.FundedKeys[0]},
+		kycAdminKey.Address(),
+		[]*secp256k1.PrivateKey{kycAdminKey},
 		nil,
 	)
 	require.NoError(err)
@@ -720,8 +777,8 @@ func TestAdminProposals(t *testing.T) {
 
 	// Add admin proposal
 	chainTime := vm.state.GetTimestamp()
-	proposalTx := buildAddMemberProposalTx(t, vm, proposerKey, proposalBondAmount, fee,
-		proposerKey, applicantAddr, chainTime.Add(100*time.Second), true)
+	proposalTx := buildAddMemberProposalTx(t, vm, consortiumSecretaryKey, proposalBondAmount, fee,
+		consortiumSecretaryKey, applicantAddr, chainTime.Add(100*time.Second), true)
 	proposalState, nextProposalIDsToExpire, nexExpirationTime, proposalIDsToFinish := makeProposalWithTx(t, vm, proposalTx)
 	addMemberProposalState, ok := proposalState.(*dac.AddMemberProposalState)
 	require.True(ok)
@@ -730,7 +787,7 @@ func TestAdminProposals(t *testing.T) {
 	require.Equal(proposalState.EndTime(), nexExpirationTime)
 	require.Equal([]ids.ID{proposalTx.ID()}, proposalIDsToFinish) // admin proposal must be immediately finished
 	burnedAmt += fee
-	checkBalance(t, vm.state, proposerAddr,
+	checkBalance(t, vm.state, consortiumSecretaryKey.Address(),
 		balance-burnedAmt,                          // total
 		proposalBondAmount,                         // bonded
 		0, 0, balance-proposalBondAmount-burnedAmt, // unlocked
@@ -747,7 +804,7 @@ func TestAdminProposals(t *testing.T) {
 	proposalIDsToFinish, err = vm.state.GetProposalIDsToFinish()
 	require.NoError(err)
 	require.Empty(proposalIDsToFinish)
-	checkBalance(t, vm.state, proposerAddr,
+	checkBalance(t, vm.state, consortiumSecretaryKey.Address(),
 		balance-burnedAmt,          // total
 		0, 0, 0, balance-burnedAmt, // unlocked
 	)
@@ -764,9 +821,9 @@ func TestExcludeMemberProposals(t *testing.T) {
 	memberToExcludeNodeKey, memberToExcludeNodeShortID := test.Keys[1], test.Keys[1].Address()
 	memberToExcludeNodeID := ids.NodeID(memberToExcludeNodeShortID)
 
-	// admin & funds & proposer
 	rootAdminKey := test.FundedKeys[0]
-	consortiumAdminKey := test.FundedKeys[0]
+	kycAdminKey := test.FundedKeys[0]
+	consortiumSecretaryKey := test.FundedKeys[0]
 	proposerMemberKey := test.FundedKeys[0]
 	fundsKey := test.FundedKeys[0]
 	fundsAddr := test.FundedKeys[0].Address()
@@ -870,11 +927,11 @@ func TestExcludeMemberProposals(t *testing.T) {
 				0, 0, balance-bondedAmt, // unlocked
 			)
 
-			// give root admin consortiumAdmin role
+			// set ConsortiumSecretary role
 			addrStateTx, err := vm.txBuilder.NewAddressStateTx(
-				consortiumAdminKey.Address(),
+				consortiumSecretaryKey.Address(),
 				false,
-				as.AddressStateBitRoleConsortiumAdminProposer,
+				as.AddressStateBitRoleConsortiumSecretary,
 				rootAdminKey.Address(),
 				[]*secp256k1.PrivateKey{rootAdminKey, fundsKey},
 				nil,
@@ -899,9 +956,9 @@ func TestExcludeMemberProposals(t *testing.T) {
 			_, err = vm.state.GetShortIDLink(memberToExcludeAddr, state.ShortLinkKeyRegisterNode)
 			require.ErrorIs(err, database.ErrNotFound)
 			addrStateTx, err = vm.txBuilder.NewAddressStateTx(
-				memberToExcludeAddr,
+				kycAdminKey.Address(),
 				false,
-				as.AddressStateBitKYCVerified,
+				as.AddressStateBitRoleKYCAdmin,
 				rootAdminKey.Address(),
 				[]*secp256k1.PrivateKey{rootAdminKey},
 				nil,
@@ -918,9 +975,29 @@ func TestExcludeMemberProposals(t *testing.T) {
 				bondedAmt,                         // bonded
 				0, 0, balance-bondedAmt-burnedAmt, // unlocked
 			)
+			addrStateTx, err = vm.txBuilder.NewAddressStateTx(
+				memberToExcludeAddr,
+				false,
+				as.AddressStateBitKYCVerified,
+				kycAdminKey.Address(),
+				[]*secp256k1.PrivateKey{kycAdminKey},
+				nil,
+			)
+			require.NoError(err)
+			_ = buildAndAcceptBlock(t, vm, addrStateTx)
+			expectedHeight++
+			height, err = vm.GetCurrentHeight(context.Background())
+			require.NoError(err)
+			require.Equal(expectedHeight, height)
+			burnedAmt += fee
+			checkBalance(t, vm.state, fundsAddr,
+				balance-burnedAmt,                 // total
+				bondedAmt,                         // bonded
+				0, 0, balance-bondedAmt-burnedAmt, // unlocked
+			)
 
 			addMemberProposalTx := buildAddMemberProposalTx(t, vm, fundsKey, proposalBondAmount, defaultTxFee,
-				consortiumAdminKey, memberToExcludeAddr, vm.clock.Time(), true)
+				consortiumSecretaryKey, memberToExcludeAddr, vm.clock.Time(), true)
 			_, _, _, _ = makeProposalWithTx(t, vm, addMemberProposalTx) // add admin proposal
 			expectedHeight++
 			height, err = vm.GetCurrentHeight(context.Background())
@@ -1090,7 +1167,7 @@ func TestExcludeMemberProposals(t *testing.T) {
 
 			if tt.moreExclude {
 				excludeMemberProposalTx := buildExcludeMemberProposalTx(t, vm, fundsKey, proposalBondAmount, fee,
-					consortiumAdminKey, memberToExcludeAddr, proposalStartTime, proposalStartTime.Add(time.Duration(dac.ExcludeMemberProposalMinDuration)*time.Second), true)
+					consortiumSecretaryKey, memberToExcludeAddr, proposalStartTime, proposalStartTime.Add(time.Duration(dac.ExcludeMemberProposalMinDuration)*time.Second), true)
 				err = issueTx(t, vm, excludeMemberProposalTx)
 				require.ErrorIs(err, txexecutor.ErrInvalidProposal)
 				height, err = vm.GetCurrentHeight(context.Background())

--- a/vms/platformvm/dac/camino_add_member_proposal.go
+++ b/vms/platformvm/dac/camino_add_member_proposal.go
@@ -40,7 +40,7 @@ func (*AddMemberProposal) GetOptions() any {
 }
 
 func (*AddMemberProposal) AdminProposer() as.AddressState {
-	return as.AddressStateRoleConsortiumAdminProposer
+	return as.AddressStateRoleConsortiumSecretary
 }
 
 func (p *AddMemberProposal) Verify() error {

--- a/vms/platformvm/dac/camino_exclude_member_proposal.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal.go
@@ -47,7 +47,7 @@ func (p *ExcludeMemberProposal) GetData() any {
 }
 
 func (*ExcludeMemberProposal) AdminProposer() as.AddressState {
-	return as.AddressStateRoleConsortiumAdminProposer
+	return as.AddressStateRoleConsortiumSecretary
 }
 
 func (p *ExcludeMemberProposal) Verify() error {

--- a/vms/platformvm/dac/camino_proposal.go
+++ b/vms/platformvm/dac/camino_proposal.go
@@ -62,11 +62,12 @@ type Proposal interface {
 
 	StartTime() time.Time
 	EndTime() time.Time
-	// AddressStateEmpty means that this proposal can't be used as admin proposal
-	AdminProposer() as.AddressState
 	CreateProposalState(allowedVoters []ids.ShortID) ProposalState
 	CreateFinishedProposalState(optionIndex uint32) (ProposalState, error)
 	VerifyWith(Verifier) error
+
+	// AddressStateEmpty means that this proposal can't be used as admin proposal
+	AdminProposer() as.AddressState
 
 	// Returns proposal options. (used in magellan)
 	//

--- a/vms/platformvm/txs/executor/camino_advance_time_test.go
+++ b/vms/platformvm/txs/executor/camino_advance_time_test.go
@@ -207,6 +207,10 @@ func TestDeferredStakers(t *testing.T) {
 			subnetID := testSubnet1.ID()
 			env.config.TrackedSubnets.Add(subnetID)
 
+			addrState, err := env.state.GetAddressStates(test.FundedKeys[0].Address())
+			require.NoError(err)
+			env.state.SetAddressStates(test.FundedKeys[0].Address(), addrState|as.AddressStateRoleValidatorAdmin)
+
 			for _, staker := range tt.stakers {
 				_, err := addCaminoPendingValidator(
 					env,

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -2252,7 +2252,7 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 	}
 
 	// Verify that executor roles are allowed to modify tx.State
-	if !isPermittedToModifyAddrStateBit(roles, txAddressState) {
+	if !isPermittedToModifyAddrStateBit(isBerlinPhase, roles, txAddressState) {
 		return fmt.Errorf("%w (addr: %s, bit: %b)", errAddrStateNotPermitted, tx.Address, tx.StateBit)
 	}
 
@@ -2326,13 +2326,24 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 	return nil
 }
 
+const (
+	addressStateKYCAll   = as.AddressStateKYCVerified | as.AddressStateKYCExpired
+	addressStateRoleBits = as.AddressStateRoleAdmin | as.AddressStateRoleKYCAdmin |
+		as.AddressStateRoleConsortiumSecretary | as.AddressStateRoleOffersAdmin |
+		as.AddressStateRoleValidatorAdmin | as.AddressStateFoundationAdmin
+)
+
 // [state] must have only one bit set
-func isPermittedToModifyAddrStateBit(roles, state as.AddressState) bool {
-	const addressStateKYCAll = as.AddressStateKYCVerified | as.AddressStateKYCExpired
+func isPermittedToModifyAddrStateBit(isBerlinPhase bool, roles, state as.AddressState) bool {
 	switch {
-	case roles.Is(as.AddressStateRoleAdmin): // admin can do anything
-	case addressStateKYCAll&state != 0 && roles.Is(as.AddressStateRoleKYCAdmin): // kyc role can change kyc status
-	case state == as.AddressStateOffersCreator && roles.Is(as.AddressStateRoleOffersAdmin): // offers admin can assign offers creator role
+	// admin can do anything before BerlinPhase, after that admin can only modify other roles
+	case roles.Is(as.AddressStateRoleAdmin) && (!isBerlinPhase || addressStateRoleBits&state != 0):
+	// kyc role can change kyc status
+	case addressStateKYCAll&state != 0 && roles.Is(as.AddressStateRoleKYCAdmin):
+	// offers admin can assign offers creator role
+	case state == as.AddressStateOffersCreator && roles.Is(as.AddressStateRoleOffersAdmin):
+	// validator admin can defer or resume node
+	case state == as.AddressStateNodeDeferred && roles.Is(as.AddressStateRoleValidatorAdmin):
 	default:
 		return false
 	}

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -1480,7 +1480,7 @@ func TestCaminoRewardValidatorTx(t *testing.T) {
 	})
 }
 
-func TestCaminoStandardTxAddressStateTx(t *testing.T) {
+func TestCaminoStandardTxExecutorAddressStateTx(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.PChainID)
 	caminoGenesisConf := api.Camino{VerifyNodeSignature: true, LockModeBondDeposit: true}
 
@@ -1987,7 +1987,7 @@ func TestCaminoStandardTxAddressStateTx(t *testing.T) {
 					[]ids.ShortID{feeOwnerAddr, executorAddr}, nil)
 
 				s.EXPECT().GetAddressStates(utx.Address).Return(as.AddressStateEmpty, nil)
-				s.EXPECT().SetAddressStates(utx.Address, as.AddressStateKYCVerified)
+				s.EXPECT().SetAddressStates(utx.Address, as.AddressStateRoleKYCAdmin)
 
 				expect.ConsumeUTXOs(t, s, utx.Ins)
 				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
@@ -2003,7 +2003,7 @@ func TestCaminoStandardTxAddressStateTx(t *testing.T) {
 					},
 				}},
 				Address:      otherAddr,
-				StateBit:     as.AddressStateBitKYCVerified,
+				StateBit:     as.AddressStateBitRoleKYCAdmin,
 				ExecutorAuth: &secp256k1fx.Input{},
 			},
 			phase: phase,
@@ -2022,29 +2022,29 @@ func TestCaminoStandardTxAddressStateTx(t *testing.T) {
 			executorAddrState:      as.AddressStateRoleAdmin,
 		},
 		"OK: target state is not empty": {
-			txStateBit:             as.AddressStateBitKYCVerified,
+			txStateBit:             as.AddressStateBitRoleKYCAdmin,
 			currentTargetAddrState: as.AddressStateConsortium,
 			executorAddrState:      as.AddressStateRoleAdmin,
 		},
 		"OK: not modified": {
-			txStateBit:             as.AddressStateBitKYCVerified,
-			currentTargetAddrState: as.AddressStateKYCVerified,
+			txStateBit:             as.AddressStateBitRoleKYCAdmin,
+			currentTargetAddrState: as.AddressStateRoleKYCAdmin,
 			executorAddrState:      as.AddressStateRoleAdmin,
 		},
 		"OK: modifying executors own address state": {
 			selfModify:             true,
-			txStateBit:             as.AddressStateBitKYCVerified,
+			txStateBit:             as.AddressStateBitRoleKYCAdmin,
 			currentTargetAddrState: as.AddressStateRoleAdmin,
 			executorAddrState:      as.AddressStateRoleAdmin,
 		},
 		"OK: removal": {
-			txStateBit:             as.AddressStateBitKYCVerified,
+			txStateBit:             as.AddressStateBitRoleKYCAdmin,
 			remove:                 true,
-			currentTargetAddrState: as.AddressStateKYCVerified,
+			currentTargetAddrState: as.AddressStateRoleKYCAdmin,
 			executorAddrState:      as.AddressStateRoleAdmin,
 		},
 		"OK: removal, not modified": {
-			txStateBit:             as.AddressStateBitKYCVerified,
+			txStateBit:             as.AddressStateBitRoleKYCAdmin,
 			remove:                 true,
 			currentTargetAddrState: as.AddressStateConsortium,
 			executorAddrState:      as.AddressStateRoleAdmin,
@@ -2052,46 +2052,54 @@ func TestCaminoStandardTxAddressStateTx(t *testing.T) {
 	}
 
 	validBits := getBitsFromAddressState(as.AddressStateValidBits)
-
-	// set role-bit permissions
-	permissionsMatrix := map[as.AddressStateBit]map[as.AddressStateBit]bool{}
-	for _, role := range validBits {
-		permissionsMatrix[role] = map[as.AddressStateBit]bool{}
-		for _, bit := range validBits {
-			permissionsMatrix[role][bit] = false
-		}
-	}
-	for _, bit := range validBits {
-		permissionsMatrix[as.AddressStateBitRoleAdmin][bit] = true
-	}
-	permissionsMatrix[as.AddressStateBitRoleKYCAdmin][as.AddressStateBitKYCVerified] = true
-	permissionsMatrix[as.AddressStateBitRoleKYCAdmin][as.AddressStateBitKYCExpired] = true
-	permissionsMatrix[as.AddressStateBitRoleOffersAdmin][as.AddressStateBitOffersCreator] = true
-
-	// set phase-bit restrictions
-	bitsPhaseMatrix := map[as.AddressStateBit]map[test.Phase]error{}
-	for _, bit := range validBits {
-		bitsPhaseMatrix[bit] = map[test.Phase]error{}
-		for phase := test.PhaseFirst; phase <= test.PhaseLast; phase++ {
-			bitsPhaseMatrix[bit][phase] = nil
-		}
-	}
-	// sunriseBits := getBitsFromAddressState(as.AddressStateSunrisePhaseBits)
+	roleBits := getBitsFromAddressState(addressStateRoleBits)
 	athensBits := getBitsFromAddressState(as.AddressStateAthensPhaseBits)
 	berlinBits := getBitsFromAddressState(as.AddressStateBerlinPhaseBits)
-	for _, bit := range athensBits {
-		for phase := test.PhaseFirst; phase < test.PhaseAthens; phase++ {
-			bitsPhaseMatrix[bit][phase] = errNotAthensPhase
-		}
-	}
-	for _, bit := range berlinBits {
-		for phase := test.PhaseFirst; phase < test.PhaseBerlin; phase++ {
-			bitsPhaseMatrix[bit][phase] = errNotBerlinPhase
-		}
-	}
-	bitsPhaseMatrix[as.AddressStateBitConsortium][test.PhaseBerlin] = errBerlinPhase
 
-	// set phase-txUpgrade restrictions := getBitsFromAddressState(as.AddressStateSunrisePhaseBits)
+	// set phase-role-bit permissions
+	permissionsMatrix := map[test.Phase]map[as.AddressStateBit]map[as.AddressStateBit]error{}
+	for phase := test.PhaseFirst; phase <= test.PhaseLast; phase++ {
+		permissionsMatrix[phase] = make(map[as.AddressStateBit]map[as.AddressStateBit]error)
+	}
+	for _, permissionsMatrix := range permissionsMatrix {
+		for _, role := range validBits {
+			permissionsMatrix[role] = map[as.AddressStateBit]error{}
+			for _, bit := range validBits {
+				permissionsMatrix[role][bit] = errAddrStateNotPermitted
+			}
+		}
+	}
+	for phase := test.PhaseFirst; phase < test.PhaseBerlin; phase++ {
+		for _, bit := range validBits {
+			permissionsMatrix[phase][as.AddressStateBitRoleAdmin][bit] = nil
+		}
+	}
+	for phase := test.PhaseBerlin; phase <= test.PhaseLast; phase++ {
+		for _, bit := range roleBits {
+			permissionsMatrix[phase][as.AddressStateBitRoleAdmin][bit] = nil
+		}
+	}
+	for _, permissionsMatrix := range permissionsMatrix {
+		permissionsMatrix[as.AddressStateBitRoleKYCAdmin][as.AddressStateBitKYCVerified] = nil
+		permissionsMatrix[as.AddressStateBitRoleKYCAdmin][as.AddressStateBitKYCExpired] = nil
+		permissionsMatrix[as.AddressStateBitRoleOffersAdmin][as.AddressStateBitOffersCreator] = nil
+		permissionsMatrix[as.AddressStateBitRoleValidatorAdmin][as.AddressStateBitNodeDeferred] = nil
+	}
+	for _, role := range validBits {
+		for phase := test.PhaseFirst; phase < test.PhaseAthens; phase++ {
+			for _, bit := range athensBits {
+				permissionsMatrix[phase][role][bit] = errNotAthensPhase
+			}
+		}
+		for phase := test.PhaseFirst; phase < test.PhaseBerlin; phase++ {
+			for _, bit := range berlinBits {
+				permissionsMatrix[phase][role][bit] = errNotBerlinPhase
+			}
+		}
+		permissionsMatrix[test.PhaseBerlin][role][as.AddressStateBitConsortium] = errBerlinPhase
+	}
+
+	// set phase-txUpgrade restrictions
 	txUpgradeMatrix := map[test.Phase][]codec.UpgradeVersionID{}
 	for phase := test.PhaseFirst; phase < test.PhaseBerlin; phase++ {
 		txUpgradeMatrix[phase] = append(txUpgradeMatrix[phase], codec.UpgradeVersion0)
@@ -2100,15 +2108,13 @@ func TestCaminoStandardTxAddressStateTx(t *testing.T) {
 		txUpgradeMatrix[phase] = append(txUpgradeMatrix[phase], codec.UpgradeVersion1)
 	}
 
-	for role, permissions := range permissionsMatrix {
-		for bit, allowed := range permissions {
-			if allowed {
-				for phase := test.PhaseFirst; phase <= test.PhaseLast; phase++ {
-					if bitsPhaseMatrix[bit][phase] != nil {
-						continue
-					}
-					txUpgrades := txUpgradeMatrix[phase]
-					for _, txUpgrade := range txUpgrades {
+	for phase, permissionsMatrix := range permissionsMatrix {
+		for role, permissions := range permissionsMatrix {
+			for bit, expectedErr := range permissions {
+				txUpgrades := txUpgradeMatrix[phase]
+				for _, txUpgrade := range txUpgrades {
+					switch expectedErr {
+					case nil:
 						if bit == as.AddressStateBitConsortium {
 							// resume node, defer is tested below
 							testCaseOK[txUpgrade](t, testData{
@@ -2121,35 +2127,16 @@ func TestCaminoStandardTxAddressStateTx(t *testing.T) {
 							txStateBit:        bit,
 							executorAddrState: role.ToAddressState(),
 						}, fmt.Sprintf("OK: (%0d) modifies (%0d)", role, bit), phase)
-					}
-				}
-			} else {
-				for phase := test.PhaseFirst; phase <= test.PhaseLast; phase++ {
-					if bitsPhaseMatrix[bit][phase] != nil {
-						continue
-					}
-					txUpgrades := txUpgradeMatrix[phase]
-					for _, txUpgrade := range txUpgrades {
+					case errAddrStateNotPermitted:
 						testCaseFailNoPermission[txUpgrade](t, testData{
 							txStateBit:        bit,
 							executorAddrState: role.ToAddressState(),
 						}, fmt.Sprintf("Fail: (%0d) modifies (%0d)", role, bit), phase)
+					default:
+						testCaseFailBitForbidden[txUpgrade](t, testData{txStateBit: bit},
+							fmt.Sprintf("Fail: (%0d) modifies (%0d), forbidden by phase", bit, role), expectedErr, phase)
 					}
 				}
-			}
-		}
-	}
-
-	for _, bit := range validBits {
-		for phase := test.PhaseFirst; phase <= test.PhaseLast; phase++ {
-			expectedErr := bitsPhaseMatrix[bit][phase]
-			if expectedErr == nil {
-				continue
-			}
-			txUpgrades := txUpgradeMatrix[phase]
-			for _, txUpgrade := range txUpgrades {
-				testCaseFailBitForbidden[txUpgrade](t, testData{txStateBit: bit},
-					fmt.Sprintf("Forbid bit %d", bit), expectedErr, phase)
 			}
 		}
 	}
@@ -6229,7 +6216,7 @@ func TestCaminoStandardTxExecutorAddProposalTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(caminoStateConf, nil)
 				s.EXPECT().GetTimestamp().Return(cfg.BerlinPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateRoleConsortiumAdminProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateRoleConsortiumSecretary, nil)
 				expect.VerifyMultisigPermission(t, s, []ids.ShortID{utx.ProposerAddress}, nil)
 
 				// * proposal verifier

--- a/vms/platformvm/txs/executor/dac/camino_dac.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac.go
@@ -103,7 +103,7 @@ func (e *proposalVerifier) BaseFeeProposal(*dac.BaseFeeProposal) error {
 		return err
 	}
 
-	if proposerAddressState.IsNot(as.AddressStateCaminoProposer) {
+	if proposerAddressState.IsNot(as.AddressStateFoundationAdmin) {
 		return errNotPermittedToCreateProposal
 	}
 
@@ -372,7 +372,7 @@ func (e *proposalVerifier) FeeDistributionProposal(*dac.FeeDistributionProposal)
 		return err
 	}
 
-	if proposerAddressState.IsNot(as.AddressStateCaminoProposer) {
+	if proposerAddressState.IsNot(as.AddressStateFoundationAdmin) {
 		return errNotPermittedToCreateProposal
 	}
 

--- a/vms/platformvm/txs/executor/dac/camino_dac_test.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac_test.go
@@ -83,11 +83,11 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 			},
 			expectedErr: errNotCairoPhase,
 		},
-		"Proposer isn't caminoProposer": {
+		"Proposer isn't FoundationAdmin": {
 			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateCaminoProposer
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateFoundationAdmin
 				return s
 			},
 			config: defaultConfig,
@@ -113,7 +113,7 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Release()
 
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateFoundationAdmin, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
@@ -140,7 +140,7 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Error().Return(nil)
 
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateFoundationAdmin, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
@@ -355,7 +355,7 @@ func TestProposalVerifierAddMemberProposal(t *testing.T) {
 
 func TestProposalExecutorAddMemberProposal(t *testing.T) {
 	applicantAddress := ids.ShortID{1}
-	applicantAddressState := as.AddressStateCaminoProposer // just not empty
+	applicantAddressState := as.AddressStateFoundationAdmin // just not empty
 
 	tests := map[string]struct {
 		state       func(*gomock.Controller) *state.MockDiff
@@ -617,7 +617,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 
 func TestProposalExecutorExcludeMemberProposal(t *testing.T) {
 	memberAddress := ids.ShortID{1}
-	memberAddressState := as.AddressStateCaminoProposer | as.AddressStateConsortium // just not only c-member
+	memberAddressState := as.AddressStateFoundationAdmin | as.AddressStateConsortium // just not only c-member
 	memberNodeShortID := ids.ShortID{2}
 	memberNodeID := ids.NodeID(memberNodeShortID)
 	memberValidator := &state.Staker{TxID: ids.ID{3}}
@@ -923,11 +923,11 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 			},
 			expectedErr: errNotCairoPhase,
 		},
-		"Proposer isn't caminoProposer": {
+		"Proposer isn't FoundationAdmin": {
 			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateCaminoProposer
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateFoundationAdmin
 				return s
 			},
 			config: defaultConfig,
@@ -953,7 +953,7 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Release()
 
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateFoundationAdmin, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
@@ -980,7 +980,7 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Error().Return(nil)
 
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateFoundationAdmin, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},


### PR DESCRIPTION
## Why this should be merged
This PR improves addr state roles permissions segregation:
- starting with BerlinPhase, AddressStateRoleAdmin can only modify role bits.
-  new role AddressStateRoleValidatorAdmin can defer/resume node.

There also some renamings to address states.
## How this works
In addition to changes in address state permissions logic, there are some changes in tests:
- integration tests where changed in accordance with permission changes
- AddressStateTx executor unit-test is changed in order to accommodate new for new possibility: that some role may have different rights in different phases.
## How this was tested
With existing unit-tests and integration tests.