### PR TITLE
Unlocked expired deposits with new UnlockExpiredDepositsTx after CairoPhase

### DIFF
--- a/vms/platformvm/blocks/builder/camino_builder.go
+++ b/vms/platformvm/blocks/builder/camino_builder.go
@@ -78,11 +78,18 @@ func caminoBuildBlock(
 		return nil, fmt.Errorf("could not find next deposits to unlock: %w", err)
 	}
 	if shouldUnlock {
-		unlockDepositTx, err := txBuilder.NewSystemUnlockDepositTx(depositsTxIDs)
-		if err != nil {
-			return nil, fmt.Errorf("could not build tx to unlock deposits: %w", err)
+		var unlockDepositTx *txs.Tx
+		if builder.txExecutorBackend.Config.IsCairoPhaseActivated(timestamp) {
+			unlockDepositTx, err = txBuilder.NewUnlockExpiredDepositTx(depositsTxIDs)
+			if err != nil {
+				return nil, fmt.Errorf("could not build tx to unlock deposits: %w", err)
+			}
+		} else {
+			unlockDepositTx, err = txBuilder.NewSystemUnlockDepositTx(depositsTxIDs)
+			if err != nil {
+				return nil, fmt.Errorf("could not build tx to unlock deposits: %w", err)
+			}
 		}
-
 		return blocks.NewBanffStandardBlock(
 			timestamp,
 			parentID,

--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -108,7 +108,7 @@ func (*txMetrics) FinishProposalsTx(*txs.FinishProposalsTx) error {
 	return nil
 }
 
-func (m *txMetrics) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
+func (*txMetrics) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
 	return nil
 }
 

--- a/vms/platformvm/metrics/camino_tx_metrics.go
+++ b/vms/platformvm/metrics/camino_tx_metrics.go
@@ -24,7 +24,8 @@ type caminoTxMetrics struct {
 	numAddDepositOfferTxs,
 	numAddProposalTxs,
 	numAddVoteTxs,
-	numFinishProposalsTxs prometheus.Counter
+	numFinishProposalsTxs,
+	numUnlockExpiredDepositTxs prometheus.Counter
 }
 
 func newCaminoTxMetrics(
@@ -40,18 +41,19 @@ func newCaminoTxMetrics(
 	m := &caminoTxMetrics{
 		txMetrics: *txm,
 		// Camino specific tx metrics
-		numAddressStateTxs:    newTxMetric(namespace, "add_address_state", registerer, &errs),
-		numDepositTxs:         newTxMetric(namespace, "deposit", registerer, &errs),
-		numUnlockDepositTxs:   newTxMetric(namespace, "unlock_deposit", registerer, &errs),
-		numClaimTxs:           newTxMetric(namespace, "claim", registerer, &errs),
-		numRegisterNodeTxs:    newTxMetric(namespace, "register_node", registerer, &errs),
-		numRewardsImportTxs:   newTxMetric(namespace, "rewards_import", registerer, &errs),
-		numBaseTxs:            newTxMetric(namespace, "base", registerer, &errs),
-		numMultisigAliasTxs:   newTxMetric(namespace, "multisig_alias", registerer, &errs),
-		numAddDepositOfferTxs: newTxMetric(namespace, "add_deposit_offer", registerer, &errs),
-		numAddProposalTxs:     newTxMetric(namespace, "add_proposal", registerer, &errs),
-		numAddVoteTxs:         newTxMetric(namespace, "add_vote", registerer, &errs),
-		numFinishProposalsTxs: newTxMetric(namespace, "finish_proposals", registerer, &errs),
+		numAddressStateTxs:         newTxMetric(namespace, "add_address_state", registerer, &errs),
+		numDepositTxs:              newTxMetric(namespace, "deposit", registerer, &errs),
+		numUnlockDepositTxs:        newTxMetric(namespace, "unlock_deposit", registerer, &errs),
+		numClaimTxs:                newTxMetric(namespace, "claim", registerer, &errs),
+		numRegisterNodeTxs:         newTxMetric(namespace, "register_node", registerer, &errs),
+		numRewardsImportTxs:        newTxMetric(namespace, "rewards_import", registerer, &errs),
+		numBaseTxs:                 newTxMetric(namespace, "base", registerer, &errs),
+		numMultisigAliasTxs:        newTxMetric(namespace, "multisig_alias", registerer, &errs),
+		numAddDepositOfferTxs:      newTxMetric(namespace, "add_deposit_offer", registerer, &errs),
+		numAddProposalTxs:          newTxMetric(namespace, "add_proposal", registerer, &errs),
+		numAddVoteTxs:              newTxMetric(namespace, "add_vote", registerer, &errs),
+		numFinishProposalsTxs:      newTxMetric(namespace, "finish_proposals", registerer, &errs),
+		numUnlockExpiredDepositTxs: newTxMetric(namespace, "system_unlock_deposit", registerer, &errs),
 	}
 	return m, errs.Err
 }
@@ -103,6 +105,10 @@ func (*txMetrics) AddVoteTx(*txs.AddVoteTx) error {
 }
 
 func (*txMetrics) FinishProposalsTx(*txs.FinishProposalsTx) error {
+	return nil
+}
+
+func (m *txMetrics) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
 	return nil
 }
 
@@ -165,5 +171,10 @@ func (m *caminoTxMetrics) AddVoteTx(*txs.AddVoteTx) error {
 
 func (m *caminoTxMetrics) FinishProposalsTx(*txs.FinishProposalsTx) error {
 	m.numFinishProposalsTxs.Inc()
+	return nil
+}
+
+func (m *caminoTxMetrics) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
+	m.numUnlockExpiredDepositTxs.Inc()
 	return nil
 }

--- a/vms/platformvm/test/generate/camino_generate.go
+++ b/vms/platformvm/test/generate/camino_generate.go
@@ -99,6 +99,15 @@ func OutFromUTXO(t *testing.T, utxo *avax.UTXO, depositTxID, bondTxID ids.ID) *a
 	}
 }
 
