### PR TITLE
[PVM] limit MultisigAliasTx nested msig check to berlin phase

### DIFF
--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1534,13 +1534,15 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		return err
 	}
 
-	// verify that alias isn't nesting another alias
-	isNestedMsig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
-	switch {
-	case err != nil:
-		return err
-	case isNestedMsig:
-		return errNestedMsigAlias
+	if e.Config.IsBerlinPhaseActivated(e.State.GetTimestamp()) {
+		// verify that alias isn't nesting another alias
+		isNestedMsig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
+		switch {
+		case err != nil:
+			return err
+		case isNestedMsig:
+			return errNestedMsigAlias
+		}
 	}
 
 	aliasAddrState := as.AddressStateEmpty


### PR DESCRIPTION
`MultisigAliasTx` with msig alias having other msig alias in its owners became prohibited Berlin, but wasn't limited to Berlin phase. Because columbus network already has such tx before Berlin 0, we need to put this check into berlin phase logic to allow pre-berlin txs with nested msig alias.