### PR TITLE
Update phase timestamp maps, fix pvm test phase times

### DIFF
--- a/version/constants.go
+++ b/version/constants.go
@@ -74,41 +74,111 @@ var (
 	// by avalanchego, but is useful for downstream libraries.
 	RPCChainVMProtocolCompatibility map[uint][]*Semantic
 
+	DefaultUpgradeTime    = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
+	unreachableFutureTime = time.Date(10000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	caminoEarliestTime     = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+	columbusEarliestTime   = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+	kopernikusEarliestTime = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+
+	ApricotPhase1Times = map[uint32]time.Time{
+		constants.MainnetID: time.Date(2021, time.March, 31, 14, 0, 0, 0, time.UTC),
+		constants.FujiID:    time.Date(2021, time.March, 26, 14, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
+
+	ApricotPhase2Times = map[uint32]time.Time{
+		constants.MainnetID: time.Date(2021, time.May, 10, 11, 0, 0, 0, time.UTC),
+		constants.FujiID:    time.Date(2021, time.May, 5, 14, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
+
 	ApricotPhase3Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.August, 24, 14, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.August, 16, 19, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase3DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
 	ApricotPhase4Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.September, 22, 21, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.September, 16, 21, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase4DefaultTime     = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 	ApricotPhase4MinPChainHeight = map[uint32]uint64{
 		constants.MainnetID: 793005,
 		constants.FujiID:    47437,
+
+		constants.CaminoID:     0,
+		constants.ColumbusID:   0,
+		constants.KopernikusID: 0,
 	}
 	ApricotPhase4DefaultMinPChainHeight uint64
 
 	ApricotPhase5Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.December, 2, 18, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.November, 24, 15, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase5DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
-	SunrisePhase0Times       = map[uint32]time.Time{}
-	SunrisePhase0DefaultTime = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+	ApricotPhasePre6Times = map[uint32]time.Time{
+		constants.MainnetID: time.Date(2022, time.September, 5, 1, 30, 0, 0, time.UTC),
+		constants.FujiID:    time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
+
+	SunrisePhase0Times = map[uint32]time.Time{
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
 
 	ApricotPhase6Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
+	}
+
+	ApricotPhasePost6Times = map[uint32]time.Time{
+		constants.MainnetID: time.Date(2022, time.September, 7, 3, 0, 0, 0, time.UTC),
+		constants.FujiID:    time.Date(2022, time.September, 7, 6, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase6DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
 	BanffTimes = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2022, time.October, 18, 16, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.October, 3, 14, 0, 0, 0, time.UTC),
+
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	BanffDefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
@@ -117,20 +187,22 @@ var (
 		constants.ColumbusID:   time.Date(2023, time.July, 7, 8, 0, 0, 0, time.UTC),
 		constants.CaminoID:     time.Date(2023, time.July, 17, 8, 0, 0, 0, time.UTC),
 	}
-	AthensPhaseDefaultTime = time.Date(2023, time.July, 1, 8, 0, 0, 0, time.UTC)
 
-	// TODO: update this before release
+	// TODO @evlekht update this before release
 	BerlinPhaseTimes = map[uint32]time.Time{
-		constants.KopernikusID: time.Date(2023, time.July, 4, 13, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2023, time.July, 7, 8, 0, 0, 0, time.UTC),
-		constants.CaminoID:     time.Date(2023, time.July, 17, 8, 0, 0, 0, time.UTC),
+		constants.KopernikusID: unreachableFutureTime,
+		constants.ColumbusID:   unreachableFutureTime,
+		constants.CaminoID:     unreachableFutureTime,
 	}
-	BerlinPhaseDefaultTime = time.Date(2023, time.July, 1, 8, 0, 0, 0, time.UTC)
 
-	// TODO: update this before release, must be exactly the same as Berlin
+	// TODO @evlekht update this before release, must be exactly the same as Berlin
 	CortinaTimes = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2023, time.April, 25, 15, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2023, time.April, 6, 15, 0, 0, 0, time.UTC),
+
+		constants.KopernikusID: unreachableFutureTime,
+		constants.ColumbusID:   unreachableFutureTime,
+		constants.CaminoID:     unreachableFutureTime,
 	}
 	CortinaDefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 )
@@ -188,7 +260,7 @@ func GetSunrisePhase0Time(networkID uint32) time.Time {
 	if upgradeTime, exists := SunrisePhase0Times[networkID]; exists {
 		return upgradeTime
 	}
-	return SunrisePhase0DefaultTime
+	return DefaultUpgradeTime
 }
 
 func GetApricotPhase6Time(networkID uint32) time.Time {
@@ -209,14 +281,14 @@ func GetAthensPhaseTime(networkID uint32) time.Time {
 	if upgradeTime, exists := AthensPhaseTimes[networkID]; exists {
 		return upgradeTime
 	}
-	return AthensPhaseDefaultTime
+	return DefaultUpgradeTime
 }
 
 func GetBerlinPhaseTime(networkID uint32) time.Time {
 	if upgradeTime, exists := BerlinPhaseTimes[networkID]; exists {
 		return upgradeTime
 	}
-	return BerlinPhaseDefaultTime
+	return DefaultUpgradeTime
 }
 
 func GetCortinaTime(networkID uint32) time.Time {

--- a/vms/platformvm/camino_vm_test.go
+++ b/vms/platformvm/camino_vm_test.go
@@ -834,7 +834,7 @@ func TestExcludeMemberProposals(t *testing.T) {
 	proposalBondAmount := defaultConfig.CaminoConfig.DACProposalBondAmount
 	validatorBondAmount := defaultConfig.MaxValidatorStake // is equal to min
 	initialBalance := test.PreFundedBalance + test.ValidatorWeight
-	initialHeight := uint64(2)
+	initialHeight := uint64(1)
 
 	// for simplicity: member == member that will be excluded
 	//                 proposer == member that creates excludeMember proposal

--- a/vms/platformvm/test/camino_defaults.go
+++ b/vms/platformvm/test/camino_defaults.go
@@ -84,22 +84,21 @@ func Config(t *testing.T, phase Phase) *config.Config {
 	case PhaseCairo:
 		cairoTime = LatestPhaseTime
 		fallthrough
-	case PhaseBerlin: // same time, as PhaseCortina
+	case PhaseBerlin:
 		berlinTime = LatestPhaseTime
+		cortinaTime = LatestPhaseTime
 		fallthrough
 	case PhaseAthens:
 		athensTime = LatestPhaseTime
 		fallthrough
-	case PhaseSunrise: // Banff is considered to be part of SunrisePhase release
+	case PhaseSunrise:
 		banffTime = LatestPhaseTime
 		fallthrough
 	case PhaseApricot5:
 		apricotPhase5Time = LatestPhaseTime
-		fallthrough
-	case PhaseApricot3:
 		apricotPhase3Time = LatestPhaseTime
 	default:
-		require.FailNow(t, "unhandled fork %d", phase)
+		require.FailNowf(t, "", "unknown phase %d (%s)", phase)
 	}
 
 	vdrs := validators.NewManager()

--- a/vms/platformvm/test/camino_phase.go
+++ b/vms/platformvm/test/camino_phase.go
@@ -16,17 +16,14 @@ type Phase int
 
 // Camino phases must go in consecutive order
 const (
-	PhaseApricot3 Phase = -2 // avax
-	PhaseApricot5 Phase = -1 // avax
+	PhaseApricot5 Phase = 0 // avax
+	PhaseBanff    Phase = 1 // avax, included into Sunrise phase
 	PhaseSunrise  Phase = 1
-	PhaseBanff    Phase = 1 // avax, phase actually happened after Sunrise, but before Athens. But first release is Sunrise.
 	PhaseAthens   Phase = 2
 	PhaseCortina  Phase = 3 // avax, included into Berlin phase
 	PhaseBerlin   Phase = 3
 	PhaseCairo    Phase = 4
 )
-
-// TODO @evlekht we might want to clean up sunrise/banff timestamps/relations later
 
 const (
 	PhaseFirst = PhaseSunrise


### PR DESCRIPTION
- Adds missing avax Apricot phase timestamps and camino networks timestamps to all avax phases, so they can be used in evm.
- Fixes some issues in PVM test phases and timestamps.
## Additional references
Original PR based on cortina-15 dev
https://github.com/chain4travel/caminogo/pull/363