+func OutsFromUTXOs(t *testing.T, utxos []*avax.UTXO, depositTxID, bondTxID ids.ID) []*avax.TransferableOutput {
+	t.Helper()
+	outs := make([]*avax.TransferableOutput, len(utxos))
+	for i := range utxos {
+		outs[i] = OutFromUTXO(t, utxos[i], depositTxID, bondTxID)
+	}
+	return outs
+}
+
 func Out(assetID ids.ID, amount uint64, outputOwners secp256k1fx.OutputOwners, depositTxID, bondTxID ids.ID) *avax.TransferableOutput {
 	var out avax.TransferableOut = &secp256k1fx.TransferOutput{
 		Amt:          amount,
@@ -267,6 +276,15 @@ func InsFromUTXOsWithSigIndices(t *testing.T, utxos []*avax.UTXO, sigIndices []u
 	ins := make([]*avax.TransferableInput, len(utxos))
 	for i := range utxos {
 		ins[i] = InFromUTXO(t, utxos[i], sigIndices, false)
+	}
+	return ins
+}
+
+func InsFromUTXOsWithoutSigIndices(t *testing.T, utxos []*avax.UTXO) []*avax.TransferableInput {
+	t.Helper()
+	ins := make([]*avax.TransferableInput, len(utxos))
+	for i := range utxos {
+		ins[i] = InFromUTXO(t, utxos[i], []uint32{}, false)
 	}
 	return ins
 }

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -114,6 +114,10 @@ type CaminoTxBuilder interface {
 		depositTxIDs []ids.ID,
 	) (*txs.Tx, error)
 
+	NewUnlockExpiredDepositTx(
+		depositTxIDs []ids.ID,
+	) (*txs.Tx, error)
+
 	NewFinishProposalsTx(
 		state state.Chain,
 		earlyFinishedProposalIDs []ids.ID,
@@ -703,6 +707,7 @@ func (b *caminoBuilder) NewRewardsImportTx() (*txs.Tx, error) {
 	return tx, tx.SyntacticVerify(b.ctx)
 }
 
+// TODO@ test
 func (b *caminoBuilder) NewSystemUnlockDepositTx(
 	depositTxIDs []ids.ID,
 ) (*txs.Tx, error) {
@@ -718,6 +723,24 @@ func (b *caminoBuilder) NewSystemUnlockDepositTx(
 			Ins:          ins,
 			Outs:         outs,
 		}},
+	}}
+	if err := tx.Initialize(txs.Codec); err != nil {
+		return nil, err
+	}
+	return tx, tx.SyntacticVerify(b.ctx)
+}
+
+func (b *caminoBuilder) NewUnlockExpiredDepositTx(
+	depositTxIDs []ids.ID,
+) (*txs.Tx, error) {
+	ins, outs, err := b.Unlock(b.state, depositTxIDs, locked.StateDeposited)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate tx inputs/outputs: %w", err)
+	}
+
+	tx := &txs.Tx{Unsigned: &txs.UnlockExpiredDepositTx{
+		Ins:  ins,
+		Outs: outs,
 	}}
 	if err := tx.Initialize(txs.Codec); err != nil {
 		return nil, err

--- a/vms/platformvm/txs/camino_unlock_expired_deposit_tx.go
+++ b/vms/platformvm/txs/camino_unlock_expired_deposit_tx.go
@@ -21,7 +21,7 @@ type UnlockExpiredDepositTx struct {
 	unsignedBytes []byte // Unsigned byte representation of this data
 }
 
-func (tx *UnlockExpiredDepositTx) SyntacticVerify(ctx *snow.Context) error {
+func (tx *UnlockExpiredDepositTx) SyntacticVerify(_ *snow.Context) error {
 	return nil
 }
 

--- a/vms/platformvm/txs/camino_unlock_expired_deposit_tx.go
+++ b/vms/platformvm/txs/camino_unlock_expired_deposit_tx.go
@@ -21,7 +21,7 @@ type UnlockExpiredDepositTx struct {
 	unsignedBytes []byte // Unsigned byte representation of this data
 }
 
-func (tx *UnlockExpiredDepositTx) SyntacticVerify(_ *snow.Context) error {
+func (*UnlockExpiredDepositTx) SyntacticVerify(_ *snow.Context) error {
 	return nil
 }
 

--- a/vms/platformvm/txs/camino_unlock_expired_deposit_tx.go
+++ b/vms/platformvm/txs/camino_unlock_expired_deposit_tx.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txs
+
+import (
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/utils/set"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+)
+
+var _ UnsignedTx = (*UnlockExpiredDepositTx)(nil)
+
+// UnlockExpiredDepositTx is an unsigned UnlockExpiredDepositTx
+type UnlockExpiredDepositTx struct {
+	Ins  []*avax.TransferableInput  `serialize:"true" json:"inputs"`
+	Outs []*avax.TransferableOutput `serialize:"true" json:"outputs"`
+
+	unsignedBytes []byte // Unsigned byte representation of this data
+}
+
+func (tx *UnlockExpiredDepositTx) SyntacticVerify(ctx *snow.Context) error {
+	return nil
+}
+
+func (tx *UnlockExpiredDepositTx) SetBytes(unsignedBytes []byte) {
+	tx.unsignedBytes = unsignedBytes
+}
+
+func (tx *UnlockExpiredDepositTx) Bytes() []byte {
+	return tx.unsignedBytes
+}
+
+func (tx *UnlockExpiredDepositTx) InitCtx(ctx *snow.Context) {
+	for _, in := range tx.Ins {
+		in.FxID = secp256k1fx.ID
+	}
+	for _, out := range tx.Outs {
+		out.FxID = secp256k1fx.ID
+		out.InitCtx(ctx)
+	}
+}
+
+func (tx *UnlockExpiredDepositTx) InputIDs() set.Set[ids.ID] {
+	inputIDs := set.NewSet[ids.ID](len(tx.Ins))
+	for _, in := range tx.Ins {
+		inputIDs.Add(in.InputID())
+	}
+	return inputIDs
+}
+
+func (tx *UnlockExpiredDepositTx) Outputs() []*avax.TransferableOutput {
+	return tx.Outs
+}
+
+func (tx *UnlockExpiredDepositTx) Visit(visitor Visitor) error {
+	return visitor.UnlockExpiredDepositTx(tx)
+}

--- a/vms/platformvm/txs/camino_visitor.go
+++ b/vms/platformvm/txs/camino_visitor.go
@@ -7,6 +7,7 @@ type CaminoVisitor interface {
 	AddressStateTx(*AddressStateTx) error
 	DepositTx(*DepositTx) error
 	UnlockDepositTx(*UnlockDepositTx) error
+	UnlockExpiredDepositTx(*UnlockExpiredDepositTx) error
 	ClaimTx(*ClaimTx) error
 	RegisterNodeTx(*RegisterNodeTx) error
 	RewardsImportTx(*RewardsImportTx) error

--- a/vms/platformvm/txs/codec.go
+++ b/vms/platformvm/txs/codec.go
@@ -134,6 +134,7 @@ func RegisterUnsignedTxsTypes(targetCodec codec.CaminoRegistry) error {
 		targetCodec.RegisterCustomType(&dac.ExcludeMemberProposal{}),
 		targetCodec.RegisterCustomType(&dac.GeneralProposal{}),
 		targetCodec.RegisterCustomType(&dac.FeeDistributionProposal{}),
+		targetCodec.RegisterCustomType(&UnlockExpiredDepositTx{}),
 	)
 	return errs.Err
 }

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -106,7 +106,6 @@ var (
 	errNotPermittedToCreateProposal      = errors.New("don't have permission to create proposal of this type")
 	errZeroDepositOfferLimits            = errors.New("deposit offer TotalMaxAmount and TotalMaxRewardAmount are zero")
 	errAddrStateNotChanged               = errors.New("address state wasn't changed")
-	errDepositExpired                    = errors.New("deposit is expired")
 	errNotDepositedInput                 = errors.New("input is not deposited")
 	errNotCairoPhase                     = errors.New("not allowed before CairoPhase")
 	errDepositNotExpired                 = errors.New("deposit is not expired")

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -106,6 +106,10 @@ var (
 	errNotPermittedToCreateProposal      = errors.New("don't have permission to create proposal of this type")
 	errZeroDepositOfferLimits            = errors.New("deposit offer TotalMaxAmount and TotalMaxRewardAmount are zero")
 	errAddrStateNotChanged               = errors.New("address state wasn't changed")
+	errDepositExpired                    = errors.New("deposit is expired")
+	errNotDepositedInput                 = errors.New("input is not deposited")
+	errNotCairoPhase                     = errors.New("not allowed before CairoPhase")
+	errDepositNotExpired                 = errors.New("deposit is not expired")
 
 	ErrInvalidProposal = errors.New("proposal is semantically invalid")
 )
@@ -971,6 +975,120 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 				Duration:            deposit.Duration,
 				RewardOwner:         deposit.RewardOwner,
 			})
+		}
+	}
+
+	avax.Consume(e.State, tx.Ins)
+	avax.Produce(e.State, e.Tx.ID(), tx.Outs)
+
+	return nil
+}
+
+func (e *CaminoStandardTxExecutor) UnlockExpiredDepositTx(tx *txs.UnlockExpiredDepositTx) error {
+	caminoConfig, err := e.State.CaminoConfig()
+	if err != nil {
+		return err
+	}
+
+	if !caminoConfig.LockModeBondDeposit {
+		return errWrongLockMode
+	}
+
+	switch {
+	case tx == nil:
+		return txs.ErrNilTx
+	case len(e.Tx.Creds) != 0:
+		return errWrongCredentialsNumber
+	}
+
+	chainTime := e.State.GetTimestamp()
+
+	if !e.Config.IsCairoPhaseActivated(chainTime) {
+		return errNotCairoPhase
+	}
+
+	chainTimestamp := uint64(chainTime.Unix())
+	depositTxIDs := set.Set[ids.ID]{}
+
+	for _, input := range tx.Ins {
+		lockedIn, ok := input.In.(*locked.In)
+		if !ok || lockedIn.DepositTxID == ids.Empty {
+			return errNotDepositedInput
+		}
+
+		deposit, err := e.State.GetDeposit(lockedIn.DepositTxID)
+		if err != nil {
+			return err
+		}
+
+		if !deposit.IsExpired(chainTimestamp) {
+			return errDepositNotExpired
+		}
+
+		depositTxIDs.Add(lockedIn.DepositTxID)
+	}
+
+	expectedIns, expectedOuts, err := e.FlowChecker.Unlock(
+		e.State,
+		depositTxIDs.List(),
+		locked.StateDeposited,
+	)
+	if err != nil {
+		return err
+	}
+
+	if !inputsAreEqual(tx.Ins, expectedIns) {
+		return fmt.Errorf("%w: invalid inputs", errInvalidSystemTxBody)
+	}
+
+	if !outputsAreEqual(tx.Outs, expectedOuts) {
+		return fmt.Errorf("%w: invalid outputs", errInvalidSystemTxBody)
+	}
+
+	for depositTxID := range depositTxIDs {
+		deposit, err := e.State.GetDeposit(depositTxID)
+		if err != nil {
+			return err
+		}
+
+		offer, err := e.State.GetDepositOffer(deposit.DepositOfferID)
+		if err != nil {
+			return err
+		}
+
+		e.State.RemoveDeposit(depositTxID, deposit)
+
+		if remainingReward := deposit.TotalReward(offer) - deposit.ClaimedRewardAmount; remainingReward > 0 {
+			claimableOwnerID, err := txs.GetOwnerID(deposit.RewardOwner)
+			if err != nil {
+				return err
+			}
+
+			claimable, err := e.State.GetClaimable(claimableOwnerID)
+			switch {
+			case err == database.ErrNotFound:
+				secpOwner, ok := deposit.RewardOwner.(*secp256k1fx.OutputOwners)
+				if !ok {
+					return errWrongOwnerType
+				}
+				claimable = &state.Claimable{
+					Owner: secpOwner,
+				}
+			case err != nil:
+				return err
+			}
+
+			newClaimable := &state.Claimable{
+				Owner:           claimable.Owner,
+				ValidatorReward: claimable.ValidatorReward,
+			}
+
+			newClaimable.ExpiredDepositReward, err = math.Add64(claimable.ExpiredDepositReward, remainingReward)
+			if err != nil {
+				return err
+			}
+
+			e.State.SetClaimable(claimableOwnerID, newClaimable)
 		}
 	}
 

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -8330,3 +8330,334 @@ func TestGetBitsFromAddressState(t *testing.T) {
 		require.Equal(t, tt.expectedAddressStateBits, addressStateBits)
 	}
 }
