### PR TITLE
[PVM] AddressStateTx and tests refactoring

### DIFF
--- a/genesis/camino_genesis.go
+++ b/genesis/camino_genesis.go
@@ -370,7 +370,7 @@ func buildPGenesis(config *Config, hrp string, xGenesisBytes []byte, xGenesisDat
 	for _, allocation := range config.Camino.Allocations {
 		var addrState as.AddressState
 		if allocation.AddressStates.ConsortiumMember {
-			addrState |= as.AddressStateConsortiumMember
+			addrState |= as.AddressStateConsortium
 		}
 		if allocation.AddressStates.KYCVerified {
 			addrState |= as.AddressStateKYCVerified

--- a/vms/platformvm/addrstate/camino_address_state.go
+++ b/vms/platformvm/addrstate/camino_address_state.go
@@ -11,7 +11,7 @@ const (
 
 	AddressStateBitRoleAdmin AddressStateBit = 0 // super role
 
-	AddressStateBitRoleKYC                     AddressStateBit = 1 // allows to set KYCVerified and KYCExpired
+	AddressStateBitRoleKYCAdmin                AddressStateBit = 1 // allows to set KYCVerified and KYCExpired
 	AddressStateBitRoleOffersAdmin             AddressStateBit = 2 // allows to set OffersCreator
 	AddressStateBitRoleConsortiumAdminProposer AddressStateBit = 3 // allows to create admin add/exclude member proposals
 
@@ -28,30 +28,33 @@ const (
 
 	AddressStateEmpty AddressState = 0
 
-	AddressStateRoleAdmin                   AddressState = AddressState(1) << AddressStateBitRoleAdmin                   // 0b1
-	AddressStateRoleKYC                     AddressState = AddressState(1) << AddressStateBitRoleKYC                     // 0b10
-	AddressStateRoleOffersAdmin             AddressState = AddressState(1) << AddressStateBitRoleOffersAdmin             // 0b100
-	AddressStateRoleConsortiumAdminProposer AddressState = AddressState(1) << AddressStateBitRoleConsortiumAdminProposer // 0b1000
-	AddressStateRoleAll                     AddressState = AddressStateRoleAdmin | AddressStateRoleKYC |                 // 0b1111
-		AddressStateRoleOffersAdmin | AddressStateRoleConsortiumAdminProposer
+	AddressStateRoleAdmin                   = AddressState(1) << AddressStateBitRoleAdmin                   // 0b1
+	AddressStateRoleKYCAdmin                = AddressState(1) << AddressStateBitRoleKYCAdmin                // 0b10
+	AddressStateRoleOffersAdmin             = AddressState(1) << AddressStateBitRoleOffersAdmin             // 0b100
+	AddressStateRoleConsortiumAdminProposer = AddressState(1) << AddressStateBitRoleConsortiumAdminProposer // 0b1000
 
-	AddressStateKYCVerified AddressState = AddressState(1) << AddressStateBitKYCVerified    // 0b0100000000000000000000000000000000
-	AddressStateKYCExpired  AddressState = AddressState(1) << AddressStateBitKYCExpired     // 0b1000000000000000000000000000000000
-	AddressStateKYCAll      AddressState = AddressStateKYCVerified | AddressStateKYCExpired // 0b1100000000000000000000000000000000
+	AddressStateKYCVerified = AddressState(1) << AddressStateBitKYCVerified // 0b0100000000000000000000000000000000
+	AddressStateKYCExpired  = AddressState(1) << AddressStateBitKYCExpired  // 0b1000000000000000000000000000000000
 
-	AddressStateConsortiumMember AddressState = AddressState(1) << AddressStateBitConsortium            // 0b0100000000000000000000000000000000000000
-	AddressStateNodeDeferred     AddressState = AddressState(1) << AddressStateBitNodeDeferred          // 0b1000000000000000000000000000000000000000
-	AddressStateVotableBits      AddressState = AddressStateConsortiumMember | AddressStateNodeDeferred // 0b1100000000000000000000000000000000000000
+	AddressStateConsortium   = AddressState(1) << AddressStateBitConsortium   // 0b0100000000000000000000000000000000000000
+	AddressStateNodeDeferred = AddressState(1) << AddressStateBitNodeDeferred // 0b1000000000000000000000000000000000000000
 
-	AddressStateOffersCreator  AddressState = AddressState(1) << AddressStateBitOffersCreator  // 0b00100000000000000000000000000000000000000000000000000
-	AddressStateCaminoProposer AddressState = AddressState(1) << AddressStateBitCaminoProposer // 0b01000000000000000000000000000000000000000000000000000
+	AddressStateOffersCreator  = AddressState(1) << AddressStateBitOffersCreator  // 0b0100000000000000000000000000000000000000000000000000
+	AddressStateCaminoProposer = AddressState(1) << AddressStateBitCaminoProposer // 0b1000000000000000000000000000000000000000000000000000
 
-	AddressStateAthensPhaseBits = AddressStateRoleOffersAdmin | AddressStateOffersCreator
-	AddressStateBerlinPhaseBits = AddressStateCaminoProposer | AddressStateRoleOffersAdmin
+	// Bit groups (as AddressState)
 
-	AddressStateValidBits = AddressStateRoleAll | AddressStateKYCAll | AddressStateVotableBits |
+	AddressStateSunrisePhaseBits = AddressStateRoleAdmin | AddressStateRoleKYCAdmin | // 0b1100001100000000000000000000000000000011
+		AddressStateKYCVerified | AddressStateKYCExpired | AddressStateConsortium |
+		AddressStateNodeDeferred
+
+	AddressStateAthensPhaseBits = AddressStateRoleOffersAdmin | AddressStateOffersCreator // 0b0100000000000000000000000000000000000000000000000100
+
+	AddressStateBerlinPhaseBits = AddressStateCaminoProposer | AddressStateRoleConsortiumAdminProposer // 0b1000000000000000000000000000000000000000000000001000
+
+	AddressStateValidBits = AddressStateSunrisePhaseBits | // 0b1100000000001100001100000000000000000000000000001111
 		AddressStateAthensPhaseBits |
-		AddressStateBerlinPhaseBits // 0b1100000000001100001100000000000000000000000000001111
+		AddressStateBerlinPhaseBits
 )
 
 func (as AddressState) Is(state AddressState) bool {
@@ -60,4 +63,8 @@ func (as AddressState) Is(state AddressState) bool {
 
 func (as AddressState) IsNot(state AddressState) bool {
 	return as&state != state
+}
+
+func (asb AddressStateBit) ToAddressState() AddressState {
+	return AddressState(1) << asb
 }

--- a/vms/platformvm/camino_helpers_test.go
+++ b/vms/platformvm/camino_helpers_test.go
@@ -189,7 +189,7 @@ func newCaminoGenesisWithUTXOs(caminoGenesisConfig api.Camino, genesisUTXOs []ap
 		caminoGenesisConfig.ValidatorConsortiumMembers[i] = key.Address()
 		caminoGenesisConfig.AddressStates = append(caminoGenesisConfig.AddressStates, genesis.AddressState{
 			Address: key.Address(),
-			State:   as.AddressStateConsortiumMember,
+			State:   as.AddressStateConsortium,
 		})
 	}
 

--- a/vms/platformvm/camino_service.go
+++ b/vms/platformvm/camino_service.go
@@ -280,10 +280,11 @@ func (s *CaminoService) SetAddressState(_ *http.Request, args *SetAddressStateAr
 
 	// Create the transaction
 	tx, err := s.vm.txBuilder.NewAddressStateTx(
-		targetAddr,  // Address to change state
-		args.Remove, // Add or remove State
-		args.State,  // The state to change
-		privKeys,    // Keys providing the staked tokens
+		targetAddr,     // Address to change state
+		args.Remove,    // Add or remove State
+		args.State,     // The state to change
+		ids.ShortEmpty, // executor address
+		privKeys,       // Keys providing the staked tokens
 		change,
 	)
 	if err != nil {

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -86,6 +86,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 		adminProposerKey.Address(),
 		false,
 		as.AddressStateBitRoleConsortiumAdminProposer,
+		rootAdminKey.Address(),
 		[]*secp256k1.PrivateKey{rootAdminKey},
 		outputOwners,
 	)
@@ -95,6 +96,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		false,
 		as.AddressStateBitKYCVerified,
+		caminoPreFundedKeys[0].Address(),
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		nil,
 	)
@@ -153,6 +155,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		false,
 		as.AddressStateBitNodeDeferred,
+		caminoPreFundedKeys[0].Address(),
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		outputOwners,
 	)
@@ -167,7 +170,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 
 	// Verify that the validator's owner's deferred state and consortium member is true
 	ownerState, _ := vm.state.GetAddressStates(consortiumMemberKey.Address())
-	require.Equal(ownerState, as.AddressStateNodeDeferred|as.AddressStateConsortiumMember|as.AddressStateKYCVerified)
+	require.Equal(ownerState, as.AddressStateNodeDeferred|as.AddressStateConsortium|as.AddressStateKYCVerified)
 
 	// Fast-forward clock to time for validator to be rewarded
 	vm.clock.Set(endTime)
@@ -218,7 +221,7 @@ func TestRemoveDeferredValidator(t *testing.T) {
 
 	// Verify that the validator's owner's deferred state is false
 	ownerState, _ = vm.state.GetAddressStates(consortiumMemberKey.Address())
-	require.Equal(ownerState, as.AddressStateConsortiumMember|as.AddressStateKYCVerified)
+	require.Equal(ownerState, as.AddressStateConsortium|as.AddressStateKYCVerified)
 
 	timestamp := vm.state.GetTimestamp()
 	require.Equal(endTime.Unix(), timestamp.Unix())
@@ -272,6 +275,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 		adminProposerKey.Address(),
 		false,
 		as.AddressStateBitRoleConsortiumAdminProposer,
+		rootAdminKey.Address(),
 		[]*secp256k1.PrivateKey{rootAdminKey},
 		outputOwners,
 	)
@@ -281,6 +285,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		false,
 		as.AddressStateBitKYCVerified,
+		caminoPreFundedKeys[0].Address(),
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		nil,
 	)
@@ -340,6 +345,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		false,
 		as.AddressStateBitNodeDeferred,
+		caminoPreFundedKeys[0].Address(),
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		outputOwners,
 	)
@@ -357,6 +363,7 @@ func TestRemoveReactivatedValidator(t *testing.T) {
 		consortiumMemberKey.Address(),
 		true,
 		as.AddressStateBitNodeDeferred,
+		caminoPreFundedKeys[0].Address(),
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		outputOwners,
 	)
@@ -600,6 +607,7 @@ func TestProposals(t *testing.T) {
 				proposerAddr,
 				false,
 				as.AddressStateBitCaminoProposer,
+				caminoPreFundedKeys[0].Address(),
 				[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 				nil,
 			)
@@ -741,6 +749,7 @@ func TestAdminProposals(t *testing.T) {
 		proposerAddr,
 		false,
 		as.AddressStateBitRoleConsortiumAdminProposer,
+		caminoPreFundedKeys[0].Address(),
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		nil,
 	)
@@ -750,13 +759,14 @@ func TestAdminProposals(t *testing.T) {
 	checkTx(t, vm, blk.ID(), addrStateTx.ID())
 	applicantAddrState, err := vm.state.GetAddressStates(applicantAddr)
 	require.NoError(err)
-	require.True(applicantAddrState.IsNot(as.AddressStateConsortiumMember))
+	require.True(applicantAddrState.IsNot(as.AddressStateConsortium))
 
 	// Make applicant (see admin proposal below) kyc-verified
 	addrStateTx, err = vm.txBuilder.NewAddressStateTx(
 		applicantAddr,
 		false,
 		as.AddressStateBitKYCVerified,
+		caminoPreFundedKeys[0].Address(),
 		[]*secp256k1.PrivateKey{caminoPreFundedKeys[0]},
 		nil,
 	)
@@ -805,7 +815,7 @@ func TestAdminProposals(t *testing.T) {
 	// check that applicant became c-member
 	applicantAddrState, err = vm.state.GetAddressStates(applicantAddr)
 	require.NoError(err)
-	require.True(applicantAddrState.Is(as.AddressStateConsortiumMember))
+	require.True(applicantAddrState.Is(as.AddressStateConsortium))
 }
 
 func TestExcludeMemberProposals(t *testing.T) {
@@ -933,6 +943,7 @@ func TestExcludeMemberProposals(t *testing.T) {
 				consortiumAdminKey.Address(),
 				false,
 				as.AddressStateBitRoleConsortiumAdminProposer,
+				rootAdminKey.Address(),
 				[]*secp256k1.PrivateKey{rootAdminKey, fundsKey},
 				nil,
 			)
@@ -959,6 +970,7 @@ func TestExcludeMemberProposals(t *testing.T) {
 				memberToExcludeAddr,
 				false,
 				as.AddressStateBitKYCVerified,
+				rootAdminKey.Address(),
 				[]*secp256k1.PrivateKey{rootAdminKey},
 				nil,
 			)
@@ -997,7 +1009,7 @@ func TestExcludeMemberProposals(t *testing.T) {
 			require.Equal(expectedHeight, height)
 			memberAddrState, err = vm.state.GetAddressStates(memberToExcludeAddr)
 			require.NoError(err)
-			require.Equal(as.AddressStateConsortiumMember|as.AddressStateKYCVerified, memberAddrState)
+			require.Equal(as.AddressStateConsortium|as.AddressStateKYCVerified, memberAddrState)
 			bondedAmt -= proposalBondAmount
 			checkBalance(t, vm.state, fundsAddr,
 				balance-burnedAmt,                 // total
@@ -1226,7 +1238,7 @@ func TestExcludeMemberProposals(t *testing.T) {
 					0, 0, balance-burnedAmt-bondedAmt, // unlocked
 				)
 			} else {
-				require.Equal(as.AddressStateConsortiumMember|as.AddressStateKYCVerified, memberAddrState)
+				require.Equal(as.AddressStateConsortium|as.AddressStateKYCVerified, memberAddrState)
 				if tt.pendingValidator {
 					require.NoError(pendingValidatorErr)
 				} else {

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -386,9 +386,9 @@ func (cs *caminoState) syncGenesis(s *state, g *genesis.State) error {
 		initalAdminAddressState|as.AddressStateRoleAdmin)
 
 	addrStateTx, err := txs.NewSigned(&txs.AddressStateTx{
-		Address: g.Camino.InitialAdmin,
-		State:   as.AddressStateBitRoleAdmin,
-		Remove:  false,
+		Address:  g.Camino.InitialAdmin,
+		StateBit: as.AddressStateBitRoleAdmin,
+		Remove:   false,
 	}, txs.Codec, nil)
 	if err != nil {
 		return err

--- a/vms/platformvm/state/camino_test.go
+++ b/vms/platformvm/state/camino_test.go
@@ -253,13 +253,13 @@ func TestSyncGenesis(t *testing.T) {
 					},
 					{
 						Address: shortID,
-						State:   as.AddressStateRoleKYC,
+						State:   as.AddressStateRoleKYCAdmin,
 					},
 				}, depositTxs, initialAdmin),
 			},
 			cs: *wrappers.IgnoreError(newCaminoState(baseDB, validatorsDB, prometheus.NewRegistry())).(*caminoState),
 			want: caminoDiff{
-				modifiedAddressStates: map[ids.ShortID]as.AddressState{initialAdmin: as.AddressStateRoleAdmin, shortID: as.AddressStateRoleKYC},
+				modifiedAddressStates: map[ids.ShortID]as.AddressState{initialAdmin: as.AddressStateRoleAdmin, shortID: as.AddressStateRoleKYCAdmin},
 				modifiedDepositOffers: map[ids.ID]*deposit.Offer{
 					depositOffers[0].ID: depositOffers[0],
 					depositOffers[1].ID: depositOffers[1],

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -40,6 +40,7 @@ func TestCaminoEnv(t *testing.T) {
 	env.config.BanffTime = env.state.GetTimestamp()
 }
 
+// only support upgr version 0
 func TestCaminoBuilderTxAddressState(t *testing.T) {
 	caminoConfig := api.Camino{
 		VerifyNodeSignature: true,
@@ -56,39 +57,32 @@ func TestCaminoBuilderTxAddressState(t *testing.T) {
 
 	tests := map[string]struct {
 		remove      bool
-		state       as.AddressStateBit
+		stateBit    as.AddressStateBit
 		address     ids.ShortID
 		expectedErr error
 	}{
 		"KYC Role: Add": {
-			remove:      false,
-			state:       as.AddressStateBitRoleKYC,
-			address:     caminoPreFundedKeys[0].PublicKey().Address(),
-			expectedErr: nil,
+			stateBit: as.AddressStateBitRoleKYCAdmin,
+			address:  caminoPreFundedKeys[0].Address(),
 		},
 		"KYC Role: Remove": {
-			remove:      true,
-			state:       as.AddressStateBitRoleKYC,
-			address:     caminoPreFundedKeys[0].PublicKey().Address(),
-			expectedErr: nil,
+			remove:   true,
+			stateBit: as.AddressStateBitRoleKYCAdmin,
+			address:  caminoPreFundedKeys[0].Address(),
 		},
 		"Admin Role: Add": {
-			remove:      false,
-			state:       as.AddressStateBitRoleAdmin,
-			address:     caminoPreFundedKeys[0].PublicKey().Address(),
-			expectedErr: nil,
+			stateBit: as.AddressStateBitRoleAdmin,
+			address:  caminoPreFundedKeys[0].Address(),
 		},
 		"Admin Role: Remove": {
-			remove:      true,
-			state:       as.AddressStateBitRoleAdmin,
-			address:     caminoPreFundedKeys[0].PublicKey().Address(),
-			expectedErr: nil,
+			remove:   true,
+			stateBit: as.AddressStateBitRoleAdmin,
+			address:  caminoPreFundedKeys[0].Address(),
 		},
-		"Empty Address": {
-			remove:      false,
-			state:       as.AddressStateBitRoleKYC,
+		"Empty address": {
+			stateBit:    as.AddressStateBitRoleKYCAdmin,
 			address:     ids.ShortEmpty,
-			expectedErr: txs.ErrEmptyAddress,
+			expectedErr: errEmptyAddress,
 		},
 	}
 
@@ -97,7 +91,8 @@ func TestCaminoBuilderTxAddressState(t *testing.T) {
 			_, err := env.txBuilder.NewAddressStateTx(
 				tt.address,
 				tt.remove,
-				tt.state,
+				tt.stateBit,
+				caminoPreFundedKeys[0].Address(),
 				caminoPreFundedKeys,
 				nil,
 			)
@@ -190,7 +185,7 @@ func TestUnlockDepositTx(t *testing.T) {
 	outputOwners := secp256k1fx.OutputOwners{
 		Locktime:  0,
 		Threshold: 1,
-		Addrs:     []ids.ShortID{testKey.PublicKey().Address()},
+		Addrs:     []ids.ShortID{testKey.Address()},
 	}
 	depositTxID := ids.GenerateTestID()
 	depositStartTime := time.Now()

--- a/vms/platformvm/txs/executor/camino_advance_time_test.go
+++ b/vms/platformvm/txs/executor/camino_advance_time_test.go
@@ -376,6 +376,7 @@ func deferValidator(env *caminoEnvironment, nodeOwnerAddress ids.ShortID, key *s
 		nodeOwnerAddress,
 		false,
 		as.AddressStateBitNodeDeferred,
+		key.Address(),
 		[]*secp256k1.PrivateKey{key},
 		outputOwners,
 	)

--- a/vms/platformvm/txs/executor/dac/camino_dac.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac.go
@@ -146,7 +146,7 @@ func (e *proposalVerifier) AddMemberProposal(proposal *dac.AddMemberProposal) er
 	switch {
 	case err != nil:
 		return err
-	case applicantAddress.Is(as.AddressStateConsortiumMember):
+	case applicantAddress.Is(as.AddressStateConsortium):
 		return fmt.Errorf("%w (applicant)", errConsortiumMember)
 	case applicantAddress.IsNot(as.AddressStateKYCVerified):
 		return fmt.Errorf("%w (applicant)", errNotKYCVerified)
@@ -185,7 +185,7 @@ func (e *proposalExecutor) AddMemberProposal(proposal *dac.AddMemberProposalStat
 	if err != nil {
 		return err
 	}
-	newAddrState := addrState | as.AddressStateConsortiumMember
+	newAddrState := addrState | as.AddressStateConsortium
 	if newAddrState == addrState {
 		// c-member was somehow already added
 		// this should never happen, cause adding only done via addMemberProposal
@@ -208,7 +208,7 @@ func (e *proposalVerifier) ExcludeMemberProposal(proposal *dac.ExcludeMemberProp
 	switch {
 	case err != nil:
 		return err
-	case memberAddressState.IsNot(as.AddressStateConsortiumMember):
+	case memberAddressState.IsNot(as.AddressStateConsortium):
 		return fmt.Errorf("%w (member)", errNotConsortiumMember)
 	}
 
@@ -218,7 +218,7 @@ func (e *proposalVerifier) ExcludeMemberProposal(proposal *dac.ExcludeMemberProp
 		switch {
 		case err != nil:
 			return err
-		case proposerAddressState.IsNot(as.AddressStateConsortiumMember):
+		case proposerAddressState.IsNot(as.AddressStateConsortium):
 			return fmt.Errorf("%w (proposer)", errNotConsortiumMember)
 		}
 
@@ -262,7 +262,7 @@ func (e *proposalExecutor) ExcludeMemberProposal(proposal *dac.ExcludeMemberProp
 	if err != nil {
 		return err
 	}
-	newAddrState := addrState ^ as.AddressStateConsortiumMember
+	newAddrState := addrState ^ as.AddressStateConsortium
 	if newAddrState == addrState {
 		// c-member was somehow already excluded
 		// this should never happen, cause excluding only done via excludeMemberProposal
@@ -341,7 +341,7 @@ func (e *proposalVerifier) GeneralProposal(*dac.GeneralProposal) error {
 	switch {
 	case err != nil:
 		return err
-	case proposerAddressState.IsNot(as.AddressStateConsortiumMember):
+	case proposerAddressState.IsNot(as.AddressStateConsortium):
 		return fmt.Errorf("%w (proposer)", errNotConsortiumMember)
 	}
 

--- a/vms/platformvm/txs/executor/dac/camino_dac_test.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac_test.go
@@ -214,7 +214,7 @@ func TestProposalVerifierAddMemberProposal(t *testing.T) {
 		"Applicant address is consortium member": {
 			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(applicantAddress).Return(as.AddressStateConsortiumMember, nil)
+				s.EXPECT().GetAddressStates(applicantAddress).Return(as.AddressStateConsortium, nil)
 				return s
 			},
 			utx: func() *txs.AddProposalTx {
@@ -332,7 +332,7 @@ func TestProposalExecutorAddMemberProposal(t *testing.T) {
 			state: func(c *gomock.Controller) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetAddressStates(applicantAddress).Return(applicantAddressState, nil)
-				s.EXPECT().SetAddressStates(applicantAddress, applicantAddressState|as.AddressStateConsortiumMember)
+				s.EXPECT().SetAddressStates(applicantAddress, applicantAddressState|as.AddressStateConsortium)
 				return s
 			},
 			proposal: &dac.AddMemberProposalState{
@@ -415,7 +415,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 		"Proposer is not consortium member": {
 			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortiumMember, nil)
+				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortium, nil)
 				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil)
 				return s
 			},
@@ -435,8 +435,8 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 		"Proposer doesn't have registered node": {
 			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortiumMember, nil)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortiumMember, nil)
+				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortium, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortium, nil)
 				s.EXPECT().GetShortIDLink(utx.ProposerAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortEmpty, database.ErrNotFound)
 				return s
 			},
@@ -456,8 +456,8 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 		"Proposer doesn't have active validator": {
 			state: func(c *gomock.Controller, utx *txs.AddProposalTx) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortiumMember, nil)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortiumMember, nil)
+				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortium, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortium, nil)
 				s.EXPECT().GetShortIDLink(utx.ProposerAddress, state.ShortLinkKeyRegisterNode).Return(memberNodeShortID, nil)
 				s.EXPECT().GetCurrentValidator(constants.PrimaryNetworkID, memberNodeID).Return(nil, database.ErrNotFound)
 				return s
@@ -483,8 +483,8 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Value().Return(&dac.ExcludeMemberProposalState{MemberAddress: memberAddress}, nil)
 				proposalsIterator.EXPECT().Release()
 
-				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortiumMember, nil)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortiumMember, nil)
+				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortium, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortium, nil)
 				s.EXPECT().GetShortIDLink(utx.ProposerAddress, state.ShortLinkKeyRegisterNode).Return(memberNodeShortID, nil)
 				s.EXPECT().GetCurrentValidator(constants.PrimaryNetworkID, memberNodeID).Return(memberValidator, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
@@ -511,7 +511,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Release()
 				proposalsIterator.EXPECT().Error().Return(nil)
 
-				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortiumMember, nil)
+				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortium, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
@@ -536,8 +536,8 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Release()
 				proposalsIterator.EXPECT().Error().Return(nil)
 
-				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortiumMember, nil)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortiumMember, nil)
+				s.EXPECT().GetAddressStates(memberAddress).Return(as.AddressStateConsortium, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateConsortium, nil)
 				s.EXPECT().GetShortIDLink(utx.ProposerAddress, state.ShortLinkKeyRegisterNode).Return(memberNodeShortID, nil)
 				s.EXPECT().GetCurrentValidator(constants.PrimaryNetworkID, memberNodeID).Return(memberValidator, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
@@ -578,7 +578,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 
 func TestProposalExecutorExcludeMemberProposal(t *testing.T) {
 	memberAddress := ids.ShortID{1}
-	memberAddressState := as.AddressStateCaminoProposer | as.AddressStateConsortiumMember // just not only c-member
+	memberAddressState := as.AddressStateCaminoProposer | as.AddressStateConsortium // just not only c-member
 	memberNodeShortID := ids.ShortID{2}
 	memberNodeID := ids.NodeID(memberNodeShortID)
 	memberValidator := &state.Staker{TxID: ids.ID{3}}
@@ -592,7 +592,7 @@ func TestProposalExecutorExcludeMemberProposal(t *testing.T) {
 			state: func(c *gomock.Controller) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetAddressStates(memberAddress).Return(memberAddressState, nil)
-				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortiumMember)
+				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortium)
 				s.EXPECT().GetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode).Return(memberNodeShortID, nil)
 				s.EXPECT().SetShortIDLink(memberNodeShortID, state.ShortLinkKeyRegisterNode, nil)
 				s.EXPECT().SetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode, nil)
@@ -614,7 +614,7 @@ func TestProposalExecutorExcludeMemberProposal(t *testing.T) {
 			state: func(c *gomock.Controller) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetAddressStates(memberAddress).Return(memberAddressState, nil)
-				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortiumMember)
+				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortium)
 				s.EXPECT().GetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode).Return(memberNodeShortID, nil)
 				s.EXPECT().SetShortIDLink(memberNodeShortID, state.ShortLinkKeyRegisterNode, nil)
 				s.EXPECT().SetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode, nil)
@@ -635,7 +635,7 @@ func TestProposalExecutorExcludeMemberProposal(t *testing.T) {
 			state: func(c *gomock.Controller) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetAddressStates(memberAddress).Return(memberAddressState, nil)
-				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortiumMember)
+				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortium)
 				s.EXPECT().GetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode).Return(memberNodeShortID, nil)
 				s.EXPECT().SetShortIDLink(memberNodeShortID, state.ShortLinkKeyRegisterNode, nil)
 				s.EXPECT().SetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode, nil)
@@ -655,7 +655,7 @@ func TestProposalExecutorExcludeMemberProposal(t *testing.T) {
 			state: func(c *gomock.Controller) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetAddressStates(memberAddress).Return(memberAddressState, nil)
-				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortiumMember)
+				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortium)
 				s.EXPECT().GetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode).Return(memberNodeShortID, nil)
 				s.EXPECT().SetShortIDLink(memberNodeShortID, state.ShortLinkKeyRegisterNode, nil)
 				s.EXPECT().SetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode, nil)
@@ -674,7 +674,7 @@ func TestProposalExecutorExcludeMemberProposal(t *testing.T) {
 			state: func(c *gomock.Controller) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetAddressStates(memberAddress).Return(memberAddressState, nil)
-				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortiumMember)
+				s.EXPECT().SetAddressStates(memberAddress, memberAddressState^as.AddressStateConsortium)
 				s.EXPECT().GetShortIDLink(memberAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortEmpty, database.ErrNotFound)
 				return s
 			},


### PR DESCRIPTION
## Why this should be merged
This PR is mainly focused on rewriting addressStateTx execution and syntacticVerify tests as well as refactoring some parts of addressStateTx execution logic.

Previous syntacticVerify wasn't correctly splitting test cases for testing package and wasn't handling all required test cases.

Previous execution test wasn't correctly testing things at all and there were also separate test function for testing node deferring/resuming.

And addressStateTx execution logic just had some checks and state actions in a not optimal order.

This PR also updates tx builder, so its addressStateTx method will support upgradeVersion1.
## How this works
SyntacticVerify test were simply rewritten, so it will match pattern of other syntactic tests, where each test case it called with its own t.Run(). There are also previously missing test cases, that were added.

AddressStateTx execution refactoring is basically only about renaming and some reshuffling of checks and state function calls, so checks will always go first before any other action, also prioritizing stateless checks first.

There are other small changes, but they're mostly renaming.

The most complex change is execution logic test rewrite. This complexity comes out of of transaction structure, 64 possible bits of address states, permissions logic and 3 different phases (for now ) that are putting different limitations on allowed bits and tx structure. So, it all have to be combined, and not every combination is possible. And some of combinations require different mock setups for state.
### codec.UpgradeVersion
In athens, we added new feature to codec.
Its a technical field called "UpgradeVersionID". It must be first field in struct. 
This field value is used to determine upgradeVersion value.
And fields of marshallable with codec structs like transactions, they could have tag "upgradeversion:n". Fields with this tag will be ignored if structure upgradeVersion is less, than tags value. 
## How this was tested
With new unit tests.
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminogo/pull/348