### PR TITLE
[PVM] limit AddDepositOfferTx zero-limits offer check to berlin phase

### DIFF
--- a/vms/platformvm/test/expect/camino_expect.go
+++ b/vms/platformvm/test/expect/camino_expect.go
@@ -13,10 +13,12 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/multisig"
+	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
 	"github.com/ava-labs/avalanchego/vms/platformvm/status"
+	"github.com/ava-labs/avalanchego/vms/platformvm/test"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 )
@@ -194,4 +196,9 @@ func Lock(t *testing.T, s *state.MockState, utxosMap map[ids.ShortID][]*avax.UTX
 	for addr := range utxosMap {
 		s.EXPECT().GetMultisigAlias(addr).Return(nil, database.ErrNotFound).AnyTimes()
 	}
+}
+
+func PhaseTime(t *testing.T, s *state.MockDiff, cfg *config.Config, phase test.Phase) {
+	t.Helper()
+	s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
 }

--- a/vms/platformvm/txs/camino_add_deposit_offer_tx.go
+++ b/vms/platformvm/txs/camino_add_deposit_offer_tx.go
@@ -22,7 +22,6 @@ var (
 	errEmptyDepositOfferCreatorAddress = errors.New("deposit offer creator address is empty")
 	errWrongDepositOfferVersion        = errors.New("wrong deposit offer version")
 	errNotZeroDepositOfferAmounts      = errors.New("deposit offer rewardedAmount or depositedAmount isn't zero")
-	errZeroDepositOfferLimits          = errors.New("deposit offer TotalMaxAmount and TotalMaxRewardAmount are zero")
 )
 
 // AddDepositOfferTx is an unsigned depositTx
@@ -50,8 +49,6 @@ func (tx *AddDepositOfferTx) SyntacticVerify(ctx *snow.Context) error {
 		return errWrongDepositOfferVersion
 	case tx.DepositOffer.RewardedAmount > 0 || tx.DepositOffer.DepositedAmount > 0:
 		return errNotZeroDepositOfferAmounts
-	case tx.DepositOffer.TotalMaxAmount == 0 && tx.DepositOffer.TotalMaxRewardAmount == 0:
-		return errZeroDepositOfferLimits
 	}
 
 	if err := tx.BaseTx.SyntacticVerify(ctx); err != nil {

--- a/vms/platformvm/txs/camino_add_deposit_offer_tx_test.go
+++ b/vms/platformvm/txs/camino_add_deposit_offer_tx_test.go
@@ -72,16 +72,6 @@ func TestAddDepositOfferTxSyntacticVerify(t *testing.T) {
 			},
 			expectedErr: errNotZeroDepositOfferAmounts,
 		},
-		"Zero TotalMaxAmount and TotalMaxRewardAmount": {
-			tx: &AddDepositOfferTx{
-				BaseTx:                     baseTx,
-				DepositOfferCreatorAddress: creatorAddress,
-				DepositOffer: &deposit.Offer{
-					UpgradeVersionID: codec.UpgradeVersion1,
-				},
-			},
-			expectedErr: errZeroDepositOfferLimits,
-		},
 		"Bad deposit offer": {
 			tx: &AddDepositOfferTx{
 				BaseTx:                     baseTx,

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -104,6 +104,7 @@ var (
 	errExpiredProposalsMismatch          = errors.New("expired proposals mismatch")
 	errWrongAdminProposal                = errors.New("this type of proposal can't be admin-proposal")
 	errNotPermittedToCreateProposal      = errors.New("don't have permission to create proposal of this type")
+	errZeroDepositOfferLimits            = errors.New("deposit offer TotalMaxAmount and TotalMaxRewardAmount are zero")
 
 	ErrInvalidProposal = errors.New("proposal is semantically invalid")
 )
@@ -1648,6 +1649,11 @@ func (e *CaminoStandardTxExecutor) AddDepositOfferTx(tx *txs.AddDepositOfferTx) 
 
 	if !e.Config.IsAthensPhaseActivated(chainTime) {
 		return errNotAthensPhase
+	}
+
+	if e.Config.IsBerlinPhaseActivated(chainTime) &&
+		tx.DepositOffer.TotalMaxAmount == 0 && tx.DepositOffer.TotalMaxRewardAmount == 0 {
+		return errZeroDepositOfferLimits
 	}
 
 	if len(e.Tx.Creds) < 2 {


### PR DESCRIPTION
`AddDepositOfferTx` with both `tx.DepositOffer.TotalMaxAmount` and `tx.DepositOffer.TotalMaxRewardAmount` equal to 0 is already prohibited in current dev (Berlin 0). But columbus network has such tx before Berlin 0, so we need to put this check into berlin phase logic to allow pre-berlin txs with zero limits.