+
+func TestCaminoStandardTxExecutorUnlockExpiredDepositTx(t *testing.T) {
+	caminoGenesisConf := api.Camino{
+		VerifyNodeSignature: true,
+		LockModeBondDeposit: true,
+	}
+	caminoConfig := &state.CaminoConfig{
+		VerifyNodeSignature: caminoGenesisConf.VerifyNodeSignature,
+		LockModeBondDeposit: caminoGenesisConf.LockModeBondDeposit,
+	}
+
+	depositOwnerKey1, depositOwnerAddr1, depositOwner1 := generate.KeyAndOwner(t, test.Keys[0])
+	_, depositOwnerAddr2, depositOwner2 := generate.KeyAndOwner(t, test.Keys[1])
+	_, _, rewardOwner1 := generate.KeyAndOwner(t, test.Keys[2])
+	_, _, rewardOwner2 := generate.KeyAndOwner(t, test.Keys[3])
+	claimableOwnerID1, err := txs.GetOwnerID(rewardOwner1)
+	require.NoError(t, err)
+	claimableOwnerID2, err := txs.GetOwnerID(rewardOwner2)
+	require.NoError(t, err)
+
+	depositTxID1 := ids.ID{3}
+	depositTxID2 := ids.ID{4}
+	depositTxID3 := ids.ID{5}
+	bondTxID1 := ids.ID{6}
+	bondTxID2 := ids.ID{7}
+
+	depositedUTXO1 := generate.UTXO(ids.ID{8}, test.AVAXAssetID, 7, depositOwner1, depositTxID1, ids.Empty, true)
+	depositedUTXO2 := generate.UTXO(ids.ID{9}, test.AVAXAssetID, 11, depositOwner1, depositTxID2, ids.Empty, true)
+	depositedUTXO3 := generate.UTXO(ids.ID{10}, test.AVAXAssetID, 13, depositOwner2, depositTxID3, ids.Empty, true)
+	depositedBondedUTXO1 := generate.UTXO(ids.ID{11}, test.AVAXAssetID, 17, depositOwner1, depositTxID1, bondTxID1, true)
+	depositedBondedUTXO2 := generate.UTXO(ids.ID{12}, test.AVAXAssetID, 19, depositOwner1, depositTxID1, bondTxID2, true)
+	depositedBondedUTXO3 := generate.UTXO(ids.ID{13}, test.AVAXAssetID, 23, depositOwner1, depositTxID2, bondTxID2, true)
+
+	rewardOwnerClaimable1 := &state.Claimable{
+		Owner:                &rewardOwner1,
+		ValidatorReward:      3,
+		ExpiredDepositReward: 4,
+	}
+
+	depositOffer1 := &deposit.Offer{
+		ID: ids.ID{1},
+	}
+	depositOffer2 := &deposit.Offer{
+		ID:                    ids.ID{2},
+		InterestRateNominator: deposit.InterestRateDenominator,
+	}
+	depositOffer3 := &deposit.Offer{
+		ID:                    ids.ID{2},
+		InterestRateNominator: deposit.InterestRateDenominator,
+	}
+	deposit1 := &deposit.Deposit{
+		DepositOfferID: depositOffer1.ID,
+		Duration:       1,
+		Amount:         7 + 17 + 19, // depositedUTXO1 + depositedBondedUTXO1 + depositedBondedUTXO2
+	}
+	deposit2 := &deposit.Deposit{
+		DepositOfferID:      depositOffer2.ID,
+		Duration:            100,
+		ClaimedRewardAmount: 29,
+		Amount:              11 + 23, // depositedUTXO2 + depositedBondedUTXO3
+		RewardOwner:         &rewardOwner1,
+	}
+	deposit3 := &deposit.Deposit{
+		DepositOfferID:      depositOffer2.ID,
+		Duration:            100,
+		ClaimedRewardAmount: 31,
+		Amount:              13, // depositedUTXO3
+		RewardOwner:         &rewardOwner2,
+	}
+	require.Greater(t, deposit2.TotalReward(depositOffer2), deposit2.ClaimedRewardAmount)
+	require.Greater(t, deposit3.TotalReward(depositOffer3), deposit3.ClaimedRewardAmount)
+
+	unlockExpiredDepositTx := &txs.UnlockExpiredDepositTx{
+		Ins:  generate.InsFromUTXOs(t, []*avax.UTXO{depositedUTXO1}),
+		Outs: generate.OutsFromUTXOs(t, []*avax.UTXO{depositedUTXO1}, ids.Empty, ids.Empty),
+	}
+
+	tests := map[string]struct {
+		state       func(*testing.T, *gomock.Controller, *config.Config, test.Phase, *txs.UnlockExpiredDepositTx, ids.ID) *state.MockDiff
+		tx          *txs.UnlockExpiredDepositTx
+		signers     [][]*secp256k1.PrivateKey
+		phase       test.Phase
+		expectedErr error
+	}{
+		"Not zero credentials": {
+			state: func(_ *testing.T, ctrl *gomock.Controller, _ *config.Config, _ test.Phase, _ *txs.UnlockExpiredDepositTx, _ ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				return s
+			},
+			tx:          unlockExpiredDepositTx,
+			signers:     [][]*secp256k1.PrivateKey{{depositOwnerKey1}},
+			phase:       test.PhaseLast,
+			expectedErr: errWrongCredentialsNumber,
+		},
+		"Not CairoPhase": {
+			state: func(_ *testing.T, ctrl *gomock.Controller, cfg *config.Config, phase test.Phase, _ *txs.UnlockExpiredDepositTx, _ ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+				return s
+			},
+			tx:          unlockExpiredDepositTx,
+			phase:       test.PhaseBerlin,
+			expectedErr: errNotCairoPhase,
+		},
+		"Not deposited input": {
+			state: func(_ *testing.T, ctrl *gomock.Controller, cfg *config.Config, phase test.Phase, _ *txs.UnlockExpiredDepositTx, _ ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil) // for ins[0] deposited input
+				return s
+			},
+			tx: &txs.UnlockExpiredDepositTx{
+				Ins: append(
+					unlockExpiredDepositTx.Ins,
+					generate.In(test.AVAXAssetID, 3, ids.Empty, ids.Empty, []uint32{}), // not deposited input
+				),
+				Outs: unlockExpiredDepositTx.Outs,
+			},
+			phase:       test.PhaseLast,
+			expectedErr: errNotDepositedInput,
+		},
+		"Not expired deposit": {
+			state: func(_ *testing.T, ctrl *gomock.Controller, cfg *config.Config, phase test.Phase, _ *txs.UnlockExpiredDepositTx, _ ids.ID) *state.MockDiff {
+				chainTime := test.PhaseTime(t, phase, cfg)
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				s.EXPECT().GetTimestamp().Return(chainTime)
+				s.EXPECT().GetDeposit(depositTxID1).Return(&deposit.Deposit{
+					Start: uint64(chainTime.Unix()), Duration: 1,
+				}, nil)
+				return s
+			},
+			tx:          unlockExpiredDepositTx,
+			phase:       test.PhaseLast,
+			expectedErr: errDepositNotExpired,
+		},
+		"Invalid inputs (one excess)": {
+			state: func(t *testing.T, ctrl *gomock.Controller, cfg *config.Config, phase test.Phase, _ *txs.UnlockExpiredDepositTx, _ ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2) // per input deposit
+				expect.Unlock(t, s,
+					[]ids.ID{depositTxID1},
+					[]ids.ShortID{depositOwnerAddr1},
+					[]*avax.UTXO{depositedUTXO1},
+					locked.StateDeposited,
+				)
+				return s
+			},
+			tx: &txs.UnlockExpiredDepositTx{
+				Ins: append(
+					unlockExpiredDepositTx.Ins,
+					generate.In(test.AVAXAssetID, 3, depositTxID1, ids.Empty, []uint32{}), // excess input
+				),
+				Outs: unlockExpiredDepositTx.Outs,
+			},
+			phase:       test.PhaseLast,
+			expectedErr: errInvalidSystemTxBody,
+		},
+		"Invalid inputs (wrong amount)": {
+			state: func(t *testing.T, ctrl *gomock.Controller, cfg *config.Config, phase test.Phase, _ *txs.UnlockExpiredDepositTx, _ ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
+				expect.Unlock(t, s,
+					[]ids.ID{depositTxID1},
+					[]ids.ShortID{depositOwnerAddr1},
+					[]*avax.UTXO{depositedUTXO1},
+					locked.StateDeposited,
+				)
+				return s
+			},
+			tx: &txs.UnlockExpiredDepositTx{
+				Ins: func() []*avax.TransferableInput {
+					input := generate.InFromUTXO(t, depositedUTXO1, []uint32{}, false)
+					input.In.(*locked.In).TransferableIn.(*secp256k1fx.TransferInput).Amt++ // wrong amount
+					return []*avax.TransferableInput{input}
+				}(),
+				Outs: unlockExpiredDepositTx.Outs,
+			},
+			phase:       test.PhaseLast,
+			expectedErr: errInvalidSystemTxBody,
+		},
+		"Invalid outputs (one excess)": {
+			state: func(t *testing.T, ctrl *gomock.Controller, cfg *config.Config, phase test.Phase, _ *txs.UnlockExpiredDepositTx, _ ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
+				expect.Unlock(t, s,
+					[]ids.ID{depositTxID1},
+					[]ids.ShortID{depositOwnerAddr1},
+					[]*avax.UTXO{depositedUTXO1},
+					locked.StateDeposited,
+				)
+				return s
+			},
+			tx: &txs.UnlockExpiredDepositTx{
+				Ins: unlockExpiredDepositTx.Ins,
+				Outs: append(
+					unlockExpiredDepositTx.Outs,
+					generate.Out(test.AVAXAssetID, 3, depositOwner1, ids.Empty, ids.Empty), // excess output
+				),
+			},
+			phase:       test.PhaseLast,
+			expectedErr: errInvalidSystemTxBody,
+		},
+		"Invalid outputs (wrong amount)": {
+			state: func(t *testing.T, ctrl *gomock.Controller, cfg *config.Config, phase test.Phase, _ *txs.UnlockExpiredDepositTx, _ ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
+				expect.Unlock(t, s,
+					[]ids.ID{depositTxID1},
+					[]ids.ShortID{depositOwnerAddr1},
+					[]*avax.UTXO{depositedUTXO1},
+					locked.StateDeposited,
+				)
+				return s
+			},
+			tx: &txs.UnlockExpiredDepositTx{
+				Ins: unlockExpiredDepositTx.Ins,
+				Outs: []*avax.TransferableOutput{generate.Out(
+					test.AVAXAssetID,
+					unlockExpiredDepositTx.Outs[0].Out.(*secp256k1fx.TransferOutput).Amt+1, // wrong amount
+					depositOwner1,
+					depositTxID1,
+					ids.Empty,
+				)},
+			},
+			phase:       test.PhaseLast,
+			expectedErr: errInvalidSystemTxBody,
+		},
+		"OK": {
+			state: func(t *testing.T, ctrl *gomock.Controller, cfg *config.Config, phase test.Phase, tx *txs.UnlockExpiredDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(ctrl)
+				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(3) // per input with depositTxID1
+				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil).Times(2) // per input with depositTxID2
+				s.EXPECT().GetDeposit(depositTxID3).Return(deposit3, nil)          // per input with depositTxID3
+				expect.Unlock(t, s,
+					[]ids.ID{depositTxID1, depositTxID2, depositTxID3},
+					[]ids.ShortID{depositOwnerAddr1, depositOwnerAddr2},
+					[]*avax.UTXO{
+						depositedUTXO1,
+						depositedUTXO2,
+						depositedUTXO3,
+						depositedBondedUTXO1,
+						depositedBondedUTXO2,
+						depositedBondedUTXO3,
+					},
+					locked.StateDeposited,
+				)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
+				s.EXPECT().GetDepositOffer(deposit1.DepositOfferID).Return(depositOffer1, nil)
+				s.EXPECT().RemoveDeposit(depositTxID1, deposit1)
+				s.EXPECT().GetClaimable(claimableOwnerID1).Return(rewardOwnerClaimable1, nil)
+				remainingReward := deposit2.TotalReward(depositOffer2) - deposit2.ClaimedRewardAmount
+				newClaimable := &state.Claimable{
+					Owner:                rewardOwnerClaimable1.Owner,
+					ValidatorReward:      rewardOwnerClaimable1.ValidatorReward,
+					ExpiredDepositReward: rewardOwnerClaimable1.ExpiredDepositReward + remainingReward,
+				}
+				s.EXPECT().SetClaimable(claimableOwnerID1, newClaimable)
+
+				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil)
+				s.EXPECT().GetDepositOffer(deposit2.DepositOfferID).Return(depositOffer2, nil)
+				s.EXPECT().RemoveDeposit(depositTxID2, deposit2)
+
+				s.EXPECT().GetDeposit(depositTxID3).Return(deposit3, nil)
+				s.EXPECT().GetDepositOffer(deposit3.DepositOfferID).Return(depositOffer3, nil)
+				s.EXPECT().RemoveDeposit(depositTxID3, deposit3)
+				s.EXPECT().GetClaimable(claimableOwnerID2).Return(nil, database.ErrNotFound)
+				s.EXPECT().SetClaimable(claimableOwnerID2, &state.Claimable{
+					Owner:                &rewardOwner2,
+					ValidatorReward:      0,
+					ExpiredDepositReward: deposit3.TotalReward(depositOffer3) - deposit3.ClaimedRewardAmount,
+				})
+
+				expect.ConsumeUTXOs(t, s, tx.Ins)
+				expect.ProduceUTXOs(t, s, tx.Outs, txID, 0)
+				return s
+			},
+			phase: test.PhaseLast,
+			tx: &txs.UnlockExpiredDepositTx{
+				Ins: generate.InsFromUTXOsWithoutSigIndices(t, []*avax.UTXO{
+					depositedUTXO1,
+					depositedUTXO2,
+					depositedUTXO3,
+					depositedBondedUTXO1,
+					depositedBondedUTXO2,
+					depositedBondedUTXO3,
+				}),
+				Outs: []*avax.TransferableOutput{
+					generate.OutFromUTXO(t, depositedUTXO1, ids.Empty, ids.Empty),
+					generate.OutFromUTXO(t, depositedUTXO2, ids.Empty, ids.Empty),
+					generate.OutFromUTXO(t, depositedUTXO3, ids.Empty, ids.Empty),
+					generate.OutFromUTXO(t, depositedBondedUTXO1, ids.Empty, bondTxID1),
+					generate.OutFromUTXO(t, depositedBondedUTXO2, ids.Empty, bondTxID2),
+					generate.OutFromUTXO(t, depositedBondedUTXO3, ids.Empty, bondTxID2),
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			backend := newExecutorBackend(t, caminoGenesisConf, tt.phase, nil)
+
+			tx, err := txs.NewSigned(tt.tx, txs.Codec, tt.signers)
+			require.NoError(t, err)
+
+			txExecutor := CaminoStandardTxExecutor{
+				StandardTxExecutor{
+					State:   tt.state(t, ctrl, backend.Config, tt.phase, tt.tx, tx.ID()),
+					Backend: backend,
+					Tx:      tx,
+				},
+			}
+			err = tx.Unsigned.Visit(&txExecutor)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -8377,7 +8377,7 @@ func TestCaminoStandardTxExecutorUnlockExpiredDepositTx(t *testing.T) {
 		InterestRateNominator: deposit.InterestRateDenominator,
 	}
 	depositOffer3 := &deposit.Offer{
-		ID:                    ids.ID{2},
+		ID:                    ids.ID{3},
 		InterestRateNominator: deposit.InterestRateDenominator,
 	}
 	deposit1 := &deposit.Deposit{
@@ -8393,7 +8393,7 @@ func TestCaminoStandardTxExecutorUnlockExpiredDepositTx(t *testing.T) {
 		RewardOwner:         &rewardOwner1,
 	}
 	deposit3 := &deposit.Deposit{
-		DepositOfferID:      depositOffer2.ID,
+		DepositOfferID:      depositOffer3.ID,
 		Duration:            100,
 		ClaimedRewardAmount: 31,
 		Amount:              13, // depositedUTXO3
@@ -8612,7 +8612,6 @@ func TestCaminoStandardTxExecutorUnlockExpiredDepositTx(t *testing.T) {
 				s.EXPECT().GetClaimable(claimableOwnerID2).Return(nil, database.ErrNotFound)
 				s.EXPECT().SetClaimable(claimableOwnerID2, &state.Claimable{
 					Owner:                &rewardOwner2,
-					ValidatorReward:      0,
 					ExpiredDepositReward: deposit3.TotalReward(depositOffer3) - deposit3.ClaimedRewardAmount,
 				})
 

--- a/vms/platformvm/txs/executor/camino_visitor.go
+++ b/vms/platformvm/txs/executor/camino_visitor.go
@@ -57,6 +57,10 @@ func (*StandardTxExecutor) FinishProposalsTx(*txs.FinishProposalsTx) error {
 	return errWrongTxType
 }
 
+func (*StandardTxExecutor) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
+	return errWrongTxType
+}
+
 // Proposal
 
 func (*ProposalTxExecutor) AddressStateTx(*txs.AddressStateTx) error {
@@ -104,6 +108,10 @@ func (*ProposalTxExecutor) AddVoteTx(*txs.AddVoteTx) error {
 }
 
 func (*ProposalTxExecutor) FinishProposalsTx(*txs.FinishProposalsTx) error {
+	return errWrongTxType
+}
+
+func (*ProposalTxExecutor) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
 	return errWrongTxType
 }
 
@@ -157,6 +165,10 @@ func (*AtomicTxExecutor) FinishProposalsTx(*txs.FinishProposalsTx) error {
 	return errWrongTxType
 }
 
+func (*AtomicTxExecutor) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
+	return errWrongTxType
+}
+
 // MemPool
 
 func (v *MempoolTxVerifier) AddressStateTx(tx *txs.AddressStateTx) error {
@@ -204,5 +216,9 @@ func (v *MempoolTxVerifier) AddVoteTx(tx *txs.AddVoteTx) error {
 }
 
 func (*MempoolTxVerifier) FinishProposalsTx(*txs.FinishProposalsTx) error {
+	return errWrongTxType
+}
+
+func (*MempoolTxVerifier) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
 	return errWrongTxType
 }

--- a/vms/platformvm/txs/mempool/camino_visitor.go
+++ b/vms/platformvm/txs/mempool/camino_visitor.go
@@ -72,6 +72,10 @@ func (*issuer) FinishProposalsTx(*txs.FinishProposalsTx) error {
 	return errUnsupportedTxType
 }
 
+func (*issuer) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
+	return errUnsupportedTxType
+}
+
 // Remover
 
 func (r *remover) AddressStateTx(*txs.AddressStateTx) error {
@@ -130,6 +134,11 @@ func (r *remover) AddVoteTx(*txs.AddVoteTx) error {
 }
 
 func (*remover) FinishProposalsTx(*txs.FinishProposalsTx) error {
+	// this tx is never in mempool
+	return nil
+}
+
+func (*remover) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
 	// this tx is never in mempool
 	return nil
 }

--- a/wallet/chain/p/camino_visitor.go
+++ b/wallet/chain/p/camino_visitor.go
@@ -58,6 +58,10 @@ func (*backendVisitor) FinishProposalsTx(*txs.FinishProposalsTx) error {
 	return errUnsupportedTxType
 }
 
+func (*backendVisitor) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
+	return errUnsupportedTxType
+}
+
 // signer
 
 func (s *signerVisitor) AddressStateTx(tx *txs.AddressStateTx) error {
@@ -145,5 +149,9 @@ func (s *signerVisitor) AddVoteTx(tx *txs.AddVoteTx) error {
 }
 
 func (*signerVisitor) FinishProposalsTx(*txs.FinishProposalsTx) error {
+	return errUnsupportedTxType
+}
+
+func (*signerVisitor) UnlockExpiredDepositTx(*txs.UnlockExpiredDepositTx) error {
 	return errUnsupportedTxType
 }


### PR DESCRIPTION
PR adds new `UnlockExpiredDepositTx`. This is system tx and will only be created by node, when deposit expires and needs to be unlocked.
Previously, this was done by `UnlockDepositTx`, which was also responsible for unlocking active deposits and could also be issued by user. 
After Cairo Phase node will create `UnlockExpiredDepositTx` for unlocking expired deposits instead of `UnlockDepositTx`.