### PR TITLE
[PVM] Add validator admin role, reduce root admin permissions

### DIFF
--- a/vms/platformvm/addrstate/camino_address_state.go
+++ b/vms/platformvm/addrstate/camino_address_state.go
@@ -9,50 +9,74 @@ type (
 const (
 	// Bits
 
-	AddressStateBitRoleAdmin AddressStateBit = 0 // super role
+	// Allow to set role bits
+	AddressStateBitRoleAdmin AddressStateBit = 0
+	// Allows to set KYC and KYB bits
+	AddressStateBitRoleKYCAdmin AddressStateBit = 1
+	// Allows to set OffersCreator bit
+	AddressStateBitRoleOffersAdmin AddressStateBit = 2
+	// Allows to create addMember and excludeMember admin-proposals
+	AddressStateBitRoleConsortiumSecretary AddressStateBit = 3
+	// Allows to set node deferred bit
+	AddressStateBitRoleValidatorAdmin AddressStateBit = 4
 
-	AddressStateBitRoleKYCAdmin                AddressStateBit = 1 // allows to set KYCVerified and KYCExpired
-	AddressStateBitRoleOffersAdmin             AddressStateBit = 2 // allows to set OffersCreator
-	AddressStateBitRoleConsortiumAdminProposer AddressStateBit = 3 // allows to create admin add/exclude member proposals
-
-	AddressStateBitKYCVerified    AddressStateBit = 32
-	AddressStateBitKYCExpired     AddressStateBit = 33
-	AddressStateBitConsortium     AddressStateBit = 38
-	AddressStateBitNodeDeferred   AddressStateBit = 39
-	AddressStateBitOffersCreator  AddressStateBit = 50
-	AddressStateBitCaminoProposer AddressStateBit = 51
+	// Indicates that address passed KYC verification
+	AddressStateBitKYCVerified AddressStateBit = 32
+	// Indicates that address KYC verification is expired. (not yet implemented)
+	AddressStateBitKYCExpired AddressStateBit = 33
+	// Indicates that address is member of consortium
+	AddressStateBitConsortium AddressStateBit = 38
+	// Indicates that a node owned by this address (as consortium member) is deferred
+	AddressStateBitNodeDeferred AddressStateBit = 39
+	// Allows to create deposit offers
+	AddressStateBitOffersCreator AddressStateBit = 50
+	// Allows to create baseFee and feeDistribution proposals
+	AddressStateBitFoundationAdmin AddressStateBit = 51
 
 	AddressStateBitMax AddressStateBit = 63
 
 	// States
 
+	// 0b0000000000000000000000000000000000000000000000000000000000000000
 	AddressStateEmpty AddressState = 0
 
-	AddressStateRoleAdmin                   = AddressState(1) << AddressStateBitRoleAdmin                   // 0b1
-	AddressStateRoleKYCAdmin                = AddressState(1) << AddressStateBitRoleKYCAdmin                // 0b10
-	AddressStateRoleOffersAdmin             = AddressState(1) << AddressStateBitRoleOffersAdmin             // 0b100
-	AddressStateRoleConsortiumAdminProposer = AddressState(1) << AddressStateBitRoleConsortiumAdminProposer // 0b1000
+	// 0b0000000000000000000000000000000000000000000000000000000000000001
+	AddressStateRoleAdmin = AddressState(1) << AddressStateBitRoleAdmin
+	// 0b0000000000000000000000000000000000000000000000000000000000000010
+	AddressStateRoleKYCAdmin = AddressState(1) << AddressStateBitRoleKYCAdmin
+	// 0b0000000000000000000000000000000000000000000000000000000000000100
+	AddressStateRoleOffersAdmin = AddressState(1) << AddressStateBitRoleOffersAdmin
+	// 0b0000000000000000000000000000000000000000000000000000000000001000
+	AddressStateRoleConsortiumSecretary = AddressState(1) << AddressStateBitRoleConsortiumSecretary
+	// 0b0000000000000000000000000000000000000000000000000000000000010000
+	AddressStateRoleValidatorAdmin = AddressState(1) << AddressStateBitRoleValidatorAdmin
 
-	AddressStateKYCVerified = AddressState(1) << AddressStateBitKYCVerified // 0b0100000000000000000000000000000000
-	AddressStateKYCExpired  = AddressState(1) << AddressStateBitKYCExpired  // 0b1000000000000000000000000000000000
-
-	AddressStateConsortium   = AddressState(1) << AddressStateBitConsortium   // 0b0100000000000000000000000000000000000000
-	AddressStateNodeDeferred = AddressState(1) << AddressStateBitNodeDeferred // 0b1000000000000000000000000000000000000000
-
-	AddressStateOffersCreator  = AddressState(1) << AddressStateBitOffersCreator  // 0b0100000000000000000000000000000000000000000000000000
-	AddressStateCaminoProposer = AddressState(1) << AddressStateBitCaminoProposer // 0b1000000000000000000000000000000000000000000000000000
+	// 0b0000000000000000000000000000000100000000000000000000000000000000
+	AddressStateKYCVerified = AddressState(1) << AddressStateBitKYCVerified
+	// 0b0000000000000000000000000000001000000000000000000000000000000000
+	AddressStateKYCExpired = AddressState(1) << AddressStateBitKYCExpired
+	// 0b0000000000000000000000000100000000000000000000000000000000000000
+	AddressStateConsortium = AddressState(1) << AddressStateBitConsortium
+	// 0b0000000000000000000000001000000000000000000000000000000000000000
+	AddressStateNodeDeferred = AddressState(1) << AddressStateBitNodeDeferred
+	// 0b0000000000000100000000000000000000000000000000000000000000000000
+	AddressStateOffersCreator = AddressState(1) << AddressStateBitOffersCreator
+	// 0b0000000000001000000000000000000000000000000000000000000000000000
+	AddressStateFoundationAdmin = AddressState(1) << AddressStateBitFoundationAdmin
 
 	// Bit groups (as AddressState)
 
-	AddressStateSunrisePhaseBits = AddressStateRoleAdmin | AddressStateRoleKYCAdmin | // 0b1100001100000000000000000000000000000011
+	// 0b0000000000000000000000001100001100000000000000000000000000000011
+	AddressStateSunrisePhaseBits = AddressStateRoleAdmin | AddressStateRoleKYCAdmin |
 		AddressStateKYCVerified | AddressStateKYCExpired | AddressStateConsortium |
 		AddressStateNodeDeferred
-
-	AddressStateAthensPhaseBits = AddressStateRoleOffersAdmin | AddressStateOffersCreator // 0b0100000000000000000000000000000000000000000000000100
-
-	AddressStateBerlinPhaseBits = AddressStateCaminoProposer | AddressStateRoleConsortiumAdminProposer // 0b1000000000000000000000000000000000000000000000001000
-
-	AddressStateValidBits = AddressStateSunrisePhaseBits | // 0b1100000000001100001100000000000000000000000000001111
+	// 0b0000000000000100000000000000000000000000000000000000000000000100
+	AddressStateAthensPhaseBits = AddressStateRoleOffersAdmin | AddressStateOffersCreator
+	// 0b0000000000001000000000000000000000000000000000000000000000001000
+	AddressStateBerlinPhaseBits = AddressStateFoundationAdmin | AddressStateRoleConsortiumSecretary |
+		AddressStateRoleValidatorAdmin
+	// 0b0000000000001100000000001100001100000000000000000000000000011111
+	AddressStateValidBits = AddressStateSunrisePhaseBits |
 		AddressStateAthensPhaseBits |
 		AddressStateBerlinPhaseBits
 )

--- a/vms/platformvm/dac/camino_add_member_proposal.go
+++ b/vms/platformvm/dac/camino_add_member_proposal.go
@@ -39,7 +39,7 @@ func (*AddMemberProposal) GetOptions() any {
 }
 
 func (*AddMemberProposal) AdminProposer() as.AddressState {
-	return as.AddressStateRoleConsortiumAdminProposer
+	return as.AddressStateRoleConsortiumSecretary
 }
 
 func (p *AddMemberProposal) Verify() error {

--- a/vms/platformvm/dac/camino_exclude_member_proposal.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal.go
@@ -46,7 +46,7 @@ func (p *ExcludeMemberProposal) GetData() any {
 }
 
 func (*ExcludeMemberProposal) AdminProposer() as.AddressState {
-	return as.AddressStateRoleConsortiumAdminProposer
+	return as.AddressStateRoleConsortiumSecretary
 }
 
 func (p *ExcludeMemberProposal) Verify() error {

--- a/vms/platformvm/dac/camino_proposal.go
+++ b/vms/platformvm/dac/camino_proposal.go
@@ -60,11 +60,12 @@ type Proposal interface {
 
 	StartTime() time.Time
 	EndTime() time.Time
-	// AddressStateEmpty means that this proposal can't be used as admin proposal
-	AdminProposer() as.AddressState
 	CreateProposalState(allowedVoters []ids.ShortID) ProposalState
 	CreateFinishedProposalState(optionIndex uint32) (ProposalState, error)
 	VerifyWith(Verifier) error
+
+	// AddressStateEmpty means that this proposal can't be used as admin proposal
+	AdminProposer() as.AddressState
 
 	// Returns proposal options. (used in magellan)
 	//

--- a/vms/platformvm/txs/executor/camino_advance_time_test.go
+++ b/vms/platformvm/txs/executor/camino_advance_time_test.go
@@ -208,6 +208,10 @@ func TestDeferredStakers(t *testing.T) {
 			env.config.TrackedSubnets.Add(subnetID)
 			env.config.Validators.Add(subnetID, validators.NewSet())
 
+			addrState, err := env.state.GetAddressStates(test.FundedKeys[0].Address())
+			require.NoError(err)
+			env.state.SetAddressStates(test.FundedKeys[0].Address(), addrState|as.AddressStateRoleValidatorAdmin)
+
 			for _, staker := range tt.stakers {
 				_, err := addCaminoPendingValidator(
 					env,

--- a/vms/platformvm/txs/executor/dac/camino_dac.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac.go
@@ -103,7 +103,7 @@ func (e *proposalVerifier) BaseFeeProposal(*dac.BaseFeeProposal) error {
 		return err
 	}
 
-	if proposerAddressState.IsNot(as.AddressStateCaminoProposer) {
+	if proposerAddressState.IsNot(as.AddressStateFoundationAdmin) {
 		return errNotPermittedToCreateProposal
 	}
 
@@ -372,7 +372,7 @@ func (e *proposalVerifier) FeeDistributionProposal(*dac.FeeDistributionProposal)
 		return err
 	}
 
-	if proposerAddressState.IsNot(as.AddressStateCaminoProposer) {
+	if proposerAddressState.IsNot(as.AddressStateFoundationAdmin) {
 		return errNotPermittedToCreateProposal
 	}
 

--- a/vms/platformvm/txs/executor/dac/camino_dac_test.go
+++ b/vms/platformvm/txs/executor/dac/camino_dac_test.go
@@ -82,11 +82,11 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 			},
 			expectedErr: errNotCairoPhase,
 		},
-		"Proposer isn't caminoProposer": {
+		"Proposer isn't FoundationAdmin": {
 			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateCaminoProposer
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateFoundationAdmin
 				return s
 			},
 			config: defaultConfig,
@@ -112,7 +112,7 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Release()
 
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateFoundationAdmin, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
@@ -139,7 +139,7 @@ func TestProposalVerifierBaseFeeProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Error().Return(nil)
 
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateFoundationAdmin, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
@@ -354,7 +354,7 @@ func TestProposalVerifierAddMemberProposal(t *testing.T) {
 
 func TestProposalExecutorAddMemberProposal(t *testing.T) {
 	applicantAddress := ids.ShortID{1}
-	applicantAddressState := as.AddressStateCaminoProposer // just not empty
+	applicantAddressState := as.AddressStateFoundationAdmin // just not empty
 
 	tests := map[string]struct {
 		state       func(*gomock.Controller) *state.MockDiff
@@ -616,7 +616,7 @@ func TestProposalVerifierExcludeMemberProposal(t *testing.T) {
 
 func TestProposalExecutorExcludeMemberProposal(t *testing.T) {
 	memberAddress := ids.ShortID{1}
-	memberAddressState := as.AddressStateCaminoProposer | as.AddressStateConsortium // just not only c-member
+	memberAddressState := as.AddressStateFoundationAdmin | as.AddressStateConsortium // just not only c-member
 	memberNodeShortID := ids.ShortID{2}
 	memberNodeID := ids.NodeID(memberNodeShortID)
 	memberValidator := &state.Staker{TxID: ids.ID{3}}
@@ -922,11 +922,11 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 			},
 			expectedErr: errNotCairoPhase,
 		},
-		"Proposer isn't caminoProposer": {
+		"Proposer isn't FoundationAdmin": {
 			state: func(c *gomock.Controller, utx *txs.AddProposalTx, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateCaminoProposer
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateEmpty, nil) // not AddressStateFoundationAdmin
 				return s
 			},
 			config: defaultConfig,
@@ -952,7 +952,7 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Release()
 
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateFoundationAdmin, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},
@@ -979,7 +979,7 @@ func TestProposalVerifierFeeDistributionProposal(t *testing.T) {
 				proposalsIterator.EXPECT().Error().Return(nil)
 
 				s.EXPECT().GetTimestamp().Return(cfg.CairoPhaseTime)
-				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateCaminoProposer, nil)
+				s.EXPECT().GetAddressStates(utx.ProposerAddress).Return(as.AddressStateFoundationAdmin, nil)
 				s.EXPECT().GetProposalIterator().Return(proposalsIterator, nil)
 				return s
 			},


### PR DESCRIPTION
## Why this should be merged
This PR improves addr state roles permissions segregation:
- starting with BerlinPhase, AddressStateRoleAdmin can only modify role bits.
-  new role AddressStateRoleValidatorAdmin can defer/resume node.

There also some renamings to address states.
## How this works
In addition to changes in address state permissions logic, there are some changes in tests:
- integration tests where changed in accordance with permission changes
- AddressStateTx executor unit-test is changed in order to accommodate new for new possibility: that some role may have different rights in different phases.
## How this was tested
With existing unit-tests and integration tests.
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminogo/pull/351