### PR TITLE
fix license headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.go_version }}
+          go-version: '1.22' #camino-license needs go version > 1.21 because of "slices" package
           check-latest: true
       - name: Run static analysis tests
         shell: bash

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/api/admin/service.go
+++ b/api/admin/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/api/common_args_responses.go
+++ b/api/common_args_responses.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/api/info/camino_client.go
+++ b/api/info/camino_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package info

--- a/api/info/camino_service.go
+++ b/api/info/camino_service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package info

--- a/api/info/camino_service_test.go
+++ b/api/info/camino_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package info

--- a/api/info/client.go
+++ b/api/info/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/api/info/service.go
+++ b/api/info/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/app/app.go
+++ b/app/app.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/chains/atomic/camino_const.go
+++ b/chains/atomic/camino_const.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package atomic

--- a/codec/camino_codec.go
+++ b/codec/camino_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package codec

--- a/codec/camino_registry.go
+++ b/codec/camino_registry.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package codec

--- a/codec/camino_test_codec.go
+++ b/codec/camino_test_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package codec

--- a/codec/linearcodec/camino_codec.go
+++ b/codec/linearcodec/camino_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linearcodec

--- a/codec/linearcodec/camino_codec_test.go
+++ b/codec/linearcodec/camino_codec_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package linearcodec

--- a/codec/reflectcodec/struct_fielder.go
+++ b/codec/reflectcodec/struct_fielder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/codec/reflectcodec/type_codec.go
+++ b/codec/reflectcodec/type_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/config/camino.go
+++ b/config/camino.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package config

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/config/flags.go
+++ b/config/flags.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/config/keys.go
+++ b/config/keys.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/database/camino_helpers.go
+++ b/database/camino_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package database

--- a/database/linkeddb/linkeddb.go
+++ b/database/linkeddb/linkeddb.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/genesis/bootstrappers_test.go
+++ b/genesis/bootstrappers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/genesis/camino_config.go
+++ b/genesis/camino_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/camino_config_test.go
+++ b/genesis/camino_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/camino_genesis.go
+++ b/genesis/camino_genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/camino_genesis_test.go
+++ b/genesis/camino_genesis_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/camino_unparsed_config.go
+++ b/genesis/camino_unparsed_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/camino_unparsed_config_test.go
+++ b/genesis/camino_unparsed_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/config.go
+++ b/genesis/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/genesis/genesis_camino.go
+++ b/genesis/genesis_camino.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/genesis_columbus.go
+++ b/genesis/genesis_columbus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/genesis/genesis_kopernikus.go
+++ b/genesis/genesis_kopernikus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 // PrivateKey-vmRQiZeXEXYMyJhEiqdC2z5JhuDbxL8ix9UVvjgMu2Er1NepE => X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3

--- a/genesis/genesis_local.go
+++ b/genesis/genesis_local.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/genesis/params.go
+++ b/genesis/params.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/genesis/unparsed_config.go
+++ b/genesis/unparsed_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/header.yaml
+++ b/header.yaml
@@ -1,0 +1,34 @@
+default-headers: 
+  - name: avax
+    header: |
+      // Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+      // See the file LICENSE for licensing terms.
+
+  - name: avax-c4t
+    header: |
+      // Copyright (C) 2022-{YEAR}, Chain4Travel AG. All rights reserved.
+      //
+      // This file is a derived work, based on ava-labs code whose
+      // original notices appear below.
+      //
+      // It is distributed under the same license conditions as the
+      // original code from which it is derived.
+      //
+      // Much love to the original authors for their work.
+      // **********************************************************
+      // Copyright (C) 2019-2023, Ava Labs, Inc. All rights reserved.
+      // See the file LICENSE for licensing terms.
+
+custom-headers:
+  - name: c4t
+    header: |
+      // Copyright (C) 2022-{YEAR}, Chain4Travel AG. All rights reserved.
+      // See the file LICENSE for licensing terms.
+    
+    include-paths:
+      - "./**/camino*.go"
+      - "./genesis/genesis_camino.go"
+      - "./genesis/genesis_columbus.go"
+      - "./genesis/genesis_kopernikus.go"
+      - "./tools/**/*.go"
+

