### PR TITLE
[PVM] replace nil-signers Sign with Initialize, make syncGenesis private

### DIFF
--- a/vms/platformvm/api/camino.go
+++ b/vms/platformvm/api/camino.go
@@ -233,7 +233,7 @@ func buildCaminoGenesis(args *BuildGenesisArgs, reply *BuildGenesisReply) error 
 			GenesisData: genesisBytes,
 			SubnetAuth:  &secp256k1fx.Input{},
 		}}
-		if err := tx.Sign(txs.GenesisCodec, nil); err != nil {
+		if err := tx.Initialize(txs.GenesisCodec); err != nil {
 			return err
 		}
 
@@ -246,7 +246,7 @@ func buildCaminoGenesis(args *BuildGenesisArgs, reply *BuildGenesisReply) error 
 	for _, genesisBlock := range genesisBlocks {
 		if len(genesisBlock.UnlockedUTXOsTxs) != 0 {
 			tx := genesisBlock.UnlockedUTXOsTxs[0]
-			if err := tx.Sign(txs.GenesisCodec, nil); err != nil {
+			if err := tx.Initialize(txs.GenesisCodec); err != nil {
 				return err
 			}
 
@@ -351,7 +351,7 @@ func makeValidator(
 		},
 		NodeOwnerAuth: &secp256k1fx.Input{},
 	}}
-	if err := tx.Sign(txs.GenesisCodec, nil); err != nil {
+	if err := tx.Initialize(txs.GenesisCodec); err != nil {
 		return nil, err
 	}
 
@@ -428,7 +428,7 @@ func makeUTXOAndDeposit(
 			DepositDuration: uint32(deposit.Duration),
 			RewardsOwner:    &owner,
 		}}
-		if err := depositTx.Sign(txs.GenesisCodec, nil); err != nil {
+		if err := depositTx.Initialize(txs.GenesisCodec); err != nil {
 			return nil, nil, err
 		}
 

--- a/vms/platformvm/api/camino_test.go
+++ b/vms/platformvm/api/camino_test.go
@@ -154,7 +154,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 					},
 					Creds: []verify.Verifiable{},
 				}
-				require.NoError(t, validatorTx.Sign(txs.GenesisCodec, nil))
+				require.NoError(t, validatorTx.Initialize(txs.GenesisCodec))
 
 				validatorDepositTx := &txs.Tx{
 					Unsigned: &txs.DepositTx{
@@ -207,7 +207,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 					},
 					Creds: []verify.Verifiable{},
 				}
-				require.NoError(t, validatorDepositTx.Sign(txs.GenesisCodec, nil))
+				require.NoError(t, validatorDepositTx.Initialize(txs.GenesisCodec))
 
 				depositTx := &txs.Tx{
 					Unsigned: &txs.DepositTx{
@@ -244,7 +244,7 @@ func TestBuildCaminoGenesis(t *testing.T) {
 					},
 					Creds: []verify.Verifiable{},
 				}
-				require.NoError(t, depositTx.Sign(txs.GenesisCodec, nil))
+				require.NoError(t, depositTx.Initialize(txs.GenesisCodec))
 
 				return &genesis.Genesis{
 					Timestamp:     5,

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -59,17 +59,17 @@ type Block struct {
 
 func (b *Block) Init() error {
 	for _, tx := range b.Validators {
-		if err := tx.Sign(txs.GenesisCodec, nil); err != nil {
+		if err := tx.Initialize(txs.GenesisCodec); err != nil {
 			return err
 		}
 	}
 	for _, tx := range b.Deposits {
-		if err := tx.Sign(txs.GenesisCodec, nil); err != nil {
+		if err := tx.Initialize(txs.GenesisCodec); err != nil {
 			return err
 		}
 	}
 	for _, tx := range b.UnlockedUTXOsTxs {
-		if err := tx.Sign(txs.GenesisCodec, nil); err != nil {
+		if err := tx.Initialize(txs.GenesisCodec); err != nil {
 			return err
 		}
 	}

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -160,10 +160,11 @@ type CaminoState interface {
 	CaminoDiff
 
 	CaminoConfig() *CaminoConfig
-	SyncGenesis(*state, *genesis.Genesis) error
 	Load(*state) error
 	Write() error
 	Close() error
+
+	syncGenesis(*state, *genesis.Genesis) error
 }
 
 type CaminoConfig struct {
@@ -358,7 +359,7 @@ func (cs *caminoState) CaminoConfig() *CaminoConfig {
 }
 
 // Extract camino tag from genesis
-func (cs *caminoState) SyncGenesis(s *state, g *genesis.Genesis) error {
+func (cs *caminoState) syncGenesis(s *state, g *genesis.Genesis) error {
 	cs.genesisSynced = true
 	cs.lockModeBondDeposit = g.Camino.LockModeBondDeposit
 	cs.verifyNodeSignature = g.Camino.VerifyNodeSignature

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -280,7 +280,7 @@ func TestSyncGenesis(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(tt.args.g.Camino.Init())
-			err := tt.cs.SyncGenesis(tt.args.s, tt.args.g)
+			err := tt.cs.syncGenesis(tt.args.s, tt.args.g)
 			require.ErrorIs(tt.err, err)
 
 			require.Len(tt.cs.modifiedDeposits, len(tt.want.modifiedDeposits))

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1838,7 +1838,7 @@ func (s *state) init(genesisBytes []byte) error {
 		return err
 	}
 
-	if err := s.caminoState.SyncGenesis(s, genesis); err != nil {
+	if err := s.caminoState.syncGenesis(s, genesis); err != nil {
 		return err
 	}
 

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -279,13 +279,12 @@ func (b *caminoBuilder) NewRewardValidatorTx(txID ids.ID) (*txs.Tx, error) {
 		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
 	}
 
-	utx := &txs.CaminoRewardValidatorTx{
+	tx := &txs.Tx{Unsigned: &txs.CaminoRewardValidatorTx{
 		RewardValidatorTx: txs.RewardValidatorTx{TxID: txID},
 		Ins:               ins,
 		Outs:              outs,
-	}
-	tx, err := txs.NewSigned(utx, txs.Codec, nil)
-	if err != nil {
+	}}
+	if err := tx.Initialize(txs.Codec); err != nil {
 		return nil, err
 	}
 
@@ -621,15 +620,14 @@ func (b *caminoBuilder) NewRewardsImportTx() (*txs.Tx, error) {
 
 	avax.SortTransferableInputs(ins)
 
-	utx := &txs.RewardsImportTx{
+	tx := &txs.Tx{Unsigned: &txs.RewardsImportTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.ctx.NetworkID,
 			BlockchainID: b.ctx.ChainID,
 			Ins:          ins,
 		}},
-	}
-	tx, err := txs.NewSigned(utx, txs.Codec, nil)
-	if err != nil {
+	}}
+	if err := tx.Initialize(txs.Codec); err != nil {
 		return nil, err
 	}
 
@@ -644,17 +642,15 @@ func (b *caminoBuilder) NewSystemUnlockDepositTx(
 		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
 	}
 
-	utx := &txs.UnlockDepositTx{
+	tx := &txs.Tx{Unsigned: &txs.UnlockDepositTx{
 		BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 			NetworkID:    b.ctx.NetworkID,
 			BlockchainID: b.ctx.ChainID,
 			Ins:          ins,
 			Outs:         outs,
 		}},
-	}
-
-	tx, err := txs.NewSigned(utx, txs.Codec, nil)
-	if err != nil {
+	}}
+	if err := tx.Initialize(txs.Codec); err != nil {
 		return nil, err
 	}
 	return tx, tx.SyntacticVerify(b.ctx)
@@ -715,8 +711,8 @@ func (b *caminoBuilder) FinishProposalsTx(
 	utx.Ins = ins
 	utx.Outs = outs
 
-	tx, err := txs.NewSigned(utx, txs.Codec, nil)
-	if err != nil {
+	tx := &txs.Tx{Unsigned: utx}
+	if err := tx.Initialize(txs.Codec); err != nil {
 		return nil, err
 	}
 	return tx, tx.SyntacticVerify(b.ctx)

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -1439,14 +1439,12 @@ func TestCaminoRewardValidatorTx(t *testing.T) {
 	}
 
 	execute := func(t *testing.T, tt test) (CaminoProposalTxExecutor, *txs.Tx) {
-		utx := &txs.CaminoRewardValidatorTx{
+		tx := &txs.Tx{Unsigned: &txs.CaminoRewardValidatorTx{
 			RewardValidatorTx: txs.RewardValidatorTx{TxID: stakerToRemove.TxID},
 			Ins:               tt.ins,
 			Outs:              tt.outs,
-		}
-
-		tx, err := txs.NewSigned(utx, txs.Codec, nil)
-		require.NoError(t, err)
+		}}
+		require.NoError(t, tx.Initialize(txs.Codec))
 
 		tt.preExecute(t, tx)
 


### PR DESCRIPTION
## Why this should be merged
CaminoState.SyncGenesis is only called from the same package, exactly as intended, so there is no need to export this method.

txs.NewSigned calls txs.Sign. If nil signers arg is passed, than Sign method results only in setting signedTx bytes and unsignedTx bytes to tx fields, no actual signing is performed, though it still does things like calculating unsigned tx hash for signing purposes. There is no need in it. Replace all those calls with tx.Initialize which does same bytes initialization (as done in some of avax methods).

## How this works
CaminoState.SyncGenesis -> CaminoState.syncGenesis
txs.NewSigned(txs.Codec, nil) -> txs.Initialize(txs.Codec)

## How this was tested
Existing unit and e2e tests.

## Additional references
Original PR based on cortina-19 dev
https://github.com/chain4travel/caminogo/pull/327