### PR TITLE
[PVM] Fix avax TestBanffProposalBlockUpdateStakers test

### DIFF
--- a/vms/platformvm/blocks/executor/proposal_block_test.go
+++ b/vms/platformvm/blocks/executor/proposal_block_test.go
@@ -405,7 +405,7 @@ func TestBanffProposalBlockUpdateStakers(t *testing.T) {
 	// Staker5:                                     |--------------------|
 
 	// Staker0 it's here just to allow to issue a proposal block with the chosen endTime.
-	staker0RewardAddress := ids.GenerateTestShortID()
+	staker0RewardAddress := ids.ShortID{2}
 	staker0 := staker{
 		nodeID:        ids.NodeID(staker0RewardAddress),
 		rewardAddress: staker0RewardAddress,
@@ -421,7 +421,7 @@ func TestBanffProposalBlockUpdateStakers(t *testing.T) {
 		endTime:       defaultGenesisTime.Add(10 * defaultMinStakingDuration).Add(1 * time.Minute),
 	}
 
-	staker2RewardAddress := ids.GenerateTestShortID()
+	staker2RewardAddress := ids.ShortID{1}
 	staker2 := staker{
 		nodeID:        ids.NodeID(staker2RewardAddress),
 		rewardAddress: staker2RewardAddress,


### PR DESCRIPTION
## Why this should be merged
TestBanffProposalBlockUpdateStakers randomly fails (depending on tests order) because of random staker reward-address generation.
This PR fixes it.

## How this works
Replace random address with static short id.

## How this was tested
Unit-tests.