--- a/network/certs_test.go
+++ b/network/certs_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/network/network.go
+++ b/network/network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/network/peer/peer_test.go
+++ b/network/peer/peer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/network/peer/upgrader.go
+++ b/network/peer/upgrader.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/node/config.go
+++ b/node/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/node/node.go
+++ b/node/node.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/staking/tls.go
+++ b/staking/tls.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/tests/e2e/p/staking_rewards.go
+++ b/tests/e2e/p/staking_rewards.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/tests/e2e/static-handlers/suites.go
+++ b/tests/e2e/static-handlers/suites.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/tests/e2e/x/transfer/virtuous.go
+++ b/tests/e2e/x/transfer/virtuous.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/tools/cert/main.go
+++ b/tools/cert/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tools/genesis/genesis.go
+++ b/tools/genesis/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tools/genesis/main.go
+++ b/tools/genesis/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package main

--- a/tools/genesis/utils/public_key.go
+++ b/tools/genesis/utils/public_key.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/tools/genesis/utils/public_key_test.go
+++ b/tools/genesis/utils/public_key_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utils

--- a/tools/genesis/workbook/allocations.go
+++ b/tools/genesis/workbook/allocations.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package workbook

--- a/tools/genesis/workbook/deposit_offers.go
+++ b/tools/genesis/workbook/deposit_offers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package workbook

--- a/tools/genesis/workbook/load_data.go
+++ b/tools/genesis/workbook/load_data.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package workbook

--- a/tools/genesis/workbook/multisig.go
+++ b/tools/genesis/workbook/multisig.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package workbook

--- a/utils/constants/application.go
+++ b/utils/constants/application.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/utils/constants/camino_token.go
+++ b/utils/constants/camino_token.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package constants

--- a/utils/constants/network_ids.go
+++ b/utils/constants/network_ids.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/utils/constants/network_ids_test.go
+++ b/utils/constants/network_ids_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/utils/crypto/secp256k1/camino_secp256k1.go
+++ b/utils/crypto/secp256k1/camino_secp256k1.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1

--- a/utils/crypto/secp256k1/camino_secp256k1_test.go
+++ b/utils/crypto/secp256k1/camino_secp256k1_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1

--- a/utils/json/camino.go
+++ b/utils/json/camino.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package json

--- a/utils/wrappers/camino_errors.go
+++ b/utils/wrappers/camino_errors.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package wrappers

--- a/utils/wrappers/packing.go
+++ b/utils/wrappers/packing.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/version/compatibility.go
+++ b/version/compatibility.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/version/compatibility_test.go
+++ b/version/compatibility_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/version/constants.go
+++ b/version/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/version/string.go
+++ b/version/string.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/avm/camino_service_test.go
+++ b/vms/avm/camino_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avm

--- a/vms/avm/service.go
+++ b/vms/avm/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/components/avax/atomic_utxos.go
+++ b/vms/components/avax/atomic_utxos.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/components/avax/camino_timed_utxo.go
+++ b/vms/components/avax/camino_timed_utxo.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/camino_timed_utxo_test.go
+++ b/vms/components/avax/camino_timed_utxo_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/camino_transferables.go
+++ b/vms/components/avax/camino_transferables.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/avax/camino_utxo_with_msig.go
+++ b/vms/components/avax/camino_utxo_with_msig.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package avax

--- a/vms/components/message/camino_codec.go
+++ b/vms/components/message/camino_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/components/message/camino_message.go
+++ b/vms/components/message/camino_message.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package message

--- a/vms/components/multisig/camino_multisig.go
+++ b/vms/components/multisig/camino_multisig.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package multisig

--- a/vms/components/multisig/camino_multisig_test.go
+++ b/vms/components/multisig/camino_multisig_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package multisig

