### PR TITLE
[PVM] Disable baseFee and feeDistribution proposal before CairoPhase 

### DIFF
--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -521,7 +521,7 @@ func TestProposals(t *testing.T) {
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
 				InitialAdmin:        test.FundedKeys[0].Address(),
-			}, test.PhaseLast, []api.UTXO{
+			}, test.PhaseCairo, []api.UTXO{ // TODO @evlekht replace with PhaseLast when cairo is added
 				{
 					Amount:  json.Uint64(balance),
 					Address: proposerAddrStr,

--- a/vms/platformvm/config/config.go
+++ b/vms/platformvm/config/config.go
@@ -124,6 +124,9 @@ type Config struct {
 	// Time of the BerlinPhase network upgrade
 	BerlinPhaseTime time.Time
 
+	// Time of the CairoPhase network upgrade
+	CairoPhaseTime time.Time
+
 	// Camino relevant configuration
 	CaminoConfig caminoconfig.Config
 	// UseCurrentHeight forces [GetMinimumHeight] to return the current height
@@ -162,6 +165,10 @@ func (c *Config) IsAthensPhaseActivated(timestamp time.Time) bool {
 
 func (c *Config) IsBerlinPhaseActivated(timestamp time.Time) bool {
 	return !timestamp.Before(c.BerlinPhaseTime)
+}
+
+func (c *Config) IsCairoPhaseActivated(timestamp time.Time) bool {
+	return !timestamp.Before(c.CairoPhaseTime)
 }
 
 func (c *Config) GetCreateBlockchainTxFee(timestamp time.Time) uint64 {

--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -20,7 +20,7 @@ import (
 const (
 	generalProposalMaxOptionsCount = 3
 	generalProposalMaxOptionSize   = 256
-	generalProposalMinDuration     = uint64(time.Hour * 24 / time.Second)      // 1 day
+	GeneralProposalMinDuration     = uint64(time.Hour * 24 / time.Second)      // 1 day
 	generalProposalMaxDuration     = uint64(time.Hour * 24 * 30 / time.Second) // 1 month
 )
 
@@ -76,8 +76,8 @@ func (p *GeneralProposal) Verify() error {
 		return fmt.Errorf("%w (expected: no more than %d, actual: %d)", errWrongOptionsCount, generalProposalMaxOptionsCount, len(p.Options))
 	case p.Start >= p.End:
 		return errEndNotAfterStart
-	case p.End-p.Start < generalProposalMinDuration:
-		return fmt.Errorf("%w (expected: minimum duration %d, actual: %d)", errWrongDuration, generalProposalMinDuration, p.End-p.Start)
+	case p.End-p.Start < GeneralProposalMinDuration:
+		return fmt.Errorf("%w (expected: minimum duration %d, actual: %d)", errWrongDuration, GeneralProposalMinDuration, p.End-p.Start)
 	case p.End-p.Start > generalProposalMaxDuration:
 		return fmt.Errorf("%w (expected: maximum duration %d, actual: %d)", errWrongDuration, generalProposalMaxDuration, p.End-p.Start)
 	}

--- a/vms/platformvm/dac/camino_general_proposal_test.go
+++ b/vms/platformvm/dac/camino_general_proposal_test.go
@@ -72,12 +72,12 @@ func TestGeneralProposalVerify(t *testing.T) {
 		"To small duration": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration - 1,
+				End:     100 + GeneralProposalMinDuration - 1,
 				Options: [][]byte{{1}, {2}, {3}},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration - 1,
+				End:     100 + GeneralProposalMinDuration - 1,
 				Options: [][]byte{{1}, {2}, {3}},
 			},
 			expectedErr: errWrongDuration,
@@ -98,12 +98,12 @@ func TestGeneralProposalVerify(t *testing.T) {
 		"Option is bigger than allowed": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize+1)},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize+1)},
 			},
 			expectedErr: errGeneralProposalOptionIsToBig,
@@ -111,12 +111,12 @@ func TestGeneralProposalVerify(t *testing.T) {
 		"Not unique option": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{{1}, {2}, {1}},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{{1}, {2}, {1}},
 			},
 			expectedErr: errNotUniqueOption,
@@ -124,24 +124,24 @@ func TestGeneralProposalVerify(t *testing.T) {
 		"OK: 1 option": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize)},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize)},
 			},
 		},
 		"OK: 3 options": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{{1}, {2}, {3}},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{{1}, {2}, {3}},
 			},
 		},

