### PR TITLE
set Berlin timestamp for columbus

### DIFF
--- a/version/constants.go
+++ b/version/constants.go
@@ -196,8 +196,8 @@ var (
 
 	// TODO @evlekht update this before release
 	BerlinPhaseTimes = map[uint32]time.Time{
-		constants.KopernikusID: time.Date(2024, time.November, 15, 10, 0, 0, 0, time.UTC),
-		constants.ColumbusID:   time.Date(2024, time.November, 15, 10, 0, 0, 0, time.UTC),
+		constants.KopernikusID: time.Date(2024, time.November, 28, 10, 0, 0, 0, time.UTC),
+		constants.ColumbusID:   time.Date(2024, time.November, 28, 10, 0, 0, 0, time.UTC),
 		constants.CaminoID:     unreachableFutureTime,
 	}
 


### PR DESCRIPTION
This is the new Berlin timestamp for Columbus 28.11.2024 at 10:00 UTC
