### PR TITLE
[PVM] utxos Lock rewrite

### DIFF
--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -13,7 +13,10 @@ type CaminoFx interface {
 	RecoverAddresses(msg []byte, credentials []verify.Verifiable) (secp256k1fx.RecoverMap, error)
 
 	// Verifies that Multisig aliases are on inputs are only used in supported hierarchy
-	VerifyMultisigOwner(outIntf, msigIntf interface{}) error
+	VerifyMultisigOwner(ownerIntf, msigIntf interface{}) error
+
+	// Verifies that Multisig aliases are on inputs are only used in supported hierarchy
+	VerifyMultisigOutputOwner(outIntf, msigIntf interface{}) error
 
 	// VerifyMultisigTransfer verifies that the specified transaction can spend the
 	// provided utxo with no restrictions on the destination. If the transaction
@@ -33,5 +36,5 @@ type CaminoFx interface {
 	CollectMultisigAliases(ownerIntf, msigIntf interface{}) ([]interface{}, error)
 
 	// Checks if [ownerIntf] contains msig alias
-	IsOwnerContainsMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
+	OwnerContainsMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
 }

--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -36,5 +36,5 @@ type CaminoFx interface {
 	CollectMultisigAliases(ownerIntf, msigIntf interface{}) ([]interface{}, error)
 
 	// Checks if [ownerIntf] contains msig alias
-	OwnerContainsMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
+	IsNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
 }

--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -33,5 +33,5 @@ type CaminoFx interface {
 	CollectMultisigAliases(ownerIntf, msigIntf interface{}) ([]interface{}, error)
 
 	// Checks if [ownerIntf] contains msig alias
-	IsNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
+	HasNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
 }

--- a/vms/platformvm/fx/camino_fx.go
+++ b/vms/platformvm/fx/camino_fx.go
@@ -33,5 +33,5 @@ type CaminoFx interface {
 	CollectMultisigAliases(ownerIntf, msigIntf interface{}) ([]interface{}, error)
 
 	// Checks if [ownerIntf] contains msig alias
-	HasNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
+	IsOwnerContainsMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error)
 }

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -97,6 +97,21 @@ func (mr *MockFxMockRecorder) CreateOutput(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOutput", reflect.TypeOf((*MockFx)(nil).CreateOutput), arg0, arg1)
 }
 