--- a/vms/platformvm/test/camino_defaults.go
+++ b/vms/platformvm/test/camino_defaults.go
@@ -69,11 +69,15 @@ func Config(t *testing.T, phase Phase) *config.Config {
 		cortinaTime       = mockable.MaxTime
 		berlinTime        = mockable.MaxTime
 		durangoTime       = mockable.MaxTime
+		cairoTime         = mockable.MaxTime
 	)
 
 	// always reset LatestForkTime (a package level variable)
 	// to ensure test independence
 	switch phase {
+	case PhaseCairo:
+		cairoTime = LatestPhaseTime
+		fallthrough
 	case PhaseDurango:
 		durangoTime = LatestPhaseTime
 		fallthrough
@@ -117,6 +121,7 @@ func Config(t *testing.T, phase Phase) *config.Config {
 		CortinaTime:            cortinaTime,
 		BerlinPhaseTime:        berlinTime,
 		DurangoTime:            durangoTime,
+		CairoPhaseTime:         cairoTime,
 		CaminoConfig: caminoconfig.Config{
 			DACProposalBondAmount: 100 * units.Avax,
 		},

--- a/vms/platformvm/test/camino_phase.go
+++ b/vms/platformvm/test/camino_phase.go
@@ -21,6 +21,7 @@ const (
 	PhaseAthens   Phase = 2
 	PhaseCortina  Phase = 3 // avax, included into Berlin phase
 	PhaseBerlin   Phase = 3
+	PhaseCairo    Phase = 4
 	PhaseDurango  Phase = math.MaxInt // avax
 )
 
@@ -39,6 +40,8 @@ func PhaseTime(t *testing.T, phase Phase, cfg *config.Config) time.Time {
 		return cfg.AthensPhaseTime
 	case PhaseBerlin:
 		return cfg.BerlinPhaseTime
+	case PhaseCairo:
+		return cfg.CairoPhaseTime
 	}
 	require.FailNow(t, "unknown phase")
 	return time.Time{}
@@ -52,6 +55,8 @@ func PhaseName(t *testing.T, phase Phase) string {
 		return "AthensPhase"
 	case PhaseBerlin:
 		return "BerlinPhase"
+	case PhaseCairo:
+		return "CairoPhase"
 	}
 	require.FailNow(t, "unknown phase")
 	return ""

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1788,7 +1788,7 @@ func (e *CaminoStandardTxExecutor) AddProposalTx(tx *txs.AddProposalTx) error {
 		return fmt.Errorf("%w: %w", errProposerCredentialMismatch, err)
 	}
 
-	if err := txProposal.VerifyWith(dac.NewProposalVerifier(e.State, tx, isAdminProposal)); err != nil {
+	if err := txProposal.VerifyWith(dac.NewProposalVerifier(e.Config, e.State, tx, isAdminProposal)); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidProposal, err)
 	}
 
@@ -1821,7 +1821,6 @@ func (e *CaminoStandardTxExecutor) AddProposalTx(tx *txs.AddProposalTx) error {
 	var proposalState dacProposals.ProposalState
 
 	if isAdminProposal {
-		// currently we only have addMember and excludeMember proposals, and their option 0 is "success" option
 		proposalState, err = txProposal.CreateFinishedProposalState(adminProposal.OptionIndex)
 		if err != nil {
 			// should never happen

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -5900,9 +5900,10 @@ func TestCaminoStandardTxExecutorAddProposalTx(t *testing.T) {
 	bondUTXO := generate.UTXO(ids.ID{1, 2, 3, 4, 6}, ctx.AVAXAssetID, proposalBondAmt, bondOwner, ids.Empty, ids.Empty, true)
 
 	applicantAddress := ids.ShortID{1, 1, 1}
+	proposerNodeShortID := ids.ShortID{2, 2, 2}
 
-	proposalWrapper := &txs.ProposalWrapper{Proposal: &dac.BaseFeeProposal{
-		Start: 100, End: 101, Options: []uint64{1},
+	proposalWrapper := &txs.ProposalWrapper{Proposal: &dac.GeneralProposal{
+		Start: 100, End: 100 + dac.GeneralProposalMinDuration, Options: [][]byte{{}},
 	}}
 	proposalBytes, err := txs.Codec.Marshal(txs.CodecVersion, proposalWrapper)
 	require.NoError(t, err)
@@ -6142,7 +6143,7 @@ func TestCaminoStandardTxExecutorAddProposalTx(t *testing.T) {
 				s.EXPECT().CaminoConfig().Return(caminoStateConf, nil)
 				s.EXPECT().GetTimestamp().Return(cfg.BerlinPhaseTime)
 				expect.VerifyMultisigPermission(t, s, []ids.ShortID{utx.ProposerAddress}, nil)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateCaminoProposer
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateConsortium
 				return s
 			},
 			utx: func(cfg *config.Config) *txs.AddProposalTx {
@@ -6183,13 +6184,11 @@ func TestCaminoStandardTxExecutorAddProposalTx(t *testing.T) {
 				expect.VerifyMultisigPermission(t, s, []ids.ShortID{utx.ProposerAddress}, nil)
 
 				// * proposal verifier
-				proposalsIterator := state.NewMockProposalsIterator(c)
-				proposalsIterator.EXPECT().Next().Return(false)
-				proposalsIterator.EXPECT().Release()
-				proposalsIterator.EXPECT().Error().Return(nil)
-
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
-				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortium, nil)
+				s.EXPECT().GetShortIDLink(utx.ProposerAddress, state.ShortLinkKeyRegisterNode).
+					Return(proposerNodeShortID, nil)
+				s.EXPECT().GetCurrentValidator(constants.PrimaryNetworkID, ids.NodeID(proposerNodeShortID)).
+					Return(&state.Staker{}, nil)
 				// *
 
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)

--- a/vms/platformvm/txs/executor/dac/camino_dac_test.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -27,6 +28,8 @@ import (
 
 func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.PChainID)
+	// TODO @evlekht replace with test.PhaseLast when cairo phase will be added as last
+	defaultConfig := test.Config(t, test.PhaseCairo)
 
 	feeOwnerKey, _, feeOwner := generate.KeyAndOwner(t, test.Keys[0])
 	bondOwnerKey, _, bondOwner := generate.KeyAndOwner(t, test.Keys[1])
@@ -53,18 +56,41 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 	}}
 
 	tests := map[string]struct {
-		state           func(*gomock.Controller, *txs.AddProposalTx) *state.MockDiff
+		state           func(*gomock.Controller, *txs.AddProposalTx, *config.Config) *state.MockDiff
+		config          *config.Config
 		utx             func() *txs.AddProposalTx
 		signers         [][]*secp256k1.PrivateKey
 		isAdminProposal bool
 		expectedErr     error
 	}{
-		"Proposer isn't caminoProposer": {
-			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
+		"Not CairoPhase": {
+			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
+				s.EXPECT().GetTimestamp().Return(cfg.BerlinPhaseTime)
+				return s
+			},
+			config: test.Config(t, test.PhaseBerlin),
+			utx: func() *txs.AddProposalTx {
+				return &txs.AddProposalTx{
+					BaseTx:          baseTx,
+					ProposalPayload: proposalBytes,
+					ProposerAddress: proposerAddr,
+					ProposerAuth:    &secp256k1fx.Input{SigIndices: []uint32{0}},
+				}
+			},
+			signers: [][]*secp256k1.PrivateKey{
+				{feeOwnerKey}, {bondOwnerKey}, {proposerKey},
+			},
+			expectedErr: errNotCairoPhase,
+		},
+		"Proposer isn't caminoProposer": {
+			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
 				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateCaminoProposer
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -79,17 +105,19 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 			expectedErr: errNotPermittedToCreateProposal,
 		},
 		"Already active BaseFeeProposal": {
-			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
+			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				proposalsIterator := state.NewMockProposalsIterator(c)
 				proposalsIterator.EXPECT().Next().Return(true)
 				proposalsIterator.EXPECT().Value().Return(&dac.BaseFeeProposalState{}, nil)
 				proposalsIterator.EXPECT().Release()
 
+				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
 				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -104,17 +132,19 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 			expectedErr: errAlreadyActiveProposal,
 		},
 		"OK": {
-			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
+			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				proposalsIterator := state.NewMockProposalsIterator(c)
 				proposalsIterator.EXPECT().Next().Return(false)
 				proposalsIterator.EXPECT().Release()
 				proposalsIterator.EXPECT().Error().Return(nil)
 
+				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
 				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -136,7 +166,12 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 
 			proposal, err := utx.Proposal()
 			require.NoError(t, err)
-			err = proposal.VerifyWith(NewProposalVerifier(tt.state(gomock.NewController(t), utx), utx, tt.isAdminProposal))
+			err = proposal.VerifyWith(NewProposalVerifier(
+				tt.config,
+				tt.state(gomock.NewController(t), utx, tt.config),
+				utx,
+				tt.isAdminProposal,
+			))
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}
@@ -173,6 +208,7 @@ func TestProposalExecutorBaseFeeProposal(t *testing.T) {
 
 func TestProposalVerifierAddMemberProposal(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.PChainID)
+	defaultConfig := test.Config(t, test.PhaseLast)
 
 	feeOwnerKey, _, feeOwner := generate.KeyAndOwner(t, test.Keys[0])
 	bondOwnerKey, _, bondOwner := generate.KeyAndOwner(t, test.Keys[1])
@@ -201,6 +237,7 @@ func TestProposalVerifierAddMemberProposal(t *testing.T) {
 
 	tests := map[string]struct {
 		state           func(*gomock.Controller, *txs.AddProposalTx) *state.MockDiff
+		config          *config.Config
 		utx             func() *txs.AddProposalTx
 		signers         [][]*secp256k1.PrivateKey
 		isAdminProposal bool
@@ -212,6 +249,7 @@ func TestProposalVerifierAddMemberProposal(t *testing.T) {
 				s.EXPECT().GetAddressStates(applicantAddress).Return(as.AddressStateConsortium, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -256,6 +294,7 @@ func TestProposalVerifierAddMemberProposal(t *testing.T) {
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -281,6 +320,7 @@ func TestProposalVerifierAddMemberProposal(t *testing.T) {
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -302,7 +342,12 @@ func TestProposalVerifierAddMemberProposal(t *testing.T) {
 
 			proposal, err := utx.Proposal()
 			require.NoError(t, err)
-			err = proposal.VerifyWith(NewProposalVerifier(tt.state(gomock.NewController(t), utx), utx, tt.isAdminProposal))
+			err = proposal.VerifyWith(NewProposalVerifier(
+				tt.config,
+				tt.state(gomock.NewController(t), utx),
+				utx,
+				tt.isAdminProposal,
+			))
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}
@@ -343,6 +388,7 @@ func TestProposalExecutorAddMemberProposal(t *testing.T) {
 
 func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.PChainID)
+	defaultConfig := test.Config(t, test.PhaseLast)
 
 	feeOwnerKey, _, feeOwner := generate.KeyAndOwner(t, test.Keys[0])
 	bondOwnerKey, _, bondOwner := generate.KeyAndOwner(t, test.Keys[1])
@@ -374,6 +420,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 
 	tests := map[string]struct {
 		state           func(*gomock.Controller, *txs.AddProposalTx) *state.MockDiff
+		config          *config.Config
 		utx             func() *txs.AddProposalTx
 		signers         [][]*secp256k1.PrivateKey
 		isAdminProposal bool
@@ -385,6 +432,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateEmpty, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -405,6 +453,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -426,6 +475,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				s.EXPECT().GetShortIDLink(utx.ProposerAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortEmpty, database.ErrNotFound)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -448,6 +498,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				s.EXPECT().GetCurrentValidator(constants.PrimaryNetworkID, memberNodeID).Return(nil, database.ErrNotFound)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -476,6 +527,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -501,6 +553,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -529,6 +582,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -550,7 +604,12 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 
 			proposal, err := utx.Proposal()
 			require.NoError(t, err)
-			err = proposal.VerifyWith(NewProposalVerifier(tt.state(gomock.NewController(t), utx), utx, tt.isAdminProposal))
+			err = proposal.VerifyWith(NewProposalVerifier(
+				tt.config,
+				tt.state(gomock.NewController(t), utx),
+				utx,
+				tt.isAdminProposal,
+			))
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}
@@ -809,6 +868,8 @@ func TestGetBondTxIDs(t *testing.T) {
 
 func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 	ctx := snowtest.Context(t, snowtest.PChainID)
+	// TODO @evlekht replace with test.PhaseLast when cairo phase will be added as last
+	defaultConfig := test.Config(t, test.PhaseCairo)
 
 	feeOwnerKey, _, feeOwner := generate.KeyAndOwner(t, test.Keys[0])
 	bondOwnerKey, _, bondOwner := generate.KeyAndOwner(t, test.Keys[1])
@@ -835,18 +896,41 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 	}}
 
 	tests := map[string]struct {
-		state           func(*gomock.Controller, *txs.AddProposalTx) *state.MockDiff
+		state           func(*gomock.Controller, *txs.AddProposalTx, *config.Config) *state.MockDiff
+		config          *config.Config
 		utx             func() *txs.AddProposalTx
 		signers         [][]*secp256k1.PrivateKey
 		isAdminProposal bool
 		expectedErr     error
 	}{
-		"Proposer isn't caminoProposer": {
-			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
+		"Not CairoPhase": {
+			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
+				s.EXPECT().GetTimestamp().Return(cfg.BerlinPhaseTime)
+				return s
+			},
+			config: test.Config(t, test.PhaseBerlin),
+			utx: func() *txs.AddProposalTx {
+				return &txs.AddProposalTx{
+					BaseTx:          baseTx,
+					ProposalPayload: proposalBytes,
+					ProposerAddress: proposerAddr,
+					ProposerAuth:    &secp256k1fx.Input{SigIndices: []uint32{0}},
+				}
+			},
+			signers: [][]*secp256k1.PrivateKey{
+				{feeOwnerKey}, {bondOwnerKey}, {proposerKey},
+			},
+			expectedErr: errNotCairoPhase,
+		},
+		"Proposer isn't caminoProposer": {
+			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
 				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateCaminoProposer
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -861,17 +945,19 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 			expectedErr: errNotPermittedToCreateProposal,
 		},
 		"Already active FeeDistributionProposal": {
-			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
+			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				proposalsIterator := state.NewMockProposalsIterator(c)
 				proposalsIterator.EXPECT().Next().Return(true)
 				proposalsIterator.EXPECT().Value().Return(&dac.FeeDistributionProposalState{}, nil)
 				proposalsIterator.EXPECT().Release()
 
+				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
 				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -886,17 +972,19 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 			expectedErr: errAlreadyActiveProposal,
 		},
 		"OK": {
-			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
+			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				proposalsIterator := state.NewMockProposalsIterator(c)
 				proposalsIterator.EXPECT().Next().Return(false)
 				proposalsIterator.EXPECT().Release()
 				proposalsIterator.EXPECT().Error().Return(nil)
 
+				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
 				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
+			config: defaultConfig,
 			utx: func() *txs.AddProposalTx {
 				return &txs.AddProposalTx{
 					BaseTx:          baseTx,
@@ -918,7 +1006,12 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 
 			proposal, err := utx.Proposal()
 			require.NoError(t, err)
-			err = proposal.VerifyWith(NewProposalVerifier(tt.state(gomock.NewController(t), utx), utx, tt.isAdminProposal))
+			err = proposal.VerifyWith(NewProposalVerifier(
+				tt.config,
+				tt.state(gomock.NewController(t), utx, tt.config),
+				utx,
+				tt.isAdminProposal,
+			))
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
 	}


### PR DESCRIPTION
## Why this should be merged
BaseFee and FeeDistribution proposals are still missing some cross-chain logic, so we don't want them to be active now.
This PR disables those proposals till the next phase.
## How this works
Add check for cairo phase in baseFee and feeDistribution proposal verifier.
## How this was tested
With existing unit-tests and integration tests with addition of some new test cases.