### PR TITLE
[PVM] Disable baseFee and feeDistribution proposal before CairoPhase 

### DIFF
--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -521,7 +521,7 @@ func TestProposals(t *testing.T) {
 				VerifyNodeSignature: true,
 				LockModeBondDeposit: true,
 				InitialAdmin:        test.FundedKeys[0].Address(),
-			}, test.PhaseLast, []api.UTXO{
+			}, test.PhaseCairo, []api.UTXO{ // TODO @evlekht replace with PhaseLast when cairo is added
 				{
 					Amount:  json.Uint64(balance),
 					Address: proposerAddrStr,

--- a/vms/platformvm/config/config.go
+++ b/vms/platformvm/config/config.go
@@ -118,6 +118,9 @@ type Config struct {
 	// Time of the BerlinPhase network upgrade
 	BerlinPhaseTime time.Time
 
+	// Time of the CairoPhase network upgrade
+	CairoPhaseTime time.Time
+
 	// Subnet ID --> Minimum portion of the subnet's stake this node must be
 	// connected to in order to report healthy.
 	// [constants.PrimaryNetworkID] is always a key in this map.
@@ -157,6 +160,10 @@ func (c *Config) IsAthensPhaseActivated(timestamp time.Time) bool {
 
 func (c *Config) IsBerlinPhaseActivated(timestamp time.Time) bool {
 	return !timestamp.Before(c.BerlinPhaseTime)
+}
+
+func (c *Config) IsCairoPhaseActivated(timestamp time.Time) bool {
+	return !timestamp.Before(c.CairoPhaseTime)
 }
 
 func (c *Config) GetCreateBlockchainTxFee(timestamp time.Time) uint64 {

--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -19,7 +19,7 @@ import (
 const (
 	generalProposalMaxOptionsCount = 3
 	generalProposalMaxOptionSize   = 256
-	generalProposalMinDuration     = uint64(time.Hour * 24 / time.Second)      // 1 day
+	GeneralProposalMinDuration     = uint64(time.Hour * 24 / time.Second)      // 1 day
 	generalProposalMaxDuration     = uint64(time.Hour * 24 * 30 / time.Second) // 1 month
 )
 
@@ -75,8 +75,8 @@ func (p *GeneralProposal) Verify() error {
 		return fmt.Errorf("%w (expected: no more than %d, actual: %d)", errWrongOptionsCount, generalProposalMaxOptionsCount, len(p.Options))
 	case p.Start >= p.End:
 		return errEndNotAfterStart
-	case p.End-p.Start < generalProposalMinDuration:
-		return fmt.Errorf("%w (expected: minimum duration %d, actual: %d)", errWrongDuration, generalProposalMinDuration, p.End-p.Start)
+	case p.End-p.Start < GeneralProposalMinDuration:
+		return fmt.Errorf("%w (expected: minimum duration %d, actual: %d)", errWrongDuration, GeneralProposalMinDuration, p.End-p.Start)
 	case p.End-p.Start > generalProposalMaxDuration:
 		return fmt.Errorf("%w (expected: maximum duration %d, actual: %d)", errWrongDuration, generalProposalMaxDuration, p.End-p.Start)
 	}

--- a/vms/platformvm/dac/camino_general_proposal_test.go
+++ b/vms/platformvm/dac/camino_general_proposal_test.go
@@ -71,12 +71,12 @@ func TestGeneralProposalVerify(t *testing.T) {
 		"To small duration": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration - 1,
+				End:     100 + GeneralProposalMinDuration - 1,
 				Options: [][]byte{{1}, {2}, {3}},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration - 1,
+				End:     100 + GeneralProposalMinDuration - 1,
 				Options: [][]byte{{1}, {2}, {3}},
 			},
 			expectedErr: errWrongDuration,
@@ -97,12 +97,12 @@ func TestGeneralProposalVerify(t *testing.T) {
 		"Option is bigger than allowed": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize+1)},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize+1)},
 			},
 			expectedErr: errGeneralProposalOptionIsToBig,
@@ -110,12 +110,12 @@ func TestGeneralProposalVerify(t *testing.T) {
 		"Not unique option": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{{1}, {2}, {1}},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{{1}, {2}, {1}},
 			},
 			expectedErr: errNotUniqueOption,
@@ -123,24 +123,24 @@ func TestGeneralProposalVerify(t *testing.T) {
 		"OK: 1 option": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize)},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize)},
 			},
 		},
 		"OK: 3 options": {
 			proposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{{1}, {2}, {3}},
 			},
 			expectedProposal: &GeneralProposal{
 				Start:   100,
-				End:     100 + generalProposalMinDuration,
+				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{{1}, {2}, {3}},
 			},
 		},