+// HasNestedMultisig mocks base method.
+func (m *MockFx) HasNestedMultisig(arg0, arg1 interface{}) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasNestedMultisig", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasNestedMultisig indicates an expected call of HasNestedMultisig.
+func (mr *MockFxMockRecorder) HasNestedMultisig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasNestedMultisig", reflect.TypeOf((*MockFx)(nil).HasNestedMultisig), arg0, arg1)
+}
+
 // Initialize mocks base method.
 func (m *MockFx) Initialize(arg0 interface{}) error {
 	m.ctrl.T.Helper()
@@ -124,6 +139,20 @@ func (m *MockFx) RecoverAddresses(arg0 []byte, arg1 []verify.Verifiable) (secp25
 func (mr *MockFxMockRecorder) RecoverAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecoverAddresses", reflect.TypeOf((*MockFx)(nil).RecoverAddresses), arg0, arg1)
+}
+
+// VerifyMultisigMessage mocks base method.
+func (m *MockFx) VerifyMultisigMessage(arg0 []byte, arg1, arg2, arg3, arg4 interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyMultisigMessage", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyMultisigMessage indicates an expected call of VerifyMultisigMessage.
+func (mr *MockFxMockRecorder) VerifyMultisigMessage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigMessage", reflect.TypeOf((*MockFx)(nil).VerifyMultisigMessage), arg0, arg1, arg2, arg3, arg4)
 }
 
 // VerifyMultisigOwner mocks base method.
@@ -168,20 +197,6 @@ func (mr *MockFxMockRecorder) VerifyMultisigTransfer(arg0, arg1, arg2, arg3, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigTransfer", reflect.TypeOf((*MockFx)(nil).VerifyMultisigTransfer), arg0, arg1, arg2, arg3, arg4)
 }
 
-// VerifyMultisigMessage mocks base method.
-func (m *MockFx) VerifyMultisigMessage(arg0 []byte, arg1, arg2, arg3, arg4 interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyMultisigMessage", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// VerifyMultisigMessage indicates an expected call of VerifyMultisigMessage.
-func (mr *MockFxMockRecorder) VerifyMultisigMessage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigMessage", reflect.TypeOf((*MockFx)(nil).VerifyMultisigMessage), arg0, arg1, arg2, arg3, arg4)
-}
-
 // VerifyPermission mocks base method.
 func (m *MockFx) VerifyPermission(arg0, arg1, arg2, arg3 interface{}) error {
 	m.ctrl.T.Helper()
@@ -208,21 +223,6 @@ func (m *MockFx) VerifyTransfer(arg0, arg1, arg2, arg3 interface{}) error {
 func (mr *MockFxMockRecorder) VerifyTransfer(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyTransfer", reflect.TypeOf((*MockFx)(nil).VerifyTransfer), arg0, arg1, arg2, arg3)
-}
-
-// IsNestedMultisig mocks base method.
-func (m *MockFx) IsNestedMultisig(arg0, arg1 interface{}) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsNestedMultisig", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsNestedMultisig indicates an expected call of IsNestedMultisig.
-func (mr *MockFxMockRecorder) IsNestedMultisig(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNestedMultisig", reflect.TypeOf((*MockFx)(nil).IsNestedMultisig), arg0, arg1)
 }
 
 // MockOwner is a mock of Owner interface.

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -97,19 +97,19 @@ func (mr *MockFxMockRecorder) CreateOutput(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOutput", reflect.TypeOf((*MockFx)(nil).CreateOutput), arg0, arg1)
 }
 
-// IsOwnerContainsMultisig mocks base method.
-func (m *MockFx) IsOwnerContainsMultisig(arg0, arg1 interface{}) (bool, error) {
+// OwnerContainsMultisig mocks base method.
+func (m *MockFx) OwnerContainsMultisig(arg0, arg1 interface{}) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsOwnerContainsMultisig", arg0, arg1)
+	ret := m.ctrl.Call(m, "OwnerContainsMultisig", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsOwnerContainsMultisig indicates an expected call of IsOwnerContainsMultisig.
-func (mr *MockFxMockRecorder) IsOwnerContainsMultisig(arg0, arg1 interface{}) *gomock.Call {
+// OwnerContainsMultisig indicates an expected call of OwnerContainsMultisig.
+func (mr *MockFxMockRecorder) OwnerContainsMultisig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOwnerContainsMultisig", reflect.TypeOf((*MockFx)(nil).IsOwnerContainsMultisig), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OwnerContainsMultisig", reflect.TypeOf((*MockFx)(nil).OwnerContainsMultisig), arg0, arg1)
 }
 
 // Initialize mocks base method.
@@ -167,6 +167,20 @@ func (m *MockFx) VerifyMultisigOwner(arg0, arg1 interface{}) error {
 func (mr *MockFxMockRecorder) VerifyMultisigOwner(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigOwner", reflect.TypeOf((*MockFx)(nil).VerifyMultisigOwner), arg0, arg1)
+}
+
+// VerifyMultisigOutputOwner mocks base method.
+func (m *MockFx) VerifyMultisigOutputOwner(arg0, arg1 interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyMultisigOutputOwner", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyMultisigOutputOwner indicates an expected call of VerifyMultisigOutputOwner.
+func (mr *MockFxMockRecorder) VerifyMultisigOutputOwner(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMultisigOutputOwner", reflect.TypeOf((*MockFx)(nil).VerifyMultisigOutputOwner), arg0, arg1)
 }
 
 // VerifyMultisigPermission mocks base method.

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -97,19 +97,19 @@ func (mr *MockFxMockRecorder) CreateOutput(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOutput", reflect.TypeOf((*MockFx)(nil).CreateOutput), arg0, arg1)
 }
 
-// OwnerContainsMultisig mocks base method.
-func (m *MockFx) OwnerContainsMultisig(arg0, arg1 interface{}) (bool, error) {
+// IsNestedMultisig mocks base method.
+func (m *MockFx) IsNestedMultisig(arg0, arg1 interface{}) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OwnerContainsMultisig", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsNestedMultisig", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// OwnerContainsMultisig indicates an expected call of OwnerContainsMultisig.
-func (mr *MockFxMockRecorder) OwnerContainsMultisig(arg0, arg1 interface{}) *gomock.Call {
+// IsNestedMultisig indicates an expected call of IsNestedMultisig.
+func (mr *MockFxMockRecorder) IsNestedMultisig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OwnerContainsMultisig", reflect.TypeOf((*MockFx)(nil).OwnerContainsMultisig), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNestedMultisig", reflect.TypeOf((*MockFx)(nil).IsNestedMultisig), arg0, arg1)
 }
 
 // Initialize mocks base method.

--- a/vms/platformvm/fx/mock_fx.go
+++ b/vms/platformvm/fx/mock_fx.go
@@ -97,19 +97,19 @@ func (mr *MockFxMockRecorder) CreateOutput(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOutput", reflect.TypeOf((*MockFx)(nil).CreateOutput), arg0, arg1)
 }
 
-// HasNestedMultisig mocks base method.
-func (m *MockFx) HasNestedMultisig(arg0, arg1 interface{}) (bool, error) {
+// IsOwnerContainsMultisig mocks base method.
+func (m *MockFx) IsOwnerContainsMultisig(arg0, arg1 interface{}) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasNestedMultisig", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsOwnerContainsMultisig", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// HasNestedMultisig indicates an expected call of HasNestedMultisig.
-func (mr *MockFxMockRecorder) HasNestedMultisig(arg0, arg1 interface{}) *gomock.Call {
+// IsOwnerContainsMultisig indicates an expected call of IsOwnerContainsMultisig.
+func (mr *MockFxMockRecorder) IsOwnerContainsMultisig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasNestedMultisig", reflect.TypeOf((*MockFx)(nil).HasNestedMultisig), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOwnerContainsMultisig", reflect.TypeOf((*MockFx)(nil).IsOwnerContainsMultisig), arg0, arg1)
 }
 
 // Initialize mocks base method.

--- a/vms/platformvm/test/camino_defaults.go
+++ b/vms/platformvm/test/camino_defaults.go
@@ -47,7 +47,8 @@ const (
 )
 
 var (
-	avaxAssetID  = ids.ID{'C', 'A', 'M'}
+	AVAXAssetID  = ids.ID{'C', 'A', 'M'}
+	OtherAssetID = ids.ID{'O', 'T', 'H', 'E', 'R'}
 	cChainID     = ids.ID{'C', '-', 'C', 'H', 'A', 'I', 'N'}
 	xChainID     = ids.ID{'X', '-', 'C', 'H', 'A', 'I', 'N'}
 	rewardConfig = reward.Config{
@@ -210,7 +211,7 @@ func Context(t *testing.T) *snow.Context {
 	require.NoError(t, aliaser.Alias(constants.PlatformChainID, "P"))
 
 	ctx := snow.DefaultContextTest()
-	ctx.AVAXAssetID = avaxAssetID
+	ctx.AVAXAssetID = AVAXAssetID
 	ctx.ChainID = constants.PlatformChainID
 	ctx.XChainID = xChainID
 	ctx.CChainID = cChainID

--- a/vms/platformvm/test/expect/camino_expect.go
+++ b/vms/platformvm/test/expect/camino_expect.go
@@ -21,7 +21,10 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/test"
 	"github.com/ava-labs/avalanchego/vms/platformvm/txs"
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/stretchr/testify/require"
 )
+
+// TODO @evlekht prefix all funcs with corresponding diff/state/chain
 
 func VerifyMultisigPermission(t *testing.T, s *state.MockDiff, addrs []ids.ShortID, aliases []*multisig.AliasWithNonce) {
 	t.Helper()
@@ -29,6 +32,21 @@ func VerifyMultisigPermission(t *testing.T, s *state.MockDiff, addrs []ids.Short
 }
 
 func GetMultisigAliases(t *testing.T, s *state.MockDiff, addrs []ids.ShortID, aliases []*multisig.AliasWithNonce) {
+	t.Helper()
+	for i := range addrs {
+		var alias *multisig.AliasWithNonce
+		if i < len(aliases) {
+			alias = aliases[i]
+		}
+		if alias == nil {
+			s.EXPECT().GetMultisigAlias(addrs[i]).Return(nil, database.ErrNotFound)
+		} else {
+			s.EXPECT().GetMultisigAlias(addrs[i]).Return(alias, nil)
+		}
+	}
+}
+
+func StateGetMultisigAliases(t *testing.T, s *state.MockState, addrs []ids.ShortID, aliases []*multisig.AliasWithNonce) {
 	t.Helper()
 	for i := range addrs {
 		var alias *multisig.AliasWithNonce
@@ -139,6 +157,78 @@ func GetUTXOsFromInputs(t *testing.T, s *state.MockDiff, ins []*avax.Transferabl
 	}
 }
 
+func StateGetAllUTXOs(t *testing.T, s *state.MockState, addrs []ids.ShortID, utxos [][]*avax.UTXO) {
+	t.Helper()
+	require.Len(t, addrs, len(utxos))
+	seen := set.Set[ids.ID]{}
+	for i, addr := range addrs {
+		utxoIDs := []ids.ID{}
+		for _, utxo := range utxos[i] {
+			utxoID := utxo.InputID()
+			utxoIDs = append(utxoIDs, utxoID)
+			if seen.Contains(utxoID) {
+				continue
+			}
+			seen.Add(utxoID)
+			s.EXPECT().GetUTXO(utxoID).Return(utxo, nil)
+		}
+		s.EXPECT().UTXOIDs(addr.Bytes(), ids.Empty, math.MaxInt).Return(utxoIDs, nil)
+	}
+}
+
+// Doesn't support multisig alias yet
+func StateSpendMultisig(t *testing.T, s *state.MockState, utxo *avax.UTXO) {
+	t.Helper()
+
+	out := utxo.Out
+	if lockedOut, ok := utxo.Out.(*locked.Out); ok {
+		out = lockedOut.TransferableOut
+	}
+	secpOut, ok := out.(*secp256k1fx.TransferOutput)
+	require.True(t, ok)
+
+	addrs := secpOut.OutputOwners.Addrs
+	for _, addr := range addrs {
+		s.EXPECT().GetMultisigAlias(addr).Return(nil, database.ErrNotFound)
+	}
+}
+
+// Doesn't support multisig alias yet
+func StateHasNestedMultisig(
+	t *testing.T,
+	s *state.MockState,
+	owner *secp256k1fx.OutputOwners,
+	msigAliasAddresses []ids.ShortID,
+	msigAliases []*multisig.AliasWithNonce,
+) {
+	t.Helper()
+	if owner == nil {
+		return
+	}
+	aliases := make(map[ids.ShortID]*multisig.AliasWithNonce)
+	for i := range msigAliasAddresses {
+		aliases[msigAliasAddresses[i]] = msigAliases[i]
+	}
+	addresses := set.Set[ids.ShortID]{}
+	for _, addr := range owner.Addrs {
+		addresses.Add(addr)
+	}
+	for _, alias := range msigAliases {
+		owner, ok := alias.Owners.(*secp256k1fx.OutputOwners)
+		require.True(t, ok)
+		for _, addr := range owner.Addrs {
+			addresses.Add(addr)
+		}
+	}
+	for addr := range addresses {
+		if _, ok := aliases[addr]; ok {
+			s.EXPECT().GetMultisigAlias(addr).Return(aliases[addr], nil)
+		} else {
+			s.EXPECT().GetMultisigAlias(addr).Return(nil, database.ErrNotFound)
+		}
+	}
+}
+
 func ConsumeUTXOs(t *testing.T, s *state.MockDiff, ins []*avax.TransferableInput) {
 	t.Helper()
 	for _, in := range ins {
@@ -146,7 +236,13 @@ func ConsumeUTXOs(t *testing.T, s *state.MockDiff, ins []*avax.TransferableInput
 	}
 }
 
-func ProduceUTXOs(t *testing.T, s *state.MockDiff, outs []*avax.TransferableOutput, txID ids.ID, baseOutIndex int) {
+func ProduceUTXOs(
+	t *testing.T,
+	s *state.MockDiff,
+	outs []*avax.TransferableOutput,
+	txID ids.ID,
+	baseOutIndex int,
+) {
 	t.Helper()
 	for i := range outs {
 		s.EXPECT().AddUTXO(&avax.UTXO{
@@ -160,7 +256,14 @@ func ProduceUTXOs(t *testing.T, s *state.MockDiff, outs []*avax.TransferableOutp
 	}
 }
 
-func ProduceNewlyLockedUTXOs(t *testing.T, s *state.MockDiff, outs []*avax.TransferableOutput, txID ids.ID, baseOutIndex int, lockState locked.State) {
+func ProduceNewlyLockedUTXOs(
+	t *testing.T,
+	s *state.MockDiff,
+	outs []*avax.TransferableOutput,
+	txID ids.ID,
+	baseOutIndex int,
+	lockState locked.State,
+) {
 	t.Helper()
 	for i := range outs {
 		out := outs[i].Out

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1548,11 +1548,11 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		}
 
 		// verify that alias isn't nesting another alias
-		isNestedMsig, err := e.Fx.HasNestedMultisig(tx.MultisigAlias.Owners, e.State)
+		containsMsig, err := e.Fx.IsOwnerContainsMultisig(tx.MultisigAlias.Owners, e.State)
 		switch {
 		case err != nil:
 			return err
-		case isNestedMsig:
+		case containsMsig:
 			return errNestedMsigAlias
 		}
 	}

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1548,7 +1548,7 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		}
 
 		// verify that alias isn't nesting another alias
-		isNestedMsig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
+		isNestedMsig, err := e.Fx.HasNestedMultisig(tx.MultisigAlias.Owners, e.State)
 		switch {
 		case err != nil:
 			return err

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1540,11 +1540,11 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		}
 
 		// verify that alias isn't nesting another alias
-		isNestedMultisig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
+		isNestedMsig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
 		switch {
 		case err != nil:
 			return err
-		case isNestedMultisig:
+		case isNestedMsig:
 			return errNestedMsigAlias
 		}
 	}

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1540,7 +1540,7 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		}
 
 		// verify that alias isn't nesting another alias
-		containsMsig, err := e.Fx.OwnerContainsMultisig(tx.MultisigAlias.Owners, e.State)
+		containsMsig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
 		switch {
 		case err != nil:
 			return err

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -247,11 +247,7 @@ func (e *CaminoStandardTxExecutor) AddValidatorTx(tx *txs.AddValidatorTx) error 
 			return errWrongOwnerType
 		}
 
-		if err := e.Fx.VerifyMultisigOwner(
-			&secp256k1fx.TransferOutput{
-				OutputOwners: *rewardOwner,
-			}, e.State,
-		); err != nil {
+		if err := e.Fx.VerifyMultisigOwner(rewardOwner, e.State); err != nil {
 			return err
 		}
 
@@ -741,11 +737,7 @@ func (e *CaminoStandardTxExecutor) DepositTx(tx *txs.DepositTx) error {
 		return errWrongOwnerType
 	}
 
-	if err := e.Fx.VerifyMultisigOwner(
-		&secp256k1fx.TransferOutput{
-			OutputOwners: *rewardOwner,
-		}, e.State,
-	); err != nil {
+	if err := e.Fx.VerifyMultisigOwner(rewardOwner, e.State); err != nil {
 		return err
 	}
 
@@ -1548,7 +1540,7 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		}
 
 		// verify that alias isn't nesting another alias
-		containsMsig, err := e.Fx.IsOwnerContainsMultisig(tx.MultisigAlias.Owners, e.State)
+		containsMsig, err := e.Fx.OwnerContainsMultisig(tx.MultisigAlias.Owners, e.State)
 		switch {
 		case err != nil:
 			return err

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -1540,11 +1540,11 @@ func (e *CaminoStandardTxExecutor) MultisigAliasTx(tx *txs.MultisigAliasTx) erro
 		}
 
 		// verify that alias isn't nesting another alias
-		containsMsig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
+		isNestedMultisig, err := e.Fx.IsNestedMultisig(tx.MultisigAlias.Owners, e.State)
 		switch {
 		case err != nil:
 			return err
-		case containsMsig:
+		case isNestedMultisig:
 			return errNestedMsigAlias
 		}
 	}

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -241,6 +241,9 @@ func (h *handler) Lock(
 	}
 
 	setOwner := func(secpOwner *secp256k1fx.OutputOwners, owner *Owner, errNested error) error {
+		if secpOwner == nil {
+			return nil
+		}
 		containsMsig, err := h.fx.IsOwnerContainsMultisig(secpOwner, utxoDB)
 		switch {
 		case err != nil:

--- a/vms/platformvm/utxo/camino_locked.go
+++ b/vms/platformvm/utxo/camino_locked.go
@@ -266,7 +266,7 @@ func (h *handler) Lock(
 	}
 
 	changeOwner := Owner{}
-	if err := setOwner(to, &changeOwner, errNestedMultisigChangeOwner); err != nil {
+	if err := setOwner(change, &changeOwner, errNestedMultisigChangeOwner); err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to set change owner: %w", err)
 	}
 

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -283,7 +283,7 @@ func TestLock(t *testing.T) {
 				)
 				return state
 			},
-			to:          &recipientOwner, // TODO@ nested msig
+			to:          &recipientOwner,
 			expectedErr: errNestedMultisigToOwner,
 		},
 		"Bond unlocked utxo: not enough balance": {

--- a/vms/secp256k1fx/camino_fx.go
+++ b/vms/secp256k1fx/camino_fx.go
@@ -75,7 +75,7 @@ func (fx *CaminoFx) VerifyTransfer(txIntf, inIntf, credIntf, utxoIntf interface{
 	return fx.Fx.VerifyTransfer(txIntf, inIntf, credIntf, utxoIntf)
 }
 
-func (*Fx) IsOwnerContainsMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error) {
+func (*Fx) OwnerContainsMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error) {
 	owner, ok := ownerIntf.(*OutputOwners)
 	if !ok {
 		return false, ErrWrongOwnerType
@@ -123,12 +123,16 @@ func (fx *Fx) RecoverAddresses(msg []byte, verifies []verify.Verifiable) (Recove
 	return ret, nil
 }
 
-func (*Fx) VerifyMultisigOwner(outIntf, msigIntf interface{}) error {
+func (fx *Fx) VerifyMultisigOutputOwner(outIntf, msigIntf interface{}) error {
 	out, ok := outIntf.(Owned)
 	if !ok {
 		return errWrongOutputType
 	}
-	owners, ok := out.Owners().(*OutputOwners)
+	return fx.VerifyMultisigOwner(out.Owners(), msigIntf)
+}
+
+func (*Fx) VerifyMultisigOwner(ownerIntf, msigIntf interface{}) error {
+	owners, ok := ownerIntf.(*OutputOwners)
 	if !ok {
 		return ErrWrongOwnerType
 	}

--- a/vms/secp256k1fx/camino_fx.go
+++ b/vms/secp256k1fx/camino_fx.go
@@ -75,7 +75,7 @@ func (fx *CaminoFx) VerifyTransfer(txIntf, inIntf, credIntf, utxoIntf interface{
 	return fx.Fx.VerifyTransfer(txIntf, inIntf, credIntf, utxoIntf)
 }
 
-func (*Fx) IsNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error) {
+func (*Fx) HasNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error) {
 	owner, ok := ownerIntf.(*OutputOwners)
 	if !ok {
 		return false, ErrWrongOwnerType

--- a/vms/secp256k1fx/camino_fx.go
+++ b/vms/secp256k1fx/camino_fx.go
@@ -75,7 +75,7 @@ func (fx *CaminoFx) VerifyTransfer(txIntf, inIntf, credIntf, utxoIntf interface{
 	return fx.Fx.VerifyTransfer(txIntf, inIntf, credIntf, utxoIntf)
 }
 
-func (*Fx) OwnerContainsMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error) {
+func (*Fx) IsNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error) {
 	owner, ok := ownerIntf.(*OutputOwners)
 	if !ok {
 		return false, ErrWrongOwnerType

--- a/vms/secp256k1fx/camino_fx.go
+++ b/vms/secp256k1fx/camino_fx.go
@@ -75,7 +75,7 @@ func (fx *CaminoFx) VerifyTransfer(txIntf, inIntf, credIntf, utxoIntf interface{
 	return fx.Fx.VerifyTransfer(txIntf, inIntf, credIntf, utxoIntf)
 }
 
-func (*Fx) HasNestedMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error) {
+func (*Fx) IsOwnerContainsMultisig(ownerIntf interface{}, msigIntf interface{}) (bool, error) {
 	owner, ok := ownerIntf.(*OutputOwners)
 	if !ok {
 		return false, ErrWrongOwnerType


### PR DESCRIPTION
## Why this should be merged
PVM utxos handler `Lock` method has very confusing parts of code, which were hard to follow. This method also had 2 known bugs:
- In some cases it was consuming locked utxos and producing corresponding out without any need, which resulted in unnecessary utxo creation/removal and bigger transaction size.
- It was possible to use this method to create deposit for new owner using bonded utxos, but it resulted in deposited utxos belonging to old owner.

This PR
- Rewrites `Lock` method, fixes those bugs, adds more comments and make some parts of code more readable an explicit.
- Rewrites `Lock` unit test to allow more complex test cases and adds more test cases.
- Adds unit test for `sortUTXOs` method which is used by `Lock`.

## How this was tested
With existing and new unit tests.