### PR TITLE
[PVM] Fix CaminoRewardValidatorTx onAbort address state

### DIFF
--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -616,7 +616,7 @@ func (e *CaminoProposalTxExecutor) RewardValidatorTx(tx *txs.RewardValidatorTx) 
 		if err != nil {
 			return err
 		}
-		e.OnCommitState.SetAddressStates(nodeOwnerAddressOnAbort, nodeOwnerAddressStateOnAbort&^as.AddressStateNodeDeferred)
+		e.OnAbortState.SetAddressStates(nodeOwnerAddressOnAbort, nodeOwnerAddressStateOnAbort&^as.AddressStateNodeDeferred)
 	}
 
 	txID := e.Tx.ID()


### PR DESCRIPTION
## Why this should be merged
CaminoRewardValidatorTx execution has error, most likely copy-paste mistake. It expected, that onCommit and onAbort states will be identical, but tx is not setting deferred addressState bit in onAbort state and setting it twice in onCommit state.
## How this works
This looks like a simple copy-paste error. So PR simply replaces onCommit state with onAbort state.
## How this was tested
It wasn't.
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminogo/pull/344