### PR TITLE
[DOCKER, WORKFLOWS] Fix dockerfile, fix already existing symbolic link error, exclude CNR from lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,8 @@ run:
   skip-files:
     - ".*\\.pb\\.go$"
     - ".*mock.*"
+  skip-dirs:
+    - "tools/camino-network-runner"
 
 issues:
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ WORKDIR /build
 # Copy and download caminogo dependencies using go mod
 COPY go.mod .
 COPY go.sum .
-COPY dependencies dependencies/
 RUN go mod download
 
 # Copy the code into the container

--- a/scripts/build_camino.sh
+++ b/scripts/build_camino.sh
@@ -55,7 +55,7 @@ mkdir -p $plugin_dir
 
 # Exit build successfully if the binaries are created
 if [[ -f "$caminogo_path" ]]; then
-    ln -s caminogo $camino_node_symlink_path
+    ln -sf caminogo $camino_node_symlink_path
     echo "Build Successful"
     exit 0
 else

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -2,11 +2,10 @@
 #
 # Use lower_case variables in the scripts and UPPER_CASE variables for override
 # Use the constants.sh for env overrides
-# Use the versions.sh to specify versions
-#
 
 # Set the PATHS
 GOPATH="$(go env GOPATH)"
+CAMINOGO_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 
 # Where CaminoGo binary goes
 build_dir="$CAMINOGO_PATH/build"
@@ -21,11 +20,13 @@ plugin_dir="$build_dir/plugins"
 camino_node_dockerhub_repo=${DOCKER_REPO:-"c4tplatform"}"/camino-node"
 
 # Current branch
-current_branch=$(git symbolic-ref -q --short HEAD || git describe --tags || echo unknown)
+current_branch_temp=$(git symbolic-ref -q --short HEAD || git describe --tags --always || echo unknown)
+# replace / with - to be a docker tag compatible
+current_branch=${current_branch_temp////-}
 
 # caminogo and caminoethvm git tag and sha
 git_commit=${CAMINO_NODE_COMMIT:-$(git rev-parse --short HEAD)}
-git_tag=${CAMINO_NODE_TAG:-$(git describe --tags --abbrev=0 || echo unknown)}
+git_tag=${CAMINO_NODE_TAG:-$(git describe --tags --abbrev=0 --always || echo unknown)}
 caminoethvm_tag=${CAMINO_ETHVM_VERSION:-'v1.1.0-rc4'}
 caminoethvm_commit=${CAMINOETHVM_COMMIT:-'07e50749e3c371001c92dff14dc91ef6109a368a'}
 


### PR DESCRIPTION
## Why this should be merged
caminogo has no dependencies folder anymore

## How this works
by removing the line which copies dependencies folder in dockerfile

## How this was tested
built docker image locally

## Additional references
Original PR based on cortina-4 dev
https://github.com/chain4travel/caminogo/pull/298