### PR TITLE
[PVM, EVM] Fixed collectRewardsTx cross-chain request/response handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -161,4 +161,4 @@ require (
 
 replace github.com/ava-labs/avalanche-ledger-go => github.com/chain4travel/camino-ledger-go v0.0.13-c4t
 
-replace github.com/ava-labs/coreth => github.com/chain4travel/caminoethvm v1.1.15-rc1
+replace github.com/ava-labs/coreth => github.com/chain4travel/caminoethvm v1.1.15-rc1.0.20240721114155-ee5dce4e9868

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chain4travel/caminoethvm v1.1.15-rc1 h1:zZ3kcN0FJGTgmTnfw5drrb+V10wiR0tho/m3/Jy9iS0=
-github.com/chain4travel/caminoethvm v1.1.15-rc1/go.mod h1:aXs2X5y4BVp+fGUk4sR1rk1qHmrtTl6NxTJPhUVw3P0=
+github.com/chain4travel/caminoethvm v1.1.15-rc1.0.20240721114155-ee5dce4e9868 h1:32bIll72axJXTU3hSYPxY3hxYZ5TqgJpJVE9IubyBZo=
+github.com/chain4travel/caminoethvm v1.1.15-rc1.0.20240721114155-ee5dce4e9868/go.mod h1:aXs2X5y4BVp+fGUk4sR1rk1qHmrtTl6NxTJPhUVw3P0=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## Why this should be merged
Before this PR, cross-chain CaminoRewardMessage request handler weren't doing any response, which resulted in errors in log.

This PR and https://github.com/chain4travel/caminoethvm/pull/99 fixes that.

## How this works
Sends proper response in case of non-fatal errors and if tx were issued.

## How this was tested
Manually.

## Additional references
Original PR based on cortina-19 dev
https://github.com/chain4travel/caminogo/pull/333