### PR TITLE
Bugfix: Propagate allowEarlyFinish from GeneralProposal to GeneralProposalState

### DIFF
--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -253,6 +253,7 @@ func (p *GeneralProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote) 
 			Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
 		},
 		TotalAllowedVoters: p.TotalAllowedVoters,
+		AllowEarlyFinish:   p.AllowEarlyFinish,
 	}
 	// we can't use the same slice, cause we need to change its elements
 	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])


### PR DESCRIPTION
## Why this should be merged
To allow the flag (boolean) `AllowEarlyFinish` of the  `GeneralProposal` to trigger `CanBeFinished` logic (the value of `AllowEarlyFinish` is now copied correctly from the `GeneralProposal` to  `GeneralProposalState`  where it is checked upon each `AddVote`).

## How this works

If we take a look at `CanBeFinished` of `GeneralProposal`, we can see it checks the value of `AllowEarlyFinish` on `GeneralProposalState` (not the `GeneralProposal` itself)

```
func (p *GeneralProposalState) CanBeFinished() bool {
	if !p.AllowEarlyFinish {
		return false
	}

	mostVotedWeight, mostVotedIndex, unambiguous := p.GetMostVoted()
	voted := p.Voted()
	remainingVotes := p.TotalAllowedVoters - voted

	secondMostVotedWeight := uint32(0)
	if len(p.Options) > 1 {
		for index, option := range p.Options {
			if option.Weight > secondMostVotedWeight && index != int(mostVotedIndex) {
				secondMostVotedWeight = option.Weight
			}
		}
	}

	// mostVotedThreshold = voted * p.MostVotedThresholdNominator / fractionDenominatorBig
	mostVotedThresholdNominator := big.NewInt(int64(p.MostVotedThresholdNominator))
	mostVotedThresholdBig := big.NewInt(int64(voted))
	mostVotedThresholdBig.Mul(mostVotedThresholdBig, mostVotedThresholdNominator)
	mostVotedThresholdBig.Div(mostVotedThresholdBig, fractionDenominatorBig)
	mostVotedThreshold := uint32(mostVotedThresholdBig.Uint64())

	return remainingVotes+mostVotedWeight < mostVotedThreshold+1 || // no option can win
		voted == p.TotalAllowedVoters || // everyone had voted
		unambiguous && // option will inevitably win, because
			(mostVotedWeight > remainingVotes+secondMostVotedWeight || len(p.Options) == 1) && // it has more votes than any other option + remaining votes or its the only option
			mostVotedWeight > mostVotedThreshold && // it has already surpassed mostVotedThreshold
			voted > p.TotalVotedThreshold // it has already surpassed totalVotedThreshold
}
```

This requires the `GeneralProposalState` to be updated with the correct value (from the previous state).

The initial state is set correctly in the `CreateProposalState`,
```
func (p *GeneralProposal) CreateProposalState(allowedVoters []ids.ShortID) ProposalState {
	// totalVotedThreshold = len(allowedVoters) * p.TotalVotedThresholdNominator / fractionDenominatorBig
	totalAllowedVoters := big.NewInt(int64(len(allowedVoters)))
	totalVotedThreshold := big.NewInt(int64(p.TotalVotedThresholdNominator))
	totalVotedThreshold.Mul(totalVotedThreshold, totalAllowedVoters)
	totalVotedThreshold.Div(totalVotedThreshold, fractionDenominatorBig)

	stateProposal := &GeneralProposalState{
		SimpleVoteOptions: SimpleVoteOptions[[]byte]{
			Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
		},
		Start:                       p.Start,
		End:                         p.End,
		AllowedVoters:               allowedVoters,
		TotalAllowedVoters:          uint32(len(allowedVoters)),
		TotalVotedThreshold:         uint32(totalVotedThreshold.Uint64()),
		MostVotedThresholdNominator: p.MostVotedThresholdNominator,
		AllowEarlyFinish:            p.AllowEarlyFinish,
	}
	for i := range p.Options {
		stateProposal.Options[i].Value = p.Options[i]
	}
	return stateProposal
}

```
 but the the state is updated ( on `AdVote`)  where it is currently not setting the `AllowEarlyFinish` , and thus in the `CanBeFinished`  it is always read as the default value of `boolean`, which is `false`. 

```
func (p *GeneralProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote) (ProposalState, error) {
	vote, ok := voteIntf.(*SimpleVote)
	if !ok {
		return nil, ErrWrongVote
	}
	if int(vote.OptionIndex) >= len(p.Options) {
		return nil, ErrWrongVote
	}

	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
		return bytes.Compare(id[:], other[:])
	})
	if !allowedToVote {
		return nil, ErrNotAllowedToVoteOnProposal
	}

	updatedProposal := &GeneralProposalState{
		Start:         p.Start,
		End:           p.End,
		AllowedVoters: make([]ids.ShortID, len(p.AllowedVoters)-1),
		SimpleVoteOptions: SimpleVoteOptions[[]byte]{
			Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
		},
		TotalAllowedVoters: p.TotalAllowedVoters,
		AllowEarlyFinish:   p.AllowEarlyFinish, // <- THIS IS THE FIX
	}
	// we can't use the same slice, cause we need to change its elements
	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
	// we can't use the same slice, cause we need to change its element
	copy(updatedProposal.Options, p.Options)
	updatedProposal.Options[vote.OptionIndex].Weight++
	return updatedProposal, nil
}

```


 
## How this was tested
By running examples in caminojs