--- a/vms/platformvm/test/camino_defaults.go
+++ b/vms/platformvm/test/camino_defaults.go
@@ -72,11 +72,15 @@ func Config(t *testing.T, phase Phase) *config.Config {
 		athensTime        = mockable.MaxTime
 		cortinaTime       = mockable.MaxTime
 		berlinTime        = mockable.MaxTime
+		cairoTime         = mockable.MaxTime
 	)
 
 	// always reset LatestForkTime (a package level variable)
 	// to ensure test independence
 	switch phase {
+	case PhaseCairo:
+		cairoTime = LatestPhaseTime
+		fallthrough
 	case PhaseBerlin: // same time, as PhaseCortina
 		berlinTime = LatestPhaseTime
 		fallthrough
@@ -119,6 +123,7 @@ func Config(t *testing.T, phase Phase) *config.Config {
 		AthensPhaseTime:        athensTime,
 		CortinaTime:            cortinaTime,
 		BerlinPhaseTime:        berlinTime,
+		CairoPhaseTime:         cairoTime,
 		CaminoConfig: caminoconfig.Config{
 			DACProposalBondAmount: 100 * units.Avax,
 		},

--- a/vms/platformvm/test/camino_phase.go
+++ b/vms/platformvm/test/camino_phase.go
@@ -20,6 +20,7 @@ const (
 	PhaseAthens   Phase = 2
 	PhaseCortina  Phase = 3 // avax, included into Berlin phase
 	PhaseBerlin   Phase = 3
+	PhaseCairo    Phase = 4
 )
 
 // TODO @evlekht we might want to clean up sunrise/banff timestamps/relations later
@@ -37,6 +38,8 @@ func PhaseTime(t *testing.T, phase Phase, cfg *config.Config) time.Time {
 		return cfg.AthensPhaseTime
 	case PhaseBerlin:
 		return cfg.BerlinPhaseTime
+	case PhaseCairo:
+		return cfg.CairoPhaseTime
 	}
 	require.FailNow(t, "unknown phase")
 	return time.Time{}
@@ -50,6 +53,8 @@ func PhaseName(t *testing.T, phase Phase) string {
 		return "AthensPhase"
 	case PhaseBerlin:
 		return "BerlinPhase"
+	case PhaseCairo:
+		return "CairoPhase"
 	}
 	require.FailNow(t, "unknown phase")
 	return ""

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1766,7 +1766,7 @@ func (e *CaminoStandardTxExecutor) AddProposalTx(tx *txs.AddProposalTx) error {
 		return fmt.Errorf("%w: %s", errProposerCredentialMismatch, err)
 	}
 
-	if err := txProposal.VerifyWith(dac.NewProposalVerifier(e.State, tx, isAdminProposal)); err != nil {
+	if err := txProposal.VerifyWith(dac.NewProposalVerifier(e.Config, e.State, tx, isAdminProposal)); err != nil {
 		return fmt.Errorf("%w: %s", errInvalidProposal, err)
 	}
 
@@ -1799,7 +1799,6 @@ func (e *CaminoStandardTxExecutor) AddProposalTx(tx *txs.AddProposalTx) error {
 	var proposalState dacProposals.ProposalState
 
 	if isAdminProposal {
-		// currently we only have addMember and excludeMember proposals, and their option 0 is "success" option
 		proposalState, err = txProposal.CreateFinishedProposalState(adminProposal.OptionIndex)
 		if err != nil {
 			// should never happen


### PR DESCRIPTION
## Why this should be merged
BaseFee and FeeDistribution proposals are still missing some cross-chain logic, so we don't want them to be active now.
This PR disables those proposals till the next phase.
## How this works
Add check for cairo phase in baseFee and feeDistribution proposal verifier.
## How this was tested
With existing unit-tests and integration tests with addition of some new test cases.
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminogo/pull/350