### PR TITLE
[PVM] Add missing tx builder tests for system txs

### DIFF
--- a/vms/platformvm/test/expect/camino_expect.go
+++ b/vms/platformvm/test/expect/camino_expect.go
@@ -344,18 +344,17 @@ func StateGetBondTxIDs(
 	for i, proposalID := range tx.SuccessfulProposalIDs() {
 		dacProposal := proposals[i]
 		s.EXPECT().GetProposal(proposalID).Return(dacProposal, nil)
-		switch proposal := dacProposal.(type) {
-		case *dac.ExcludeMemberProposalState:
-			if accepted, _, _ := proposal.Result(); !accepted {
+		if excludeMemberProposalState, ok := dacProposal.(*dac.ExcludeMemberProposalState); ok {
+			if accepted, _, _ := excludeMemberProposalState.Result(); !accepted {
 				continue
 			}
 			if nodeIDs[j] == ids.EmptyNodeID {
-				s.EXPECT().GetShortIDLink(proposal.MemberAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortEmpty, database.ErrNotFound)
+				s.EXPECT().GetShortIDLink(excludeMemberProposalState.MemberAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortEmpty, database.ErrNotFound)
 				j++
 				continue
 			}
 
-			s.EXPECT().GetShortIDLink(proposal.MemberAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortID(nodeIDs[j]), nil)
+			s.EXPECT().GetShortIDLink(excludeMemberProposalState.MemberAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortID(nodeIDs[j]), nil)
 
 			if validatorTxIDs[j] == ids.Empty {
 				s.EXPECT().GetPendingValidator(constants.PrimaryNetworkID, nodeIDs[j]).Return(nil, database.ErrNotFound)

--- a/vms/platformvm/test/expect/camino_expect.go
+++ b/vms/platformvm/test/expect/camino_expect.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
 	"github.com/ava-labs/avalanchego/vms/components/multisig"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
+	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
 	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -327,4 +329,42 @@ func Lock(t *testing.T, s *state.MockState, utxosMap map[ids.ShortID][]*avax.UTX
 func PhaseTime(t *testing.T, s *state.MockDiff, cfg *config.Config, phase test.Phase) {
 	t.Helper()
 	s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+}
+
+func StateGetBondTxIDs(
+	t *testing.T,
+	s *state.MockState,
+	tx *txs.FinishProposalsTx,
+	proposals []dac.ProposalState,
+	nodeIDs []ids.NodeID,
+	validatorTxIDs []ids.ID,
+) {
+	t.Helper()
+	j := 0
+	for i, proposalID := range tx.SuccessfulProposalIDs() {
+		dacProposal := proposals[i]
+		s.EXPECT().GetProposal(proposalID).Return(dacProposal, nil)
+		switch proposal := dacProposal.(type) {
+		case *dac.ExcludeMemberProposalState:
+			if accepted, _, _ := proposal.Result(); !accepted {
+				continue
+			}
+			if nodeIDs[j] == ids.EmptyNodeID {
+				s.EXPECT().GetShortIDLink(proposal.MemberAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortEmpty, database.ErrNotFound)
+				j++
+				continue
+			}
+
+			s.EXPECT().GetShortIDLink(proposal.MemberAddress, state.ShortLinkKeyRegisterNode).Return(ids.ShortID(nodeIDs[j]), nil)
+
+			if validatorTxIDs[j] == ids.Empty {
+				s.EXPECT().GetPendingValidator(constants.PrimaryNetworkID, nodeIDs[j]).Return(nil, database.ErrNotFound)
+			} else {
+				s.EXPECT().GetPendingValidator(constants.PrimaryNetworkID, nodeIDs[j]).Return(&state.Staker{
+					TxID: validatorTxIDs[j],
+				}, nil)
+			}
+			j++
+		}
+	}
 }

--- a/vms/platformvm/txs/builder/camino_builder.go
+++ b/vms/platformvm/txs/builder/camino_builder.go
@@ -110,13 +110,9 @@ type CaminoTxBuilder interface {
 
 	NewRewardsImportTx() (*txs.Tx, error)
 
-	NewSystemUnlockDepositTx(
-		depositTxIDs []ids.ID,
-	) (*txs.Tx, error)
+	NewSystemUnlockDepositTx(depositTxIDs []ids.ID) (*txs.Tx, error)
 
-	NewUnlockExpiredDepositTx(
-		depositTxIDs []ids.ID,
-	) (*txs.Tx, error)
+	NewUnlockExpiredDepositTx(depositTxIDs []ids.ID) (*txs.Tx, error)
 
 	NewFinishProposalsTx(
 		state state.Chain,
@@ -707,7 +703,6 @@ func (b *caminoBuilder) NewRewardsImportTx() (*txs.Tx, error) {
 	return tx, tx.SyntacticVerify(b.ctx)
 }
 
-// TODO@ test
 func (b *caminoBuilder) NewSystemUnlockDepositTx(
 	depositTxIDs []ids.ID,
 ) (*txs.Tx, error) {

--- a/vms/platformvm/txs/camino_unlock_expired_deposit_tx.go
+++ b/vms/platformvm/txs/camino_unlock_expired_deposit_tx.go
@@ -21,7 +21,7 @@ type UnlockExpiredDepositTx struct {
 	unsignedBytes []byte // Unsigned byte representation of this data
 }
 
-func (*UnlockExpiredDepositTx) SyntacticVerify(_ *snow.Context) error {
+func (*UnlockExpiredDepositTx) SyntacticVerify(*snow.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
Adds missing `TestNewFinishProposalsTx` and `TestNewSystemUnlockDepositTx` tx builder tests.
Those txs tests are required, because those are system txs and their build must always succeed and be correct.