### PR TITLE
[PVM] Add the functionality of multisig alias definition removal in MultisigAliasTx

### DIFF
--- a/vms/platformvm/dac/camino_add_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_add_member_proposal_test.go
@@ -38,7 +38,7 @@ func TestAddMemberProposalVerify(t *testing.T) {
 			},
 			expectedErr: errEndNotAfterStart,
 		},
-		"To small duration": {
+		"Too small duration": {
 			proposal: &AddMemberProposal{
 				Start: 100,
 				End:   100 + AddMemberProposalDuration - 1,
@@ -49,7 +49,7 @@ func TestAddMemberProposalVerify(t *testing.T) {
 			},
 			expectedErr: errWrongDuration,
 		},
-		"To big duration": {
+		"Too big duration": {
 			proposal: &AddMemberProposal{
 				Start: 100,
 				End:   100 + AddMemberProposalDuration + 1,

--- a/vms/platformvm/dac/camino_exclude_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal_test.go
@@ -38,7 +38,7 @@ func TestExcludeMemberProposalVerify(t *testing.T) {
 			},
 			expectedErr: errEndNotAfterStart,
 		},
-		"To small duration": {
+		"Too small duration": {
 			proposal: &ExcludeMemberProposal{
 				Start: 100,
 				End:   100 + ExcludeMemberProposalMinDuration - 1,
@@ -49,7 +49,7 @@ func TestExcludeMemberProposalVerify(t *testing.T) {
 			},
 			expectedErr: errWrongDuration,
 		},
-		"To big duration": {
+		"Too big duration": {
 			proposal: &ExcludeMemberProposal{
 				Start: 100,
 				End:   100 + ExcludeMemberProposalMaxDuration + 1,

--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -27,8 +27,8 @@ var (
 	_ Proposal      = (*GeneralProposal)(nil)
 	_ ProposalState = (*GeneralProposalState)(nil)
 
-	errGeneralProposalOptionIsToBig = errors.New("option size is to big")
-	errNotImplemented               = errors.New("not implemented, should never be called")
+	errGeneralProposalOptionIsTooBig = errors.New("option size is too big")
+	errNotImplemented                = errors.New("not implemented, should never be called")
 )
 
 type GeneralProposal struct {
@@ -83,7 +83,7 @@ func (p *GeneralProposal) Verify() error {
 	for i := 0; i < len(p.Options); i++ {
 		if len(p.Options[i]) > generalProposalMaxOptionSize {
 			return fmt.Errorf("%w (expected: no more than %d, actual: %d, option index: %d)",
-				errGeneralProposalOptionIsToBig, generalProposalMaxOptionSize, len(p.Options[i]), i)
+				errGeneralProposalOptionIsTooBig, generalProposalMaxOptionSize, len(p.Options[i]), i)
 		}
 		for j := i + 1; j < len(p.Options); j++ {
 			if bytes.Equal(p.Options[i], p.Options[j]) {

--- a/vms/platformvm/dac/camino_general_proposal_test.go
+++ b/vms/platformvm/dac/camino_general_proposal_test.go
@@ -68,7 +68,7 @@ func TestGeneralProposalVerify(t *testing.T) {
 			},
 			expectedErr: errEndNotAfterStart,
 		},
-		"To small duration": {
+		"Too small duration": {
 			proposal: &GeneralProposal{
 				Start:   100,
 				End:     100 + GeneralProposalMinDuration - 1,
@@ -81,7 +81,7 @@ func TestGeneralProposalVerify(t *testing.T) {
 			},
 			expectedErr: errWrongDuration,
 		},
-		"To big duration": {
+		"Too big duration": {
 			proposal: &GeneralProposal{
 				Start:   100,
 				End:     100 + generalProposalMaxDuration + 1,
@@ -105,7 +105,7 @@ func TestGeneralProposalVerify(t *testing.T) {
 				End:     100 + GeneralProposalMinDuration,
 				Options: [][]byte{make([]byte, generalProposalMaxOptionSize+1)},
 			},
-			expectedErr: errGeneralProposalOptionIsToBig,
+			expectedErr: errGeneralProposalOptionIsTooBig,
 		},
 		"Not unique option": {
 			proposal: &GeneralProposal{

--- a/vms/platformvm/state/camino.go
+++ b/vms/platformvm/state/camino.go
@@ -108,7 +108,7 @@ type CaminoDiff interface {
 	// Multisig Owners
 
 	GetMultisigAlias(ids.ShortID) (*multisig.AliasWithNonce, error)
-	SetMultisigAlias(*multisig.AliasWithNonce)
+	SetMultisigAlias(ids.ShortID, *multisig.AliasWithNonce)
 
 	// ShortIDsLink
 
@@ -425,7 +425,7 @@ func (cs *caminoState) syncGenesis(s *state, g *genesis.State) error {
 	// adding msig aliases
 
 	for _, multisigAlias := range g.Camino.MultisigAliases {
-		cs.SetMultisigAlias(&multisig.AliasWithNonce{Alias: *multisigAlias})
+		cs.SetMultisigAlias(multisigAlias.ID, &multisig.AliasWithNonce{Alias: *multisigAlias})
 	}
 
 	// adding blocks (validators and deposits)

--- a/vms/platformvm/state/camino_address_state.go
+++ b/vms/platformvm/state/camino_address_state.go
@@ -44,7 +44,7 @@ func (cs *caminoState) GetAddressStates(address ids.ShortID) (as.AddressState, e
 func (cs *caminoState) writeAddressStates() error {
 	for key, val := range cs.modifiedAddressStates {
 		delete(cs.modifiedAddressStates, key)
-		if val == 0 {
+		if val == as.AddressStateEmpty {
 			if err := cs.addressStateDB.Delete(key[:]); err != nil {
 				return err
 			}

--- a/vms/platformvm/state/camino_diff.go
+++ b/vms/platformvm/state/camino_diff.go
@@ -273,8 +273,8 @@ func (d *diff) GetNextToUnlockDepositIDsAndTime(removedDepositIDs set.Set[ids.ID
 	return nextDepositIDs, nextUnlockTime, nil
 }
 
-func (d *diff) SetMultisigAlias(alias *multisig.AliasWithNonce) {
-	d.caminoDiff.modifiedMultisigAliases[alias.ID] = alias
+func (d *diff) SetMultisigAlias(id ids.ShortID, alias *multisig.AliasWithNonce) {
+	d.caminoDiff.modifiedMultisigAliases[id] = alias
 }
 
 func (d *diff) GetMultisigAlias(alias ids.ShortID) (*multisig.AliasWithNonce, error) {
@@ -682,8 +682,8 @@ func (d *diff) ApplyCaminoState(baseState State) error {
 		}
 	}
 
-	for _, v := range d.caminoDiff.modifiedMultisigAliases {
-		baseState.SetMultisigAlias(v)
+	for multisigAliasID, multisigAlias := range d.caminoDiff.modifiedMultisigAliases {
+		baseState.SetMultisigAlias(multisigAliasID, multisigAlias)
 	}
 
 	for fullKey, link := range d.caminoDiff.modifiedShortLinks {

--- a/vms/platformvm/state/camino_diff_test.go
+++ b/vms/platformvm/state/camino_diff_test.go
@@ -2383,7 +2383,7 @@ func TestDiffSetMultisigAlias(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			tt.diff.SetMultisigAlias(tt.alias)
+			tt.diff.SetMultisigAlias(tt.alias.ID, tt.alias)
 			require.Equal(t, tt.expectedDiff, tt.diff)
 		})
 	}
@@ -5185,8 +5185,8 @@ func TestDiffApplyCaminoState(t *testing.T) {
 						s.EXPECT().ModifyDeposit(depositTxID, depositDiff.Deposit)
 					}
 				}
-				for _, v := range d.caminoDiff.modifiedMultisigAliases {
-					s.EXPECT().SetMultisigAlias(v)
+				for multisigAliasID, multisigAlias := range d.caminoDiff.modifiedMultisigAliases {
+					s.EXPECT().SetMultisigAlias(multisigAliasID, multisigAlias)
 				}
 				for fullKey, link := range d.caminoDiff.modifiedShortLinks {
 					id, key := fromShortLinkKey(fullKey)

--- a/vms/platformvm/state/camino_multisig_alias.go
+++ b/vms/platformvm/state/camino_multisig_alias.go
@@ -9,20 +9,19 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/vms/components/multisig"
-	"github.com/ava-labs/avalanchego/vms/components/verify"
 	"github.com/ava-labs/avalanchego/vms/platformvm/blocks"
 	"github.com/ava-labs/avalanchego/vms/types"
 )
 
 type msigAlias struct {
 	Memo   types.JSONByteSlice `serialize:"true"`
-	Owners verify.State        `serialize:"true"`
+	Owners multisig.Owners     `serialize:"true"`
 	Nonce  uint64              `serialize:"true"`
 }
 
-func (cs *caminoState) SetMultisigAlias(ma *multisig.AliasWithNonce) {
-	cs.modifiedMultisigAliases[ma.ID] = ma
-	cs.multisigAliasesCache.Evict(ma.ID)
+func (cs *caminoState) SetMultisigAlias(id ids.ShortID, ma *multisig.AliasWithNonce) {
+	cs.modifiedMultisigAliases[id] = ma
+	cs.multisigAliasesCache.Evict(id)
 }
 
 func (cs *caminoState) GetMultisigAlias(id ids.ShortID) (*multisig.AliasWithNonce, error) {

--- a/vms/platformvm/state/camino_multisig_alias_test.go
+++ b/vms/platformvm/state/camino_multisig_alias_test.go
@@ -222,9 +222,8 @@ func TestSetMultisigAlias(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			caminoState := tt.caminoState(ctrl)
-			caminoState.SetMultisigAlias(tt.multisigAlias)
+			caminoState := tt.caminoState(gomock.NewController(t))
+			caminoState.SetMultisigAlias(tt.multisigAlias.ID, tt.multisigAlias)
 			require.Equal(t, tt.expectedCaminoState(caminoState), caminoState)
 		})
 	}

--- a/vms/platformvm/state/camino_state.go
+++ b/vms/platformvm/state/camino_state.go
@@ -94,8 +94,8 @@ func (s *state) GetNextToUnlockDepositIDsAndTime(removedDepositIDs set.Set[ids.I
 	return s.caminoState.GetNextToUnlockDepositIDsAndTime(removedDepositIDs)
 }
 
-func (s *state) SetMultisigAlias(owner *multisig.AliasWithNonce) {
-	s.caminoState.SetMultisigAlias(owner)
+func (s *state) SetMultisigAlias(id ids.ShortID, owner *multisig.AliasWithNonce) {
+	s.caminoState.SetMultisigAlias(id, owner)
 }
 
 func (s *state) GetMultisigAlias(alias ids.ShortID) (*multisig.AliasWithNonce, error) {

--- a/vms/platformvm/state/mock_chain.go
+++ b/vms/platformvm/state/mock_chain.go
@@ -969,15 +969,15 @@ func (mr *MockChainMockRecorder) SetLastRewardImportTimestamp(arg0 interface{}) 
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockChain) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
+func (m *MockChain) SetMultisigAlias(arg0 ids.ShortID, arg1 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMultisigAlias", arg0)
+	m.ctrl.Call(m, "SetMultisigAlias", arg0, arg1)
 }
 
 // SetMultisigAlias indicates an expected call of SetMultisigAlias.
-func (mr *MockChainMockRecorder) SetMultisigAlias(arg0 interface{}) *gomock.Call {
+func (mr *MockChainMockRecorder) SetMultisigAlias(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockChain)(nil).SetMultisigAlias), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockChain)(nil).SetMultisigAlias), arg0, arg1)
 }
 
 // SetNotDistributedValidatorReward mocks base method.

--- a/vms/platformvm/state/mock_diff.go
+++ b/vms/platformvm/state/mock_diff.go
@@ -984,15 +984,15 @@ func (mr *MockDiffMockRecorder) SetDelegateeReward(arg0, arg1, arg2 interface{})
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockDiff) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
+func (m *MockDiff) SetMultisigAlias(arg0 ids.ShortID, arg1 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMultisigAlias", arg0)
+	m.ctrl.Call(m, "SetMultisigAlias", arg0, arg1)
 }
 
 // SetMultisigAlias indicates an expected call of SetMultisigAlias.
-func (mr *MockDiffMockRecorder) SetMultisigAlias(arg0 interface{}) *gomock.Call {
+func (mr *MockDiffMockRecorder) SetMultisigAlias(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockDiff)(nil).SetMultisigAlias), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockDiff)(nil).SetMultisigAlias), arg0, arg1)
 }
 
 // SetNotDistributedValidatorReward mocks base method.

--- a/vms/platformvm/state/mock_state.go
+++ b/vms/platformvm/state/mock_state.go
@@ -1145,15 +1145,15 @@ func (mr *MockStateMockRecorder) SetLastAccepted(arg0 interface{}) *gomock.Call 
 }
 
 // SetMultisigAlias mocks base method.
-func (m *MockState) SetMultisigAlias(arg0 *multisig.AliasWithNonce) {
+func (m *MockState) SetMultisigAlias(arg0 ids.ShortID, arg1 *multisig.AliasWithNonce) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMultisigAlias", arg0)
+	m.ctrl.Call(m, "SetMultisigAlias", arg0, arg1)
 }
 
 // SetMultisigAlias indicates an expected call of SetMultisigAlias.
-func (mr *MockStateMockRecorder) SetMultisigAlias(arg0 interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) SetMultisigAlias(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockState)(nil).SetMultisigAlias), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMultisigAlias", reflect.TypeOf((*MockState)(nil).SetMultisigAlias), arg0, arg1)
 }
 
 // SetNotDistributedValidatorReward mocks base method.

--- a/vms/platformvm/txs/camino_deposit_tx.go
+++ b/vms/platformvm/txs/camino_deposit_tx.go
@@ -19,7 +19,7 @@ import (
 var (
 	_ UnsignedTx = (*DepositTx)(nil)
 
-	errTooBigDeposit         = errors.New("to big deposit")
+	errTooBigDeposit         = errors.New("too big deposit")
 	errInvalidRewardOwner    = errors.New("invalid reward owner")
 	errBadOfferOwnerAuth     = errors.New("bad offer owner auth")
 	errBadDepositCreatorAuth = errors.New("bad deposit creator auth")

--- a/vms/platformvm/txs/camino_deposit_tx_test.go
+++ b/vms/platformvm/txs/camino_deposit_tx_test.go
@@ -37,7 +37,7 @@ func TestDepositTxSyntacticVerify(t *testing.T) {
 			},
 			expectedErr: errInvalidRewardOwner,
 		},
-		"To big total deposit amount": {
+		"Too big total deposit amount": {
 			tx: &DepositTx{
 				BaseTx: BaseTx{BaseTx: avax.BaseTx{
 					NetworkID:    ctx.NetworkID,

--- a/vms/platformvm/txs/camino_multisig_alias_tx.go
+++ b/vms/platformvm/txs/camino_multisig_alias_tx.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	_                            UnsignedTx = (*MultisigAliasTx)(nil)
-	errFailedToVerifyAliasOrAuth            = errors.New("failed to verify alias or auth")
+	_ UnsignedTx = (*MultisigAliasTx)(nil)
+
+	errFailedToVerifyAliasOrAuth = errors.New("failed to verify alias or auth")
 )
 
 // MultisigAliasTx is an unsigned multisig alias tx

--- a/vms/secp256k1fx/output_owners.go
+++ b/vms/secp256k1fx/output_owners.go
@@ -120,6 +120,10 @@ func (out *OutputOwners) Equals(other *OutputOwners) bool {
 	return true
 }
 
+func (out *OutputOwners) IsZero() bool {
+	return out.Equals(&OutputOwners{})
+}
+
 func (out *OutputOwners) Verify() error {
 	switch {
 	case out == nil:


### PR DESCRIPTION
## Why this should be merged
This PR adds the functionality of removing a multisig alias definition. Alias cannot be removed if its consortium member or role admin.
## How this works
If MultisigAliasTx contains empty multisig alias definition, but non-empty alias ID, than its removal.
To clarify: empty alias definition means that owners has no address and threshold is 0.
## How this was tested
By existing unit test with newly added test cases.
## Co-authors:
See original PR.
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminogo/pull/356