### PR TITLE
Change version string to match with CNR version regexp

### DIFF
--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -23,7 +23,7 @@ source ./scripts/constants.sh
 #################################
 echo "building e2e.test"
 # to install the ginkgo binary (required for test build and run)
-go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
+go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.4.0
 ACK_GINKGO_RC=true ginkgo build ./tests/e2e
 ./tests/e2e/e2e.test --help
 

--- a/scripts/tests.upgrade.sh
+++ b/scripts/tests.upgrade.sh
@@ -55,7 +55,7 @@ source ./scripts/constants.sh
 #################################
 echo "building upgrade.test"
 # to install the ginkgo binary (required for test build and run)
-go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.13.1
+go install -v github.com/onsi/ginkgo/v2/ginkgo@v2.4.0
 ACK_GINKGO_RC=true ginkgo build ./tests/upgrade
 ./tests/upgrade/upgrade.test --help
 

--- a/version/constants_test.go
+++ b/version/constants_test.go
@@ -11,5 +11,8 @@ import (
 
 func TestCurrentRPCChainVMCompatible(t *testing.T) {
 	compatibleVersions := RPCChainVMProtocolCompatibility[RPCChainVMProtocol]
+	for _, ver := range compatibleVersions {
+		_ = ver.String()
+	}
 	require.Contains(t, compatibleVersions, Current)
 }

--- a/version/string.go
+++ b/version/string.go
@@ -25,8 +25,8 @@ var String string
 func init() {
 	goVersion := runtime.Version()
 	goVersionNumber := strings.TrimPrefix(goVersion, "go")
-	String = fmt.Sprintf("%s [git %s, %s; database: %s, rpcchainvm %d, go: %s]\n",
-		CurrentApp,
+	String = fmt.Sprintf("caminogo: %s [git %s, %s; database: %s, rpcchainvm %d, go: %s]\n",
+		Current,
 		GitVersion,
 		GitCommit,
 		CurrentDatabase,


### PR DESCRIPTION
## Why this should be merged
Cortina merges changed version string. It no longer matches regexp that is used by CNR to get node version.
Update e2e script ginkgo version to match go mod ginkgo version.
## How this works
Change string to match regexp - it requires usage of different version object.
Because of that, PR also update test by initializing version objects with String() call, so they'll pass equality check.
## How this was tested
Unit tests.