### PR TITLE
[PVM] Add kyb verified state, allow kyb verified to propose add member 

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,7 +9,7 @@ fi
 
 # The -P option is not supported by the grep version installed by
 # default on macos. Since `-o errexit` is ignored in an if
-# conditional, triggering the problem here ensures script failure whenTESTS
+# conditional, triggering the problem here ensures script failure when
 # using an unsupported version of grep.
 grep -P 'lint.sh' scripts/lint.sh &> /dev/null || (\
   >&2 echo "error: This script requires a recent version of gnu grep.";\

--- a/vms/platformvm/addrstate/camino_address_state.go
+++ b/vms/platformvm/addrstate/camino_address_state.go
@@ -27,6 +27,8 @@ const (
 	AddressStateBitKYCVerified AddressStateBit = 32
 	// Indicates that address KYC verification is expired. (not yet implemented)
 	AddressStateBitKYCExpired AddressStateBit = 33
+	// Indicates that address passed KYB verification
+	AddressStateBitKYBVerified AddressStateBit = 34
 	// Indicates that address is member of consortium
 	AddressStateBitConsortium AddressStateBit = 38
 	// Indicates that a node owned by this address (as consortium member) is deferred
@@ -58,6 +60,9 @@ const (
 	AddressStateKYCVerified = AddressState(1) << AddressStateBitKYCVerified
 	// 0b0000000000000000000000000000001000000000000000000000000000000000
 	AddressStateKYCExpired = AddressState(1) << AddressStateBitKYCExpired
+	// 0b0000000000000000000000000000010000000000000000000000000000000000
+	AddressStateKYBVerified = AddressState(1) << AddressStateBitKYBVerified
+
 	// 0b0000000000000000000000000100000000000000000000000000000000000000
 	AddressStateConsortium = AddressState(1) << AddressStateBitConsortium
 	// 0b0000000000000000000000001000000000000000000000000000000000000000
@@ -75,10 +80,10 @@ const (
 		AddressStateNodeDeferred
 	// 0b0000000000000100000000000000000000000000000000000000000000000100
 	AddressStateAthensPhaseBits = AddressStateRoleOffersAdmin | AddressStateOffersCreator
-	// 0b0000000000001000000000000000000000000000000000000000000000001000
+	// 0b0000000000001000000000000000010000000000000000000000000000001000
 	AddressStateBerlinPhaseBits = AddressStateFoundationAdmin | AddressStateRoleConsortiumSecretary |
-		AddressStateRoleValidatorAdmin
-	// 0b0000000000001100000000001100001100000000000000000000000000011111
+		AddressStateRoleValidatorAdmin | AddressStateKYBVerified
+	// 0b0000000000001100000000001100011100000000000000000000000000011111
 	AddressStateValidBits = AddressStateSunrisePhaseBits |
 		AddressStateAthensPhaseBits |
 		AddressStateBerlinPhaseBits

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -2306,7 +2306,7 @@ func (e *CaminoStandardTxExecutor) AddressStateTx(tx *txs.AddressStateTx) error 
 }
 
 const (
-	addressStateKYCAll   = as.AddressStateKYCVerified | as.AddressStateKYCExpired
+	addressStateKYCAll   = as.AddressStateKYCVerified | as.AddressStateKYCExpired | as.AddressStateKYBVerified
 	addressStateRoleBits = as.AddressStateRoleAdmin | as.AddressStateRoleKYCAdmin |
 		as.AddressStateRoleConsortiumSecretary | as.AddressStateRoleOffersAdmin |
 		as.AddressStateRoleValidatorAdmin | as.AddressStateFoundationAdmin
@@ -2317,7 +2317,7 @@ func isPermittedToModifyAddrStateBit(isBerlinPhase bool, roles, state as.Address
 	switch {
 	// admin can do anything before BerlinPhase, after that admin can only modify other roles
 	case roles.Is(as.AddressStateRoleAdmin) && (!isBerlinPhase || addressStateRoleBits&state != 0):
-	// kyc role can change kyc status
+	// kyc role can change kyc/kyb bits
 	case addressStateKYCAll&state != 0 && roles.Is(as.AddressStateRoleKYCAdmin):
 	// offers admin can assign offers creator role
 	case state == as.AddressStateOffersCreator && roles.Is(as.AddressStateRoleOffersAdmin):

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -2088,6 +2088,7 @@ func TestCaminoStandardTxExecutorAddressStateTx(t *testing.T) {
 	for _, permissionsMatrix := range permissionsMatrix {
 		permissionsMatrix[as.AddressStateBitRoleKYCAdmin][as.AddressStateBitKYCVerified] = nil
 		permissionsMatrix[as.AddressStateBitRoleKYCAdmin][as.AddressStateBitKYCExpired] = nil
+		permissionsMatrix[as.AddressStateBitRoleKYCAdmin][as.AddressStateBitKYBVerified] = nil
 		permissionsMatrix[as.AddressStateBitRoleOffersAdmin][as.AddressStateBitOffersCreator] = nil
 		permissionsMatrix[as.AddressStateBitRoleValidatorAdmin][as.AddressStateBitNodeDeferred] = nil
 	}


### PR DESCRIPTION
## Why this should be merged
This PR adds AddressStateKYBVerified, its bit 34.
AddressStateKYBVerified bit can be set by AddressStateRoleKYCAdmin.
This bit allows to create addMemberProposals.
## How this works
AddressStateKYBVerified is added to BerlinPhase bits set, so its treated as valid bit starting from BerlinPhase.
PR adds corresponding test cases for AddressStateTx and for addMemberProposal.
## How this was tested
By existing unit tests.
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminogo/pull/355