### PR TITLE
Update phase timestamp maps, fix pvm test phase times

### DIFF
--- a/version/constants.go
+++ b/version/constants.go
@@ -76,18 +76,54 @@ var (
 
 	DefaultUpgradeTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
+	caminoEarliestTime     = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+	columbusEarliestTime   = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+	kopernikusEarliestTime = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+
+	unreachableFutureTime = time.Date(10000, time.December, 1, 0, 0, 0, 0, time.UTC)
+
+	ApricotPhase1Times = map[uint32]time.Time{
+		constants.MainnetID: time.Date(2021, time.March, 31, 14, 0, 0, 0, time.UTC),
+		constants.FujiID:    time.Date(2021, time.March, 26, 14, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
+
+	ApricotPhase2Times = map[uint32]time.Time{
+		constants.MainnetID: time.Date(2021, time.May, 10, 11, 0, 0, 0, time.UTC),
+		constants.FujiID:    time.Date(2021, time.May, 5, 14, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
+
 	ApricotPhase3Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.August, 24, 14, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.August, 16, 19, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 
 	ApricotPhase4Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.September, 22, 21, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.September, 16, 21, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase4MinPChainHeight = map[uint32]uint64{
 		constants.MainnetID: 793005,
 		constants.FujiID:    47437,
+
+		constants.CaminoID:     0,
+		constants.ColumbusID:   0,
+		constants.KopernikusID: 0,
 	}
 	ApricotPhase4DefaultMinPChainHeight uint64
 
@@ -96,17 +132,46 @@ var (
 		constants.FujiID:    time.Date(2021, time.November, 24, 15, 0, 0, 0, time.UTC),
 	}
 
-	SunrisePhase0Times       = map[uint32]time.Time{}
-	SunrisePhase0DefaultTime = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+	ApricotPhasePre6Times = map[uint32]time.Time{
+		constants.MainnetID: time.Date(2022, time.September, 5, 1, 30, 0, 0, time.UTC),
+		constants.FujiID:    time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
+
+	SunrisePhase0Times = map[uint32]time.Time{
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
 
 	ApricotPhase6Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
+
+	ApricotPhasePost6Times = map[uint32]time.Time{
+		constants.MainnetID: time.Date(2022, time.September, 7, 3, 0, 0, 0, time.UTC),
+		constants.FujiID:    time.Date(2022, time.September, 7, 6, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 
 	BanffTimes = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2022, time.October, 18, 16, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.October, 3, 14, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 
 	AthensPhaseTimes = map[uint32]time.Time{
@@ -114,7 +179,6 @@ var (
 		constants.ColumbusID:   time.Date(2023, time.July, 7, 8, 0, 0, 0, time.UTC),
 		constants.CaminoID:     time.Date(2023, time.July, 17, 8, 0, 0, 0, time.UTC),
 	}
-	AthensPhaseDefaultTime = time.Date(2023, time.July, 1, 8, 0, 0, 0, time.UTC)
 
 	// TODO: update this before release
 	BerlinPhaseTimes = map[uint32]time.Time{
@@ -122,18 +186,25 @@ var (
 		constants.ColumbusID:   time.Date(2023, time.July, 7, 8, 0, 0, 0, time.UTC),
 		constants.CaminoID:     time.Date(2023, time.July, 17, 8, 0, 0, 0, time.UTC),
 	}
-	BerlinPhaseDefaultTime = time.Date(2023, time.July, 1, 8, 0, 0, 0, time.UTC)
 
 	// TODO: update this before release, must be exactly the same as Berlin
 	CortinaTimes = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2023, time.April, 25, 15, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2023, time.April, 6, 15, 0, 0, 0, time.UTC),
+
+		constants.KopernikusID: time.Date(2023, time.July, 4, 13, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2023, time.July, 7, 8, 0, 0, 0, time.UTC),
+		constants.CaminoID:     time.Date(2023, time.July, 17, 8, 0, 0, 0, time.UTC),
 	}
 
 	// TODO: update this before release
 	DTimes = map[uint32]time.Time{
 		constants.MainnetID: time.Date(10000, time.December, 1, 0, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(10000, time.December, 1, 0, 0, 0, 0, time.UTC),
+
+		constants.KopernikusID: unreachableFutureTime,
+		constants.ColumbusID:   unreachableFutureTime,
+		constants.CaminoID:     unreachableFutureTime,
 	}
 )
 
@@ -190,7 +261,7 @@ func GetSunrisePhase0Time(networkID uint32) time.Time {
 	if upgradeTime, exists := SunrisePhase0Times[networkID]; exists {
 		return upgradeTime
 	}
-	return SunrisePhase0DefaultTime
+	return DefaultUpgradeTime
 }
 
 func GetApricotPhase6Time(networkID uint32) time.Time {
@@ -211,14 +282,14 @@ func GetAthensPhaseTime(networkID uint32) time.Time {
 	if upgradeTime, exists := AthensPhaseTimes[networkID]; exists {
 		return upgradeTime
 	}
-	return AthensPhaseDefaultTime
+	return DefaultUpgradeTime
 }
 
 func GetBerlinPhaseTime(networkID uint32) time.Time {
 	if upgradeTime, exists := BerlinPhaseTimes[networkID]; exists {
 		return upgradeTime
 	}
-	return BerlinPhaseDefaultTime
+	return DefaultUpgradeTime
 }
 
 func GetCortinaTime(networkID uint32) time.Time {

--- a/vms/platformvm/camino_helpers_test.go
+++ b/vms/platformvm/camino_helpers_test.go
@@ -12,11 +12,8 @@ import (
 	"github.com/ava-labs/avalanchego/api/keystore"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
-	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
-	"github.com/ava-labs/avalanchego/utils/json"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
@@ -52,12 +49,6 @@ func newCaminoVM(t *testing.T, genesisConfig api.Camino, phase test.Phase, genes
 	msgChan := make(chan common.Message, 1)
 	ctx := test.ContextWithSharedMemory(t, atomicDB)
 
-	// utxo with funds for testSubnet1 (see below)
-	genesisUTXOs = append(genesisUTXOs, api.UTXO{
-		Amount:  json.Uint64(vm.Config.CreateSubnetTxFee),
-		Address: test.FundedKeysBech32[0],
-	})
-
 	ctx.Lock.Lock()
 	defer ctx.Lock.Unlock()
 	genesisBytes := test.Genesis(t, ctx.AVAXAssetID, genesisConfig, genesisUTXOs)
@@ -83,28 +74,6 @@ func newCaminoVM(t *testing.T, genesisConfig api.Camino, phase test.Phase, genes
 	vm.state.SetTimestamp(vm.clock.Time())
 
 	require.NoError(vm.SetState(context.Background(), snow.NormalOp))
-
-	// Create a subnet and store it in testSubnet1
-	// Note: following Banff activation, block acceptance will move
-	// chain time ahead
-	testSubnet1, err := vm.txBuilder.NewCreateSubnetTx(
-		2, // threshold; 2 sigs from control keys needed to add validator to this subnet
-		[]ids.ShortID{ // control keys
-			test.FundedKeys[0].Address(),
-			test.FundedKeys[1].Address(),
-			test.FundedKeys[2].Address(),
-		},
-		[]*secp256k1.PrivateKey{test.FundedKeys[0]},
-		test.FundedKeys[0].Address(),
-	)
-
-	require.NoError(err)
-	require.NoError(vm.Builder.AddUnverifiedTx(testSubnet1))
-	blk, err := vm.Builder.BuildBlock(context.Background())
-	require.NoError(err)
-	require.NoError(blk.Verify(context.Background()))
-	require.NoError(blk.Accept(context.Background()))
-	require.NoError(vm.SetPreference(context.Background(), vm.manager.LastAccepted()))
 
 	t.Cleanup(func() {
 		vm.ctx.Lock.Lock()

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -834,7 +834,7 @@ func TestExcludeMemberProposals(t *testing.T) {
 	proposalBondAmount := defaultConfig.CaminoConfig.DACProposalBondAmount
 	validatorBondAmount := defaultConfig.MaxValidatorStake // is equal to min
 	initialBalance := test.PreFundedBalance + test.ValidatorWeight
-	initialHeight := uint64(2)
+	initialHeight := uint64(1)
 
 	// for simplicity: member == member that will be excluded
 	//                 proposer == member that creates excludeMember proposal

--- a/vms/platformvm/test/camino_defaults.go
+++ b/vms/platformvm/test/camino_defaults.go
@@ -84,22 +84,21 @@ func Config(t *testing.T, phase Phase) *config.Config {
 	case PhaseCairo:
 		cairoTime = LatestPhaseTime
 		fallthrough
-	case PhaseBerlin: // same time, as PhaseCortina
+	case PhaseBerlin:
 		berlinTime = LatestPhaseTime
+		cortinaTime = LatestPhaseTime
 		fallthrough
 	case PhaseAthens:
 		athensTime = LatestPhaseTime
 		fallthrough
-	case PhaseSunrise: // Banff is considered to be part of SunrisePhase release
+	case PhaseSunrise:
 		banffTime = LatestPhaseTime
 		fallthrough
 	case PhaseApricot5:
 		apricotPhase5Time = LatestPhaseTime
-		fallthrough
-	case PhaseApricot3:
 		apricotPhase3Time = LatestPhaseTime
 	default:
-		require.FailNow(t, "unhandled fork %d", phase)
+		require.FailNowf(t, "", "unknown phase %d (%s)", phase)
 	}
 
 	return &config.Config{

--- a/vms/platformvm/test/camino_phase.go
+++ b/vms/platformvm/test/camino_phase.go
@@ -16,17 +16,14 @@ type Phase int
 
 // Camino phases must go in consecutive order
 const (
-	PhaseApricot3 Phase = -2 // avax
-	PhaseApricot5 Phase = -1 // avax
+	PhaseApricot5 Phase = 0 // avax
+	PhaseBanff    Phase = 1 // avax, included into Sunrise phase
 	PhaseSunrise  Phase = 1
-	PhaseBanff    Phase = 1 // avax, phase actually happened after Sunrise, but before Athens. But first release is Sunrise.
 	PhaseAthens   Phase = 2
 	PhaseCortina  Phase = 3 // avax, included into Berlin phase
 	PhaseBerlin   Phase = 3
 	PhaseCairo    Phase = 4
 )
-
-// TODO @evlekht we might want to clean up sunrise/banff timestamps/relations later
 
 const (
 	PhaseFirst = PhaseSunrise


### PR DESCRIPTION
- Adds missing avax Apricot phase timestamps and camino networks timestamps to all avax phases, so they can be used in evm.
- Fixes some issues in PVM test phases and timestamps.