### PR TITLE
Fix phase timestamp inconsistency

### DIFF
--- a/chains/manager.go
+++ b/chains/manager.go
@@ -710,7 +710,7 @@ func (m *manager) createAvalancheChain(
 			VM:          vm,
 			DB:          vertexDB,
 			Log:         ctx.Log,
-			CortinaTime: version.GetCortinaTime(ctx.NetworkID),
+			CortinaTime: version.GetPreCortinaTime(ctx.NetworkID),
 		},
 	)
 

--- a/version/constants.go
+++ b/version/constants.go
@@ -85,27 +85,27 @@ var (
 		constants.MainnetID: time.Date(2021, time.March, 31, 14, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.March, 26, 14, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 
 	ApricotPhase2Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.May, 10, 11, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.May, 5, 14, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 
 	ApricotPhase3Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.August, 24, 14, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.August, 16, 19, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 	ApricotPhase3DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
@@ -113,9 +113,9 @@ var (
 		constants.MainnetID: time.Date(2021, time.September, 22, 21, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.September, 16, 21, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 	ApricotPhase4DefaultTime     = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 	ApricotPhase4MinPChainHeight = map[uint32]uint64{
@@ -132,9 +132,9 @@ var (
 		constants.MainnetID: time.Date(2021, time.December, 2, 18, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.November, 24, 15, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 	ApricotPhase5DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
@@ -142,9 +142,9 @@ var (
 		constants.MainnetID: time.Date(2022, time.September, 5, 1, 30, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 
 	SunrisePhase0Times = map[uint32]time.Time{
@@ -157,18 +157,18 @@ var (
 		constants.MainnetID: time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 
 	ApricotPhasePost6Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2022, time.September, 7, 3, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.September, 7, 6, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 	ApricotPhase6DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 

--- a/version/constants.go
+++ b/version/constants.go
@@ -77,6 +77,7 @@ var (
 	DefaultUpgradeTime    = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 	unreachableFutureTime = time.Date(10000, time.January, 1, 0, 0, 0, 0, time.UTC)
 
+	// caminoEarliestTime= time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	caminoEarliestTime     = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
 	columbusEarliestTime   = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
 	kopernikusEarliestTime = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
@@ -148,9 +149,9 @@ var (
 	}
 
 	SunrisePhase0Times = map[uint32]time.Time{
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
 	}
 
 	ApricotPhase6Times = map[uint32]time.Time{
@@ -176,9 +177,9 @@ var (
 		constants.MainnetID: time.Date(2022, time.October, 18, 16, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.October, 3, 14, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     caminoEarliestTime,
-		constants.ColumbusID:   columbusEarliestTime,
-		constants.KopernikusID: kopernikusEarliestTime,
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
 	}
 	BanffDefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 

--- a/version/constants.go
+++ b/version/constants.go
@@ -188,6 +188,12 @@ var (
 		constants.CaminoID:     time.Date(2023, time.July, 17, 8, 0, 0, 0, time.UTC),
 	}
 
+	PreCortinaTimes = map[uint32]time.Time{
+		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+	}
+
 	// TODO @evlekht update this before release
 	BerlinPhaseTimes = map[uint32]time.Time{
 		constants.KopernikusID: time.Date(2024, time.November, 14, 10, 0, 0, 0, time.UTC),
@@ -279,6 +285,13 @@ func GetBanffTime(networkID uint32) time.Time {
 func GetCortinaTime(networkID uint32) time.Time {
 	if upgradeTime, exists := CortinaTimes[networkID]; exists {
 		return upgradeTime
+	}
+	return CortinaDefaultTime
+}
+
+func GetPreCortinaTime(networkID uint32) time.Time {
+	if genesisTime, exists := PreCortinaTimes[networkID]; exists {
+		return genesisTime
 	}
 	return CortinaDefaultTime
 }

--- a/version/constants.go
+++ b/version/constants.go
@@ -77,36 +77,35 @@ var (
 	DefaultUpgradeTime    = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 	unreachableFutureTime = time.Date(10000, time.January, 1, 0, 0, 0, 0, time.UTC)
 
-	// caminoEarliestTime= time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-	caminoEarliestTime     = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
-	columbusEarliestTime   = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
-	kopernikusEarliestTime = time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC)
+	caminoEarliestTime     = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
+	columbusEarliestTime   = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
+	kopernikusEarliestTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
 	ApricotPhase1Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.March, 31, 14, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.March, 26, 14, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 
 	ApricotPhase2Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.May, 10, 11, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.May, 5, 14, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 
 	ApricotPhase3Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2021, time.August, 24, 14, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.August, 16, 19, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase3DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
@@ -114,9 +113,9 @@ var (
 		constants.MainnetID: time.Date(2021, time.September, 22, 21, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.September, 16, 21, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase4DefaultTime     = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 	ApricotPhase4MinPChainHeight = map[uint32]uint64{
@@ -133,9 +132,9 @@ var (
 		constants.MainnetID: time.Date(2021, time.December, 2, 18, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2021, time.November, 24, 15, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase5DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
@@ -143,33 +142,27 @@ var (
 		constants.MainnetID: time.Date(2022, time.September, 5, 1, 30, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-	}
-
-	SunrisePhase0Times = map[uint32]time.Time{
-		constants.CaminoID:     time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 
 	ApricotPhase6Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.September, 6, 20, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 
 	ApricotPhasePost6Times = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2022, time.September, 7, 3, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.September, 7, 6, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	ApricotPhase6DefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 
@@ -177,11 +170,17 @@ var (
 		constants.MainnetID: time.Date(2022, time.October, 18, 16, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2022, time.October, 3, 14, 0, 0, 0, time.UTC),
 
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 	BanffDefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
+
+	SunrisePhase0Times = map[uint32]time.Time{
+		constants.CaminoID:     time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2022, time.May, 16, 8, 0, 0, 0, time.UTC),
+	}
 
 	AthensPhaseTimes = map[uint32]time.Time{
 		constants.KopernikusID: time.Date(2023, time.July, 4, 13, 0, 0, 0, time.UTC),
@@ -190,26 +189,25 @@ var (
 	}
 
 	PreCortinaTimes = map[uint32]time.Time{
-		constants.CaminoID:     time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
-		constants.KopernikusID: time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC),
+		constants.CaminoID:     caminoEarliestTime,
+		constants.ColumbusID:   columbusEarliestTime,
+		constants.KopernikusID: kopernikusEarliestTime,
 	}
 
 	// TODO @evlekht update this before release
 	BerlinPhaseTimes = map[uint32]time.Time{
-		constants.KopernikusID: time.Date(2024, time.November, 14, 10, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2024, time.November, 14, 10, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2024, time.November, 15, 10, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2024, time.November, 15, 10, 0, 0, 0, time.UTC),
 		constants.CaminoID:     unreachableFutureTime,
 	}
 
-	// TODO @evlekht update this before release, must be exactly the same as Berlin
 	CortinaTimes = map[uint32]time.Time{
 		constants.MainnetID: time.Date(2023, time.April, 25, 15, 0, 0, 0, time.UTC),
 		constants.FujiID:    time.Date(2023, time.April, 6, 15, 0, 0, 0, time.UTC),
 
-		constants.KopernikusID: time.Date(2024, time.November, 14, 10, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2024, time.November, 14, 10, 0, 0, 0, time.UTC),
-		constants.CaminoID:     unreachableFutureTime,
+		constants.KopernikusID: BerlinPhaseTimes[constants.KopernikusID],
+		constants.ColumbusID:   BerlinPhaseTimes[constants.ColumbusID],
+		constants.CaminoID:     BerlinPhaseTimes[constants.CaminoID],
 	}
 	CortinaDefaultTime = time.Date(2020, time.December, 5, 5, 0, 0, 0, time.UTC)
 

--- a/vms/avm/vm.go
+++ b/vms/avm/vm.go
@@ -441,7 +441,7 @@ func (vm *VM) LastAccepted(context.Context) (ids.ID, error) {
  */
 
 func (vm *VM) Linearize(_ context.Context, stopVertexID ids.ID, toEngine chan<- common.Message) error {
-	time := version.GetCortinaTime(vm.ctx.NetworkID)
+	time := version.GetPreCortinaTime(vm.ctx.NetworkID)
 	err := vm.state.InitializeChainState(stopVertexID, time)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Why this should be merged
Berlin phase added some timestamps that were missing in Athens, but they were not consistent with default ones that are used by Athens. This PR fixes that.

## How this was tested
Manually, by bootstrapping node.