### PR TITLE
[PVM] Wrap empty-alias check into berlin phase check

### DIFF
--- a/vms/components/multisig/camino_multisig.go
+++ b/vms/components/multisig/camino_multisig.go
@@ -47,8 +47,7 @@ func (ma *Alias) InitCtx(ctx *snow.Context) {
 }
 
 func (ma *Alias) Verify() error {
-	switch {
-	case len(ma.Memo) > MaxMemoSize:
+	if len(ma.Memo) > MaxMemoSize {
 		return fmt.Errorf("%w: expected not greater than %d bytes, got %d bytes", errMemoIsTooBig, MaxMemoSize, len(ma.Memo))
 	}
 

--- a/vms/components/multisig/camino_multisig.go
+++ b/vms/components/multisig/camino_multisig.go
@@ -21,7 +21,6 @@ var (
 	_ verify.State = (*Alias)(nil)
 
 	errMemoIsTooBig = errors.New("msig alias memo is too big")
-	errEmptyAlias   = errors.New("alias id and alias owners cannot be empty both at the same time")
 )
 
 type Owners interface {
@@ -51,8 +50,6 @@ func (ma *Alias) Verify() error {
 	switch {
 	case len(ma.Memo) > MaxMemoSize:
 		return fmt.Errorf("%w: expected not greater than %d bytes, got %d bytes", errMemoIsTooBig, MaxMemoSize, len(ma.Memo))
-	case ma.Owners.IsZero() && ma.ID == ids.ShortEmpty:
-		return errEmptyAlias
 	}
 
 	return ma.Owners.Verify()

--- a/vms/components/multisig/camino_multisig_test.go
+++ b/vms/components/multisig/camino_multisig_test.go
@@ -34,13 +34,6 @@ func TestVerify(t *testing.T) {
 			},
 			expectedErr: errMemoIsTooBig,
 		},
-		"Zero owners": {
-			alias: Alias{
-				ID:     ids.ShortEmpty,
-				Owners: &testOwners{isEmpty: true},
-			},
-			expectedErr: errEmptyAlias,
-		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -5514,8 +5514,8 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 	ownerKey, ownerAddr, owner := generate.KeyAndOwner(t, test.Keys[0])
 	msigKeys, msigAlias, msigAliasOwners, msigOwner := generate.MsigAliasAndKeys([]*secp256k1.PrivateKey{test.Keys[1], test.Keys[2]}, 2, true)
 
-	ownerUTXO := generate.UTXO(ids.GenerateTestID(), ctx.AVAXAssetID, test.TxFee, owner, ids.Empty, ids.Empty, true)
-	msigUTXO := generate.UTXO(ids.GenerateTestID(), ctx.AVAXAssetID, test.TxFee, *msigOwner, ids.Empty, ids.Empty, true)
+	ownerUTXO := generate.UTXO(ids.ID{1}, ctx.AVAXAssetID, test.TxFee, owner, ids.Empty, ids.Empty, true)
+	msigUTXO := generate.UTXO(ids.ID{3}, ctx.AVAXAssetID, test.TxFee, *msigOwner, ids.Empty, ids.Empty, true)
 
 	baseTx := txs.BaseTx{
 		BaseTx: avax.BaseTx{
@@ -5546,7 +5546,13 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 			phase: test.PhaseLast,
 			utx: &txs.MultisigAliasTx{
 				BaseTx: baseTx,
-				Auth:   &secp256k1fx.Input{SigIndices: []uint32{}},
+				MultisigAlias: multisig.Alias{
+					Memo: msigAlias.Memo,
+					Owners: &secp256k1fx.OutputOwners{
+						Addrs: []ids.ShortID{},
+					},
+				},
+				Auth: &secp256k1fx.Input{SigIndices: []uint32{}},
 			},
 			signers: [][]*secp256k1.PrivateKey{
 				{ownerKey},
@@ -5847,20 +5853,23 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				{msigKeys[0], msigKeys[1]},
 			},
 		},
-		"OK: add nested alias before Berlin": {
+		// we're not testing nested alias adding before Berlin,
+		// because pre-Berlin doesn't make difference between nested and non-nested aliases
+		// and test would look exactly the same as the "OK: add new alias"
+		"OK: add empty alias before Berlin": {
 			state: func(t *testing.T, c *gomock.Controller, utx *txs.MultisigAliasTx, txID ids.ID, cfg *config.Config) *state.MockDiff {
 				s := state.NewMockDiff(c)
-				expect.PhaseTime(t, s, cfg, test.PhaseLast)
-				s.EXPECT().GetMultisigAlias(msigAliasOwners.Addrs[0]).Return(&multisig.AliasWithNonce{}, nil)
-				expect.GetMultisigAliases(t, s, msigAliasOwners.Addrs, []*multisig.AliasWithNonce{{}})
+				expect.PhaseTime(t, s, cfg, test.PhaseAthens)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyLock(t, s, utx.Ins, []*avax.UTXO{ownerUTXO}, []ids.ShortID{ownerAddr}, nil)
 				aliasID := multisig.ComputeAliasID(txID)
 				s.EXPECT().SetMultisigAlias(aliasID, &multisig.AliasWithNonce{
 					Alias: multisig.Alias{
-						ID:     aliasID,
-						Memo:   msigAlias.Memo,
-						Owners: msigAlias.Owners,
+						Memo: msigAlias.Memo,
+						Owners: &secp256k1fx.OutputOwners{
+							Addrs: []ids.ShortID{},
+						},
+						ID: aliasID,
 					},
 					Nonce: 0,
 				})
@@ -5868,13 +5877,14 @@ func TestCaminoStandardTxExecutorMultisigAliasTx(t *testing.T) {
 				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
 				return s
 			},
-			phase: test.PhaseLast,
+			phase: test.PhaseAthens,
 			utx: &txs.MultisigAliasTx{
 				BaseTx: baseTx,
 				MultisigAlias: multisig.Alias{
-					ID:     ids.ShortID{},
-					Memo:   msigAlias.Memo,
-					Owners: msigAlias.Owners,
+					Memo: msigAlias.Memo,
+					Owners: &secp256k1fx.OutputOwners{
+						Addrs: []ids.ShortID{},
+					},
 				},
 				Auth: &secp256k1fx.Input{SigIndices: []uint32{}},
 			},


### PR DESCRIPTION
## Why this should be merged
Berlin phase introduced changes to msig alias creation covering some defects from before. But those changes were not wrapped into phase check, so it may result in inconsistent state for new nodes, if network already has affected transactions.
This PR adds phase check.
## How this was tested
Unit tests