--- a/vms/platformvm/addrstate/camino_address_state.go
+++ b/vms/platformvm/addrstate/camino_address_state.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package addrstate
 
 type (

--- a/vms/platformvm/api/camino.go
+++ b/vms/platformvm/api/camino.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/vms/platformvm/api/camino_test.go
+++ b/vms/platformvm/api/camino_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package api

--- a/vms/platformvm/api/static_service.go
+++ b/vms/platformvm/api/static_service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/block/builder/camino_builder.go
+++ b/vms/platformvm/block/builder/camino_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/block/builder/camino_builder_test.go
+++ b/vms/platformvm/block/builder/camino_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/block/builder/camino_network.go
+++ b/vms/platformvm/block/builder/camino_network.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/block/codec.go
+++ b/vms/platformvm/block/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/block/executor/standard_block_test.go
+++ b/vms/platformvm/block/executor/standard_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/block/executor/verifier.go
+++ b/vms/platformvm/block/executor/verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/camino_client.go
+++ b/vms/platformvm/camino_client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/camino_helpers_test.go
+++ b/vms/platformvm/camino_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/camino_service_test.go
+++ b/vms/platformvm/camino_service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package platformvm

--- a/vms/platformvm/caminoconfig/camino_config.go
+++ b/vms/platformvm/caminoconfig/camino_config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package caminoconfig

--- a/vms/platformvm/client.go
+++ b/vms/platformvm/client.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/config/config.go
+++ b/vms/platformvm/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/dac/camino_add_member_proposal.go
+++ b/vms/platformvm/dac/camino_add_member_proposal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_add_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_add_member_proposal_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_base_fee_proposal.go
+++ b/vms/platformvm/dac/camino_base_fee_proposal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_base_fee_proposal_test.go
+++ b/vms/platformvm/dac/camino_base_fee_proposal_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_codec.go
+++ b/vms/platformvm/dac/camino_codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_exclude_member_proposal.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_exclude_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_fee_distribution_proposal.go
+++ b/vms/platformvm/dac/camino_fee_distribution_proposal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_fee_distribution_proposal_test.go
+++ b/vms/platformvm/dac/camino_fee_distribution_proposal_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_general_proposal_test.go
+++ b/vms/platformvm/dac/camino_general_proposal_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_proposal.go
+++ b/vms/platformvm/dac/camino_proposal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_simple_vote.go
+++ b/vms/platformvm/dac/camino_simple_vote.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_simple_vote_test.go
+++ b/vms/platformvm/dac/camino_simple_vote_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/dac/camino_vote.go
+++ b/vms/platformvm/dac/camino_vote.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/deposit/camino_deposit.go
+++ b/vms/platformvm/deposit/camino_deposit.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deposit

--- a/vms/platformvm/deposit/camino_deposit_offer.go
+++ b/vms/platformvm/deposit/camino_deposit_offer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package deposit

--- a/vms/platformvm/deposit/camino_deposit_test.go
+++ b/vms/platformvm/deposit/camino_deposit_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 package deposit
 

--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package fx

--- a/vms/platformvm/fx/fx.go
+++ b/vms/platformvm/fx/fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/genesis/camino.go
+++ b/vms/platformvm/genesis/camino.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package genesis

--- a/vms/platformvm/genesis/genesis.go
+++ b/vms/platformvm/genesis/genesis.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/locked/camino_lock.go
+++ b/vms/platformvm/locked/camino_lock.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package locked

--- a/vms/platformvm/locked/camino_verify.go
+++ b/vms/platformvm/locked/camino_verify.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package locked

--- a/vms/platformvm/locked/camino_verify_test.go
+++ b/vms/platformvm/locked/camino_verify_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package locked

--- a/vms/platformvm/metrics/block_metrics.go
+++ b/vms/platformvm/metrics/block_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package metrics

--- a/vms/platformvm/service.go
+++ b/vms/platformvm/service.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/service_test.go
+++ b/vms/platformvm/service_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_address_state.go
+++ b/vms/platformvm/state/camino_address_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_address_state_test.go
+++ b/vms/platformvm/state/camino_address_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_claimable.go
+++ b/vms/platformvm/state/camino_claimable.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_claimable_test.go
+++ b/vms/platformvm/state/camino_claimable_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_deposit.go
+++ b/vms/platformvm/state/camino_deposit.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_deposit_offer.go
+++ b/vms/platformvm/state/camino_deposit_offer.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_deposit_offer_test.go
+++ b/vms/platformvm/state/camino_deposit_offer_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_deposit_test.go
+++ b/vms/platformvm/state/camino_deposit_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_diff_test.go
+++ b/vms/platformvm/state/camino_diff_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_helpers_test.go
+++ b/vms/platformvm/state/camino_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_multisig_alias.go
+++ b/vms/platformvm/state/camino_multisig_alias.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_multisig_alias_test.go
+++ b/vms/platformvm/state/camino_multisig_alias_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_proposal.go
+++ b/vms/platformvm/state/camino_proposal.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_proposal_test.go
+++ b/vms/platformvm/state/camino_proposal_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_short_link.go
+++ b/vms/platformvm/state/camino_short_link.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_short_link_test.go
+++ b/vms/platformvm/state/camino_short_link_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_stakers.go
+++ b/vms/platformvm/state/camino_stakers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_state_test.go
+++ b/vms/platformvm/state/camino_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package state

--- a/vms/platformvm/state/diff.go
+++ b/vms/platformvm/state/diff.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/state/state.go
+++ b/vms/platformvm/state/state.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/state/test/camino_test_state.go
+++ b/vms/platformvm/state/test/camino_test_state.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package test
 
 import (

--- a/vms/platformvm/test/camino_defaults.go
+++ b/vms/platformvm/test/camino_defaults.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package test
 
 import (

--- a/vms/platformvm/test/camino_keys.go
+++ b/vms/platformvm/test/camino_keys.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package test
 
 import (

--- a/vms/platformvm/test/camino_keys_test.go
+++ b/vms/platformvm/test/camino_keys_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
 package test
 
 import (

--- a/vms/platformvm/test/camino_phase.go
+++ b/vms/platformvm/test/camino_phase.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package test
 
 import (

--- a/vms/platformvm/test/expect/camino_expect.go
+++ b/vms/platformvm/test/expect/camino_expect.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package expect
 
 import (

--- a/vms/platformvm/test/generate/camino_generate.go
+++ b/vms/platformvm/test/generate/camino_generate.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package generate
 
 import (

--- a/vms/platformvm/treasury/camino_treasury.go
+++ b/vms/platformvm/treasury/camino_treasury.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package treasury

--- a/vms/platformvm/txs/base_tx_test.go
+++ b/vms/platformvm/txs/base_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package builder

--- a/vms/platformvm/txs/camino_add_deposit_offer_tx.go
+++ b/vms/platformvm/txs/camino_add_deposit_offer_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_add_deposit_offer_tx_test.go
+++ b/vms/platformvm/txs/camino_add_deposit_offer_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_add_proposal_tx.go
+++ b/vms/platformvm/txs/camino_add_proposal_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_add_proposal_tx_test.go
+++ b/vms/platformvm/txs/camino_add_proposal_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_add_validator_test.go
+++ b/vms/platformvm/txs/camino_add_validator_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_add_validator_tx.go
+++ b/vms/platformvm/txs/camino_add_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_add_vote_tx.go
+++ b/vms/platformvm/txs/camino_add_vote_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_add_vote_tx_test.go
+++ b/vms/platformvm/txs/camino_add_vote_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_address_state_tx.go
+++ b/vms/platformvm/txs/camino_address_state_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_address_state_tx_test.go
+++ b/vms/platformvm/txs/camino_address_state_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_claim_tx.go
+++ b/vms/platformvm/txs/camino_claim_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_claim_tx_test.go
+++ b/vms/platformvm/txs/camino_claim_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_deposit_tx.go
+++ b/vms/platformvm/txs/camino_deposit_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_deposit_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_finish_proposals_tx.go
+++ b/vms/platformvm/txs/camino_finish_proposals_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_finish_proposals_tx_test.go
+++ b/vms/platformvm/txs/camino_finish_proposals_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_multisig_alias_tx.go
+++ b/vms/platformvm/txs/camino_multisig_alias_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_multisig_alias_tx_test.go
+++ b/vms/platformvm/txs/camino_multisig_alias_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_owner_id.go
+++ b/vms/platformvm/txs/camino_owner_id.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_register_node_tx.go
+++ b/vms/platformvm/txs/camino_register_node_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_register_node_tx_test.go
+++ b/vms/platformvm/txs/camino_register_node_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_reward_validator_tx.go
+++ b/vms/platformvm/txs/camino_reward_validator_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_rewards_import_tx.go
+++ b/vms/platformvm/txs/camino_rewards_import_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_rewards_import_tx_test.go
+++ b/vms/platformvm/txs/camino_rewards_import_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_unlock_deposit_tx.go
+++ b/vms/platformvm/txs/camino_unlock_deposit_tx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_unlock_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_unlock_deposit_tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/camino_visitor.go
+++ b/vms/platformvm/txs/camino_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package txs

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/executor/atomic_tx_executor.go
+++ b/vms/platformvm/txs/executor/atomic_tx_executor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/executor/camino_advance_time_test.go
+++ b/vms/platformvm/txs/executor/camino_advance_time_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/camino_chain_event.go
+++ b/vms/platformvm/txs/executor/camino_chain_event.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/camino_helpers_test.go
+++ b/vms/platformvm/txs/executor/camino_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/camino_main_test.go
+++ b/vms/platformvm/txs/executor/camino_main_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/camino_state_changes.go
+++ b/vms/platformvm/txs/executor/camino_state_changes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/camino_visitor.go
+++ b/vms/platformvm/txs/executor/camino_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package executor

--- a/vms/platformvm/txs/executor/dac/camino_dac.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/txs/executor/dac/camino_dac_test.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dac

--- a/vms/platformvm/txs/executor/staker_tx_verification.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
+++ b/vms/platformvm/txs/executor/staker_tx_verification_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/executor/standard_tx_executor.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/executor/standard_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/standard_tx_executor_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/executor/state_changes.go
+++ b/vms/platformvm/txs/executor/state_changes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/executor/tx_mempool_verifier.go
+++ b/vms/platformvm/txs/executor/tx_mempool_verifier.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package mempool

--- a/vms/platformvm/txs/visitor.go
+++ b/vms/platformvm/txs/visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/utxo/camino_handler.go
+++ b/vms/platformvm/utxo/camino_handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/platformvm/utxo/camino_helpers_test.go
+++ b/vms/platformvm/utxo/camino_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/platformvm/utxo/camino_multisig_test.go
+++ b/vms/platformvm/utxo/camino_multisig_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package utxo

--- a/vms/platformvm/utxo/handler.go
+++ b/vms/platformvm/utxo/handler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/utxo/handler_test.go
+++ b/vms/platformvm/utxo/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/platformvm/vm.go
+++ b/vms/platformvm/vm.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/batched_vm_test.go
+++ b/vms/proposervm/batched_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/block.go
+++ b/vms/proposervm/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/block/block.go
+++ b/vms/proposervm/block/block.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/block/build.go
+++ b/vms/proposervm/block/build.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/block/build_test.go
+++ b/vms/proposervm/block/build_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/block/parse_test.go
+++ b/vms/proposervm/block/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/post_fork_block_test.go
+++ b/vms/proposervm/post_fork_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/pre_fork_block_test.go
+++ b/vms/proposervm/pre_fork_block_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/state/block_state_test.go
+++ b/vms/proposervm/state/block_state_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/state_syncable_vm_test.go
+++ b/vms/proposervm/state_syncable_vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/proposervm/vm_test.go
+++ b/vms/proposervm/vm_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/vms/secp256k1fx/camino_credential.go
+++ b/vms/secp256k1fx/camino_credential.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/camino_credential_test.go
+++ b/vms/secp256k1fx/camino_credential_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2022, Ava Labs, Inc. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/camino_fx.go
+++ b/vms/secp256k1fx/camino_fx.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/camino_fx_test.go
+++ b/vms/secp256k1fx/camino_fx_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/camino_keychain.go
+++ b/vms/secp256k1fx/camino_keychain.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/camino_keychain_test.go
+++ b/vms/secp256k1fx/camino_keychain_test.go
@@ -1,4 +1,4 @@
-/// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/camino_transfer_input.go
+++ b/vms/secp256k1fx/camino_transfer_input.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/camino_transfer_output.go
+++ b/vms/secp256k1fx/camino_transfer_output.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/camino_transfer_output_test.go
+++ b/vms/secp256k1fx/camino_transfer_output_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package secp256k1fx

--- a/vms/secp256k1fx/keychain_test.go
+++ b/vms/secp256k1fx/keychain_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/wallet/chain/p/camino_visitor.go
+++ b/wallet/chain/p/camino_visitor.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package p

--- a/wallet/chain/p/context.go
+++ b/wallet/chain/p/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.

--- a/wallet/chain/x/context.go
+++ b/wallet/chain/x/context.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+// Copyright (C) 2022-2024, Chain4Travel AG. All rights reserved.
 //
 // This file is a derived work, based on ava-labs code whose
 // original notices appear below.


### PR DESCRIPTION
## Why this should be merged
to use camino-license instead of go-license to check license headers

## How this works
camino-license check --config=header.yaml <files>

## How this was tested
run ./scripts/lint.sh

## Original author
@mo-c4t 

## Additional references
Original PR based on cortina-19 dev
https://github.com/chain4travel/caminogo/pull/342