### PR TITLE
Fix scripts/constants.sh evm version & commit

### DIFF
--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -30,8 +30,8 @@ current_branch=${current_branch_temp////-}
 # caminogo and caminoethvm git tag and sha
 git_commit=${CAMINO_NODE_COMMIT:-$(git rev-parse --short HEAD)}
 git_tag=${CAMINO_NODE_TAG:-$(git describe --tags --abbrev=0 --always || echo unknown)}
-caminoethvm_tag=${CAMINO_ETHVM_VERSION:-'v1.1.0-rc4'}
-caminoethvm_commit=${CAMINOETHVM_COMMIT:-'07e50749e3c371001c92dff14dc91ef6109a368a'}
+caminoethvm_tag=${CAMINO_ETHVM_VERSION:-'v1.1.0-rc11'}
+caminoethvm_commit=${CAMINOETHVM_COMMIT:-'89843a190c4e56d0985d04c10a36012911101078'}
 
 # Static compilation
 static_ld_flags=''


### PR DESCRIPTION
Script has old vars default values, PR fixes that replacing them with latest berlin 0 evm tag and commit hash.