### PR TITLE
[PVM] CairoPhase unlock active deposit with fix

### DIFF
--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -848,7 +848,7 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 	for _, input := range tx.Ins {
 		lockedIn, ok := input.In.(*locked.In)
 		// bonded & not deposited inputs excluded in syntactic verification
-		if ok && lockedIn.DepositTxID != ids.Empty {
+		if ok {
 			deposit, err := e.State.GetDeposit(lockedIn.DepositTxID)
 			if err != nil {
 				return err

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -106,6 +106,7 @@ var (
 	errNotPermittedToCreateProposal      = errors.New("don't have permission to create proposal of this type")
 	errZeroDepositOfferLimits            = errors.New("deposit offer TotalMaxAmount and TotalMaxRewardAmount are zero")
 	errAddrStateNotChanged               = errors.New("address state wasn't changed")
+	errDepositExpired                    = errors.New("deposit is expired")
 	errNotDepositedInput                 = errors.New("input is not deposited")
 	errNotCairoPhase                     = errors.New("not allowed before CairoPhase")
 	errDepositNotExpired                 = errors.New("deposit is not expired")
@@ -814,6 +815,113 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 		return err
 	}
 
+	chainTime := e.State.GetTimestamp()
+
+	if !e.Config.IsCairoPhaseActivated(chainTime) {
+		// Before Cairo, unlockDepositTx was used both:
+		// as system tx for expired deposits and as user tx for active deposits.
+		// After CairoPhase system unlock of expired deposits is done by UnlockExpiredDepositTx.
+		return e.unlockDepositTxBeforeCairo(tx)
+	}
+
+	baseFee, err := e.State.GetBaseFee()
+	if err != nil {
+		return err
+	}
+
+	if err := e.FlowChecker.VerifyUnlockDeposit(
+		e.State,
+		tx,
+		tx.Ins,
+		tx.Outs,
+		e.Tx.Creds,
+		baseFee,
+		e.Ctx.AVAXAssetID,
+	); err != nil {
+		return fmt.Errorf("%w: %s", errFlowCheckFailed, err)
+	}
+
+	chainTimestamp := uint64(chainTime.Unix())
+	consumedDepositedAmounts := make(map[ids.ID]uint64)
+	producedDepositedAmounts := make(map[ids.ID]uint64)
+
+	for _, input := range tx.Ins {
+		lockedIn, ok := input.In.(*locked.In)
+		// bonded & not deposited inputs excluded in syntactic verification
+		if ok && lockedIn.DepositTxID != ids.Empty {
+			deposit, err := e.State.GetDeposit(lockedIn.DepositTxID)
+			if err != nil {
+				return err
+			}
+
+			if deposit.IsExpired(chainTimestamp) {
+				return errDepositExpired // should never happen
+			}
+
+			consumedDepositedAmounts[lockedIn.DepositTxID], err = math.Add64(consumedDepositedAmounts[lockedIn.DepositTxID], lockedIn.Amount())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(consumedDepositedAmounts) == 0 {
+		return errNoUnlock
+	}
+
+	for _, output := range tx.Outs {
+		if lockedOut, ok := output.Out.(*locked.Out); ok && lockedOut.DepositTxID != ids.Empty {
+			producedDepositedAmounts[lockedOut.DepositTxID], err = math.Add64(producedDepositedAmounts[lockedOut.DepositTxID], lockedOut.Amount())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for depositTxID, consumedDepositedAmount := range consumedDepositedAmounts {
+		deposit, err := e.State.GetDeposit(depositTxID)
+		if err != nil {
+			return err
+		}
+
+		unlockedAmount := consumedDepositedAmount - producedDepositedAmounts[depositTxID]
+		newTotalUnlockedAmount, err := math.Add64(unlockedAmount, deposit.UnlockedAmount)
+		if err != nil {
+			return err
+		}
+
+		if newTotalUnlockedAmount == deposit.UnlockedAmount {
+			return errNoUnlock
+		}
+
+		offer, err := e.State.GetDepositOffer(deposit.DepositOfferID)
+		if err != nil {
+			return err
+		}
+
+		if unlockableAmount := deposit.UnlockableAmount(offer, chainTimestamp); unlockableAmount < newTotalUnlockedAmount {
+			return errUnlockedMoreThanAvailable
+		}
+
+		e.State.ModifyDeposit(depositTxID, &deposits.Deposit{
+			DepositOfferID:      deposit.DepositOfferID,
+			UnlockedAmount:      newTotalUnlockedAmount,
+			ClaimedRewardAmount: deposit.ClaimedRewardAmount,
+			Amount:              deposit.Amount,
+			Start:               deposit.Start,
+			Duration:            deposit.Duration,
+			RewardOwner:         deposit.RewardOwner,
+		})
+	}
+
+	avax.Consume(e.State, tx.Ins)
+	avax.Produce(e.State, e.Tx.ID(), tx.Outs)
+
+	return nil
+}
+
+func (e *CaminoStandardTxExecutor) unlockDepositTxBeforeCairo(tx *txs.UnlockDepositTx) error {
+	var err error
 	chainTimestamp := uint64(e.State.GetTimestamp().Unix())
 	consumedDepositedAmounts := make(map[ids.ID]uint64)
 	producedDepositedAmounts := make(map[ids.ID]uint64)
@@ -884,7 +992,7 @@ func (e *CaminoStandardTxExecutor) UnlockDepositTx(tx *txs.UnlockDepositTx) erro
 		amountToBurn = baseFee
 	}
 
-	if err := e.FlowChecker.VerifyUnlockDeposit(
+	if err := e.FlowChecker.VerifyUnlockDepositBeforeCairo(
 		e.State,
 		tx,
 		tx.Ins,

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -3817,7 +3817,8 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 			phase:       test.PhaseBerlin,
 			expectedErr: errNoUnlock,
 		},
-		"Before Cairo/OK: no deposited input": { // we have such txs in network already
+		// we have such txs in network already
+		"Before Cairo/OK: no deposited input": {
 			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				// checks
@@ -4039,7 +4040,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 					DepositOfferID: offer.ID,
 				}
 				depositHalfUnlockTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
-				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime).Times(2)
+				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{feeUTXO, deposit1UTXO},
@@ -4139,7 +4140,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 					[]*avax.UTXO{feeUTXO, deposit1UTXO},
 					[]ids.ShortID{
 						feeOwnerAddr, owner1Addr, // consumed
-						feeOwnerAddr, owner1Addr, // produced unlocked
+						owner1Addr, // produced unlocked
 					}, nil)
 				s.EXPECT().GetDeposit(depositTxID1).Return(&deposit.Deposit{}, nil) // expired deposit
 				return s
@@ -4147,7 +4148,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 			utx: func(p test.Phase, c *config.Config) *txs.UnlockDepositTx {
 				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
 					Ins:  generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
-					Outs: generate.OutsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}, ids.Empty, ids.Empty),
+					Outs: generate.OutsFromUTXOs(t, []*avax.UTXO{deposit1UTXO}, ids.Empty, ids.Empty),
 				}}}
 			},
 			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}, {owner1Key}},

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
-	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -2400,7 +2400,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 	offerOwnerKey, offerOwnerAddr := test.Keys[3], test.Keys[3].Address()
 	depositCreatorKey, depositCreatorAddr := test.Keys[4], test.Keys[4].Address()
 
-	offer := &deposit.Offer{
+	offer := &deposits.Offer{
 		ID:          ids.ID{0, 0, 1},
 		End:         100,
 		MinAmount:   2,
@@ -2408,7 +2408,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		MaxDuration: 20,
 	}
 
-	offerWithMaxAmount := &deposit.Offer{
+	offerWithMaxAmount := &deposits.Offer{
 		ID:              ids.ID{0, 0, 2},
 		End:             100,
 		MinAmount:       2,
@@ -2418,7 +2418,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		DepositedAmount: 100,
 	}
 
-	offerWithMaxRewardAmount := &deposit.Offer{
+	offerWithMaxRewardAmount := &deposits.Offer{
 		ID:                    ids.ID{0, 0, 3},
 		End:                   100,
 		MinAmount:             2,
@@ -2429,7 +2429,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		RewardedAmount:        1000000,
 	}
 
-	offerWithOwner := &deposit.Offer{
+	offerWithOwner := &deposits.Offer{
 		ID:           ids.ID{0, 0, 4},
 		End:          100,
 		MinAmount:    2,
@@ -2552,7 +2552,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			state: func(t *testing.T, c *gomock.Controller, utx *txs.DepositTx, txID ids.ID, cfg *config.Config, phaseIndex int) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetDepositOffer(utx.DepositOfferID).Return(&deposit.Offer{Flags: deposit.OfferFlagLocked}, nil)
+				s.EXPECT().GetDepositOffer(utx.DepositOfferID).Return(&deposits.Offer{Flags: deposits.OfferFlagLocked}, nil)
 				s.EXPECT().GetTimestamp().Return(offer.StartTime())
 				return s
 			},
@@ -3043,7 +3043,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3089,7 +3089,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3138,7 +3138,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						newUTXOOwnerAddr, utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3188,7 +3188,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3237,7 +3237,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3288,7 +3288,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						newUTXOOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3337,7 +3337,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3391,7 +3391,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 							utxoOwnerAddr, // produced
 						}, nil)
 
-					deposit1 := &deposit.Deposit{
+					deposit1 := &deposits.Deposit{
 						DepositOfferID: utx.DepositOfferID,
 						Duration:       utx.DepositDuration,
 						Amount:         utx.DepositAmount(),
@@ -3449,7 +3449,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 							utxoOwnerAddr, // produced
 						}, nil)
 
-					deposit1 := &deposit.Deposit{
+					deposit1 := &deposits.Deposit{
 						DepositOfferID: utx.DepositOfferID,
 						Duration:       utx.DepositDuration,
 						Amount:         utx.DepositAmount(),
@@ -3549,74 +3549,68 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 	owner1Key, owner1Addr, owner1 := generate.KeyAndOwner(t, test.Keys[1])
 	owner1ID, err := txs.GetOwnerID(owner1)
 	require.NoError(t, err)
-	depositTxID1 := ids.ID{0, 0, 1}
-	depositWithRewardTxID1 := ids.ID{0, 0, 2}
-	depositTxID2 := ids.ID{0, 0, 3}
+	depositTxID1 := ids.ID{1}
+	depositWithRewardTxID1 := ids.ID{2}
+	depositTxID2 := ids.ID{3}
 
-	depositOffer := &deposit.Offer{
-		ID:                   ids.ID{0, 1},
+	offer := &deposits.Offer{
+		ID:                   ids.ID{4},
 		MinAmount:            1,
 		MinDuration:          60,
 		MaxDuration:          80,
 		UnlockPeriodDuration: 50,
 	}
-	depositOfferWithReward := &deposit.Offer{
-		ID:                    ids.ID{0, 2},
+	depositOfferWithReward := &deposits.Offer{
+		ID:                    ids.ID{5},
 		MinAmount:             1,
 		MinDuration:           60,
 		MaxDuration:           60,
 		UnlockPeriodDuration:  50,
 		InterestRateNominator: 365 * 24 * 60 * 60 * 1_000_000 / 10, // 10%
 	}
-	deposit1 := &deposit.Deposit{
-		Duration:       depositOffer.MinDuration,
-		Amount:         10000,
-		DepositOfferID: depositOffer.ID,
-	}
-	deposit1WithReward := &deposit.Deposit{
-		Duration:       depositOfferWithReward.MinDuration,
-		Amount:         10000,
-		DepositOfferID: depositOfferWithReward.ID,
-		RewardOwner:    &owner1,
-	}
-	deposit2 := &deposit.Deposit{
-		Duration:       depositOffer.MaxDuration,
-		Amount:         20000,
-		DepositOfferID: depositOffer.ID,
-	}
+	depositAmount1 := uint64(10000)
+	depositAmount2 := uint64(20000)
 
-	deposit1HalfUnlockTime := deposit1.StartUnlockTime(depositOffer).Add(depositOffer.UnlockPeriodDurationNano() / 2)
-	deposit1HalfUnlockableAmount := deposit1.UnlockableAmount(depositOffer, uint64(deposit1HalfUnlockTime.Unix()))
-	deposit2HalfUnlockableAmount := deposit2.UnlockableAmount(depositOffer, uint64(deposit1HalfUnlockTime.Unix()))
-
-	feeUTXO := generate.UTXO(ids.ID{1}, test.AVAXAssetID, test.TxFee, feeOwner, ids.Empty, ids.Empty, true)
-	lessFeeUTXO := generate.UTXO(ids.ID{2}, test.AVAXAssetID, 1, feeOwner, ids.Empty, ids.Empty, true)
-	deposit1UTXO := generate.UTXO(ids.ID{3}, test.AVAXAssetID, deposit1.Amount, owner1, depositTxID1, ids.Empty, true)
-	deposit2UTXO := generate.UTXO(ids.ID{4}, test.AVAXAssetID, deposit2.Amount, owner1, depositTxID2, ids.Empty, true)
-	deposit1WithRewardUTXO := generate.UTXO(ids.ID{5}, test.AVAXAssetID, deposit1WithReward.Amount, owner1, depositWithRewardTxID1, ids.Empty, true)
-	deposit1UTXOLargerTxID := generate.UTXO(ids.ID{6}, test.AVAXAssetID, deposit1.Amount, owner1, depositTxID1, ids.Empty, true)
-	unlockedUTXOWithLargerTxID := generate.UTXO(ids.ID{7}, test.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty, true)
+	feeUTXO := generate.UTXO(ids.ID{6}, test.AVAXAssetID, test.TxFee, feeOwner, ids.Empty, ids.Empty, true)
+	moreFeeUTXO := generate.UTXO(ids.ID{7}, test.AVAXAssetID, test.TxFee*10, feeOwner, ids.Empty, ids.Empty, true)
+	lessFeeUTXO := generate.UTXO(ids.ID{8}, test.AVAXAssetID, 1, feeOwner, ids.Empty, ids.Empty, true)
+	deposit1UTXO := generate.UTXO(ids.ID{9}, test.AVAXAssetID, depositAmount1, owner1, depositTxID1, ids.Empty, true)
+	deposit2UTXO := generate.UTXO(ids.ID{10}, test.AVAXAssetID, depositAmount2, owner1, depositTxID2, ids.Empty, true)
+	deposit1WithRewardUTXO := generate.UTXO(ids.ID{11}, test.AVAXAssetID, depositAmount1, owner1, depositWithRewardTxID1, ids.Empty, true)
+	deposit1UTXOLargerTxID := generate.UTXO(ids.ID{12}, test.AVAXAssetID, depositAmount1, owner1, depositTxID1, ids.Empty, true)
+	unlockedUTXOWithLargerTxID := generate.UTXO(ids.ID{13}, test.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty, true)
 
 	tests := map[string]struct {
-		state       func(*testing.T, *gomock.Controller, *txs.UnlockDepositTx, ids.ID) *state.MockDiff
-		utx         *txs.UnlockDepositTx
+		state       func(*testing.T, *gomock.Controller, test.Phase, *config.Config, *txs.UnlockDepositTx, ids.ID) *state.MockDiff
+		utx         func(test.Phase, *config.Config) *txs.UnlockDepositTx
 		signers     [][]*secp256k1.PrivateKey
+		phase       test.Phase
 		expectedErr error
 	}{
-		"Wrong lockModeBondDeposit flag": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Wrong lockModeBondDeposit flag": {
+			state: func(_ *testing.T, c *gomock.Controller, _ test.Phase, _ *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: false}, nil)
 				return s
 			},
-			utx:         &txs.UnlockDepositTx{},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{}
+			},
+			phase:       test.PhaseBerlin,
 			expectedErr: errWrongLockMode,
 		},
-		"Unlock before deposit's unlock period": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Unlock before deposit's unlock period": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1.StartUnlockTime(depositOffer).Add(-time.Second))
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				s.EXPECT().GetTimestamp().Return(deposit.StartUnlockTime(offer).Add(-time.Second)).Times(2)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{feeUTXO, deposit1UTXO},
@@ -3624,90 +3618,124 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
-				s.EXPECT().GetDepositOffer(deposit1.DepositOfferID).Return(depositOffer, nil)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
-				Outs: []*avax.TransferableOutput{
-					generate.Out(test.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
-					generate.Out(test.AVAXAssetID, deposit1.Amount-1, owner1, depositTxID1, ids.Empty),
-				},
-			}}},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
+						generate.Out(test.AVAXAssetID, depositAmount1-1, owner1, depositTxID1, ids.Empty),
+					},
+				}}}
+			},
 			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}, {owner1Key}},
+			phase:       test.PhaseBerlin,
 			expectedErr: errUnlockedMoreThanAvailable,
 		},
-		"Unlock expired deposit, tx has unlocked input before deposited input": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Unlock expired deposit, tx has unlocked input before deposited input": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1.EndTime())
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
+				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
-			}}},
-			signers:     [][]*secp256k1.PrivateKey{},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
+				}}}
+			},
+			phase:       test.PhaseBerlin,
 			expectedErr: errMixedDeposits,
 		},
-		"Unlock expired deposit, tx has unlocked input after deposited input": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Unlock expired deposit, tx has unlocked input after deposited input": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1.EndTime())
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
+				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit1UTXO, unlockedUTXOWithLargerTxID}),
-			}}},
-			signers:     [][]*secp256k1.PrivateKey{},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit1UTXO, unlockedUTXOWithLargerTxID}),
+				}}}
+			},
+			phase:       test.PhaseBerlin,
 			expectedErr: errMixedDeposits,
 		},
-		"Unlock active and expired deposits": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Unlock active and expired deposits": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1.EndTime())
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit1 := &deposits.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
+				deposit2 := &deposits.Deposit{Duration: offer.MaxDuration, Start: uint64(phaseTime.Unix())}
+				s.EXPECT().GetTimestamp().Return(deposit1.EndTime()).Times(2)
 				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil)
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit2UTXO, deposit1UTXOLargerTxID}),
-			}}},
-			signers:     [][]*secp256k1.PrivateKey{},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit2UTXO, deposit1UTXOLargerTxID}),
+				}}}
+			},
+			phase:       test.PhaseBerlin,
 			expectedErr: errMixedDeposits,
 		},
-		"Unlock not full amount, deposit expired": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Unlock not full amount, deposit expired": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1.EndTime())
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{deposit1UTXO},
 					[]ids.ShortID{
 						owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit1UTXO}),
-				Outs: []*avax.TransferableOutput{
-					generate.Out(test.AVAXAssetID, deposit1.Amount-1, owner1, ids.Empty, ids.Empty),
-					generate.Out(test.AVAXAssetID, 1, owner1, depositTxID1, ids.Empty),
-				},
-			}}},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit1UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, depositAmount1-1, owner1, ids.Empty, ids.Empty),
+						generate.Out(test.AVAXAssetID, 1, owner1, depositTxID1, ids.Empty),
+					},
+				}}}
+			},
+			phase:       test.PhaseBerlin,
 			expectedErr: errExpiredDepositNotFullyUnlocked,
 		},
-		"Unlock more, than available": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Unlock more, than available": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1HalfUnlockTime)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				depositHalfUnlockTime := deposit.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime).Times(2)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{feeUTXO, deposit1UTXO},
@@ -3715,41 +3743,57 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
-				s.EXPECT().GetDepositOffer(deposit1.DepositOfferID).Return(depositOffer, nil)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
-				Outs: []*avax.TransferableOutput{
-					generate.Out(test.AVAXAssetID, deposit1HalfUnlockableAmount+1, owner1, ids.Empty, ids.Empty),
-					generate.Out(test.AVAXAssetID, deposit1.Amount-deposit1HalfUnlockableAmount-1, owner1, depositTxID1, ids.Empty),
-				},
-			}}},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, depositAmount1/2+1, owner1, ids.Empty, ids.Empty),
+						generate.Out(test.AVAXAssetID, depositAmount1/2-1, owner1, depositTxID1, ids.Empty),
+					},
+				}}}
+			},
 			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}, {owner1Key}},
+			phase:       test.PhaseBerlin,
 			expectedErr: errUnlockedMoreThanAvailable,
 		},
-		"Burned tokens, while unlocking expired deposits": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Burned tokens, while unlocking expired deposits": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1.EndTime())
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
+				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit1UTXO}),
-				Outs: []*avax.TransferableOutput{
-					generate.Out(test.AVAXAssetID, deposit1.Amount-1, owner1, ids.Empty, ids.Empty),
-				},
-			}}},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit1UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, depositAmount1-1, owner1, ids.Empty, ids.Empty),
+					},
+				}}}
+			},
+			phase:       test.PhaseBerlin,
 			expectedErr: errBurnedDepositUnlock,
 		},
-		"Only burn fee, nothing unlocked": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/Only burn fee, nothing unlocked": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1HalfUnlockTime)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				depositHalfUnlockTime := deposit.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime).Times(2)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{feeUTXO, lessFeeUTXO, deposit1UTXO},
@@ -3757,57 +3801,114 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						feeOwnerAddr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, lessFeeUTXO, deposit1UTXO}),
-				Outs: []*avax.TransferableOutput{
-					generate.Out(test.AVAXAssetID, lessFeeUTXO.Out.(avax.Amounter).Amount(), feeOwner, ids.Empty, ids.Empty),
-					generate.Out(test.AVAXAssetID, deposit1UTXO.Out.(avax.Amounter).Amount(), owner1, depositTxID1, ids.Empty),
-				},
-			}}},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, lessFeeUTXO, deposit1UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, lessFeeUTXO.Out.(avax.Amounter).Amount(), feeOwner, ids.Empty, ids.Empty),
+						generate.OutFromUTXO(t, deposit1UTXO, depositTxID1, ids.Empty),
+					},
+				}}}
+			},
 			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}, {feeOwnerKey}, {owner1Key}},
+			phase:       test.PhaseBerlin,
 			expectedErr: errNoUnlock,
 		},
-		"OK: unlock full amount, expired deposit with unclaimed reward": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/OK: no deposited input": { // we have such txs in network already
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				// checks
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1.EndTime())
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg)).Times(2)
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
-					[]*avax.UTXO{deposit1WithRewardUTXO},
+					[]*avax.UTXO{moreFeeUTXO},
 					[]ids.ShortID{
-						owner1Addr, // produced unlocked
+						feeOwnerAddr, // consumed unlocked
+						feeOwnerAddr, // produced unlocked
 					}, nil)
-				// state update: deposit1
-				s.EXPECT().GetDeposit(depositWithRewardTxID1).Return(deposit1WithReward, nil).Times(2)
-				s.EXPECT().GetDepositOffer(deposit1WithReward.DepositOfferID).Return(depositOfferWithReward, nil)
-				s.EXPECT().GetClaimable(owner1ID).Return(&state.Claimable{Owner: &owner1}, nil)
-				s.EXPECT().SetClaimable(owner1ID, &state.Claimable{
-					Owner:                &owner1,
-					ExpiredDepositReward: deposit1WithReward.RemainingReward(depositOfferWithReward),
-				})
-				s.EXPECT().RemoveDeposit(depositWithRewardTxID1, deposit1WithReward)
 				// state update: ins/outs/utxos
 				expect.ConsumeUTXOs(t, s, utx.Ins)
 				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit1WithRewardUTXO}),
-				Outs: []*avax.TransferableOutput{
-					generate.Out(test.AVAXAssetID, deposit1WithReward.Amount, owner1, ids.Empty, ids.Empty),
-				},
-			}}},
+			utx: func(p test.Phase, c *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{moreFeeUTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, moreFeeUTXO.Out.(avax.Amounter).Amount()-test.TxFee, feeOwner, ids.Empty, ids.Empty),
+					},
+				}}}
+			},
+			signers: [][]*secp256k1.PrivateKey{{feeOwnerKey}},
+			phase:   test.PhaseBerlin,
 		},
-		"OK: unlock available amount, deposit is still unlocking": {
-			state: func(t *testing.T, c *gomock.Controller, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+		"Before Cairo/OK: unlock full amount, expired deposit with unclaimed reward": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				// checks
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetTimestamp().Return(deposit1HalfUnlockTime)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{
+					Duration:       depositOfferWithReward.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: depositOfferWithReward.ID,
+					RewardOwner:    &owner1,
+				}
+				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
+				expect.VerifyUnlockDeposit(t, s, utx.Ins,
+					[]*avax.UTXO{deposit1WithRewardUTXO},
+					[]ids.ShortID{
+						owner1Addr, // produced unlocked
+					}, nil)
+				// state update: deposit
+				s.EXPECT().GetDeposit(depositWithRewardTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDepositOffer(depositOfferWithReward.ID).Return(depositOfferWithReward, nil)
+				s.EXPECT().GetClaimable(owner1ID).Return(&state.Claimable{Owner: &owner1}, nil)
+				s.EXPECT().SetClaimable(owner1ID, &state.Claimable{
+					Owner:                &owner1,
+					ExpiredDepositReward: deposit.RemainingReward(depositOfferWithReward),
+				})
+				s.EXPECT().RemoveDeposit(depositWithRewardTxID1, deposit)
+				// state update: ins/outs/utxos
+				expect.ConsumeUTXOs(t, s, utx.Ins)
+				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
+				return s
+			},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{deposit1WithRewardUTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, depositAmount1, owner1, ids.Empty, ids.Empty),
+					},
+				}}}
+			},
+			phase: test.PhaseBerlin,
+		},
+		"Before Cairo/OK: unlock available amount, deposit is still unlocking": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				// checks
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit1 := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				deposit2 := &deposits.Deposit{
+					Duration:       offer.MaxDuration,
+					Start:          deposit1.Start,
+					Amount:         depositAmount2,
+					DepositOfferID: offer.ID,
+				}
+				chainTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				s.EXPECT().GetTimestamp().Return(chainTime).Times(2)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{feeUTXO, deposit1UTXO, deposit2UTXO},
@@ -3817,10 +3918,10 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 					}, nil)
 				// state update: deposit1
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
-				s.EXPECT().GetDepositOffer(deposit1.DepositOfferID).Return(depositOffer, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
+				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
-					UnlockedAmount:      deposit1.UnlockedAmount + deposit1HalfUnlockableAmount,
+					UnlockedAmount:      deposit1.UnlockedAmount + depositAmount1/2,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount,
 					Start:               deposit1.Start,
 					Duration:            deposit1.Duration,
@@ -3829,10 +3930,10 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				})
 				// state update: deposit2
 				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil).Times(2)
-				s.EXPECT().GetDepositOffer(deposit2.DepositOfferID).Return(depositOffer, nil)
-				s.EXPECT().ModifyDeposit(depositTxID2, &deposit.Deposit{
+				s.EXPECT().GetDepositOffer(deposit2.DepositOfferID).Return(offer, nil)
+				s.EXPECT().ModifyDeposit(depositTxID2, &deposits.Deposit{
 					DepositOfferID:      deposit2.DepositOfferID,
-					UnlockedAmount:      deposit2.UnlockedAmount + deposit2HalfUnlockableAmount,
+					UnlockedAmount:      deposit2.UnlockedAmount + deposit2.UnlockableAmount(offer, uint64(chainTime.Unix())),
 					ClaimedRewardAmount: deposit2.ClaimedRewardAmount,
 					Start:               deposit2.Start,
 					Duration:            deposit2.Duration,
@@ -3844,31 +3945,322 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
 				return s
 			},
-			utx: &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
-				Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO, deposit2UTXO}),
-				Outs: []*avax.TransferableOutput{
-					generate.Out(test.AVAXAssetID, deposit1HalfUnlockableAmount+deposit2HalfUnlockableAmount, owner1, ids.Empty, ids.Empty),
-					generate.Out(test.AVAXAssetID, deposit1.Amount-deposit1HalfUnlockableAmount, owner1, depositTxID1, ids.Empty),
-					generate.Out(test.AVAXAssetID, deposit2.Amount-deposit2HalfUnlockableAmount, owner1, depositTxID2, ids.Empty),
-				},
-			}}},
+			utx: func(phase test.Phase, cfg *config.Config) *txs.UnlockDepositTx {
+				phaseTime := test.PhaseTime(t, phase, cfg)
+
+				// state deposits
+				deposit1 := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				deposit2 := &deposits.Deposit{
+					Duration:       offer.MaxDuration,
+					Start:          deposit1.Start,
+					Amount:         depositAmount2,
+					DepositOfferID: offer.ID,
+				}
+
+				// deposit1 halfUnlockTime1, see tt.state
+				chainTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+
+				unlockedDepositAmount1 := depositAmount1 / 2 // unlocking at half of deposit1 unlock period
+				unlockedDepositAmount2 := deposit2.UnlockableAmount(offer, uint64(chainTime.Unix()))
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO, deposit2UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, unlockedDepositAmount1+unlockedDepositAmount2, owner1, ids.Empty, ids.Empty),
+						generate.Out(test.AVAXAssetID, depositAmount1-unlockedDepositAmount1, owner1, depositTxID1, ids.Empty),
+						generate.Out(test.AVAXAssetID, depositAmount2-unlockedDepositAmount2, owner1, depositTxID2, ids.Empty),
+					},
+				}}}
+			},
 			signers: [][]*secp256k1.PrivateKey{{feeOwnerKey}, {owner1Key}, {owner1Key}},
+			phase:   test.PhaseBerlin,
+		},
+		"After Cairo/Wrong lockModeBondDeposit flag": {
+			state: func(_ *testing.T, c *gomock.Controller, _ test.Phase, _ *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: false}, nil)
+				return s
+			},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{}
+			},
+			phase:       test.PhaseLast,
+			expectedErr: errWrongLockMode,
+		},
+		"After Cairo/Unlock before deposit's unlock period": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				s.EXPECT().GetTimestamp().Return(deposit.StartUnlockTime(offer).Add(-time.Second))
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
+				expect.VerifyUnlockDeposit(t, s, utx.Ins,
+					[]*avax.UTXO{feeUTXO, deposit1UTXO},
+					[]ids.ShortID{
+						feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
+						owner1Addr, // produced unlocked
+					}, nil)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
+				return s
+			},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty),
+						generate.Out(test.AVAXAssetID, depositAmount1-1, owner1, depositTxID1, ids.Empty),
+					},
+				}}}
+			},
+			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}, {owner1Key}},
+			phase:       test.PhaseLast,
+			expectedErr: errUnlockedMoreThanAvailable,
+		},
+		"After Cairo/Unlock more, than available": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				depositHalfUnlockTime := deposit.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime).Times(2)
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
+				expect.VerifyUnlockDeposit(t, s, utx.Ins,
+					[]*avax.UTXO{feeUTXO, deposit1UTXO},
+					[]ids.ShortID{
+						feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
+						owner1Addr, // produced unlocked
+					}, nil)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
+				return s
+			},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, depositAmount1/2+1, owner1, ids.Empty, ids.Empty),
+						generate.Out(test.AVAXAssetID, depositAmount1/2-1, owner1, depositTxID1, ids.Empty),
+					},
+				}}}
+			},
+			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}, {owner1Key}},
+			phase:       test.PhaseLast,
+			expectedErr: errUnlockedMoreThanAvailable,
+		},
+		"After Cairo/Only burn fee, nothing unlocked": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				depositHalfUnlockTime := deposit.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime)
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
+				expect.VerifyUnlockDeposit(t, s, utx.Ins,
+					[]*avax.UTXO{feeUTXO, lessFeeUTXO, deposit1UTXO},
+					[]ids.ShortID{
+						feeOwnerAddr, feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
+						feeOwnerAddr, // produced unlocked
+					}, nil)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				return s
+			},
+			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, lessFeeUTXO, deposit1UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, lessFeeUTXO.Out.(avax.Amounter).Amount(), feeOwner, ids.Empty, ids.Empty),
+						generate.OutFromUTXO(t, deposit1UTXO, depositTxID1, ids.Empty),
+					},
+				}}}
+			},
+			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}, {feeOwnerKey}, {owner1Key}},
+			phase:       test.PhaseLast,
+			expectedErr: errNoUnlock,
+		},
+		"After Cairo/No deposited input": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				// checks
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, phase, cfg))
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
+				expect.VerifyUnlockDeposit(t, s, utx.Ins,
+					[]*avax.UTXO{moreFeeUTXO},
+					[]ids.ShortID{
+						feeOwnerAddr, // consumed unlocked
+						feeOwnerAddr, // produced unlocked
+					}, nil)
+				return s
+			},
+			utx: func(p test.Phase, c *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{moreFeeUTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, moreFeeUTXO.Out.(avax.Amounter).Amount()-test.TxFee, feeOwner, ids.Empty, ids.Empty),
+					},
+				}}}
+			},
+			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}},
+			phase:       test.PhaseLast,
+			expectedErr: errNoUnlock,
+		},
+		"After Cairo/Expired deposit": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				// checks
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				s.EXPECT().GetTimestamp().Return(phaseTime)
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
+				expect.VerifyUnlockDeposit(t, s, utx.Ins,
+					[]*avax.UTXO{feeUTXO, deposit1UTXO},
+					[]ids.ShortID{
+						feeOwnerAddr, owner1Addr, // consumed
+						feeOwnerAddr, owner1Addr, // produced unlocked
+					}, nil)
+				s.EXPECT().GetDeposit(depositTxID1).Return(&deposits.Deposit{}, nil) // expired deposit
+				return s
+			},
+			utx: func(p test.Phase, c *config.Config) *txs.UnlockDepositTx {
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins:  generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}),
+					Outs: generate.OutsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO}, ids.Empty, ids.Empty),
+				}}}
+			},
+			signers:     [][]*secp256k1.PrivateKey{{feeOwnerKey}, {owner1Key}},
+			phase:       test.PhaseLast,
+			expectedErr: errDepositExpired,
+		},
+		"After Cairo/OK: unlock available amount": {
+			state: func(t *testing.T, c *gomock.Controller, phase test.Phase, cfg *config.Config, utx *txs.UnlockDepositTx, txID ids.ID) *state.MockDiff {
+				s := state.NewMockDiff(c)
+				// checks
+				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
+				phaseTime := test.PhaseTime(t, phase, cfg)
+				deposit1 := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				deposit2 := &deposits.Deposit{
+					Duration:       offer.MaxDuration,
+					Start:          deposit1.Start,
+					Amount:         depositAmount2,
+					DepositOfferID: offer.ID,
+				}
+				chainTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				s.EXPECT().GetTimestamp().Return(chainTime)
+				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
+				expect.VerifyUnlockDeposit(t, s, utx.Ins,
+					[]*avax.UTXO{feeUTXO, deposit1UTXO, deposit2UTXO},
+					[]ids.ShortID{
+						feeOwnerAddr, owner1Addr, owner1Addr, // consumed (not expired deposit)
+						owner1Addr, // produced unlocked
+					}, nil)
+				// state update: deposit1
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
+				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
+					DepositOfferID:      deposit1.DepositOfferID,
+					UnlockedAmount:      deposit1.UnlockedAmount + depositAmount1/2,
+					ClaimedRewardAmount: deposit1.ClaimedRewardAmount,
+					Start:               deposit1.Start,
+					Duration:            deposit1.Duration,
+					Amount:              deposit1.Amount,
+					RewardOwner:         deposit2.RewardOwner,
+				})
+				// state update: deposit2
+				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil).Times(2)
+				s.EXPECT().GetDepositOffer(deposit2.DepositOfferID).Return(offer, nil)
+				s.EXPECT().ModifyDeposit(depositTxID2, &deposits.Deposit{
+					DepositOfferID:      deposit2.DepositOfferID,
+					UnlockedAmount:      deposit2.UnlockedAmount + deposit2.UnlockableAmount(offer, uint64(chainTime.Unix())),
+					ClaimedRewardAmount: deposit2.ClaimedRewardAmount,
+					Start:               deposit2.Start,
+					Duration:            deposit2.Duration,
+					Amount:              deposit2.Amount,
+					RewardOwner:         deposit2.RewardOwner,
+				})
+				// state update: ins/outs/utxos
+				expect.ConsumeUTXOs(t, s, utx.Ins)
+				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
+				return s
+			},
+			utx: func(phase test.Phase, cfg *config.Config) *txs.UnlockDepositTx {
+				phaseTime := test.PhaseTime(t, phase, cfg)
+
+				// state deposits
+				deposit1 := &deposits.Deposit{
+					Duration:       offer.MinDuration,
+					Start:          uint64(phaseTime.Unix()),
+					Amount:         depositAmount1,
+					DepositOfferID: offer.ID,
+				}
+				deposit2 := &deposits.Deposit{
+					Duration:       offer.MaxDuration,
+					Start:          deposit1.Start,
+					Amount:         depositAmount2,
+					DepositOfferID: offer.ID,
+				}
+
+				// deposit1 halfUnlockTime1, see tt.state
+				chainTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+
+				unlockedDepositAmount1 := depositAmount1 / 2 // unlocking at half of deposit1 unlock period
+				unlockedDepositAmount2 := deposit2.UnlockableAmount(offer, uint64(chainTime.Unix()))
+				return &txs.UnlockDepositTx{BaseTx: txs.BaseTx{BaseTx: avax.BaseTx{
+					Ins: generate.InsFromUTXOs(t, []*avax.UTXO{feeUTXO, deposit1UTXO, deposit2UTXO}),
+					Outs: []*avax.TransferableOutput{
+						generate.Out(test.AVAXAssetID, unlockedDepositAmount1+unlockedDepositAmount2, owner1, ids.Empty, ids.Empty),
+						generate.Out(test.AVAXAssetID, depositAmount1-unlockedDepositAmount1, owner1, depositTxID1, ids.Empty),
+						generate.Out(test.AVAXAssetID, depositAmount2-unlockedDepositAmount2, owner1, depositTxID2, ids.Empty),
+					},
+				}}}
+			},
+			signers: [][]*secp256k1.PrivateKey{{feeOwnerKey}, {owner1Key}, {owner1Key}},
+			phase:   test.PhaseLast,
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			backend := newExecutorBackend(t, caminoGenesisConf, test.PhaseLast, nil)
+			backend := newExecutorBackend(t, caminoGenesisConf, tt.phase, nil)
 
-			tt.utx.BlockchainID = backend.Ctx.ChainID
-			tt.utx.NetworkID = backend.Ctx.NetworkID
-			tx, err := txs.NewSigned(tt.utx, txs.Codec, tt.signers)
+			cfg := test.Config(t, tt.phase)
+			utx := tt.utx(tt.phase, cfg)
+			utx.BlockchainID = backend.Ctx.ChainID
+			utx.NetworkID = backend.Ctx.NetworkID
+			tx, err := txs.NewSigned(utx, txs.Codec, tt.signers)
 			require.NoError(err)
 
 			err = tx.Unsigned.Visit(&CaminoStandardTxExecutor{
 				StandardTxExecutor{
 					Backend: backend,
-					State:   tt.state(t, gomock.NewController(t), tt.utx, tx.ID()),
+					State:   tt.state(t, gomock.NewController(t), tt.phase, cfg, utx, tx.ID()),
 					Tx:      tx,
 				},
 			})
@@ -3975,7 +4367,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 				s.EXPECT().GetTimestamp().Return(timestamp)
 				// deposit
 				s.EXPECT().GetDeposit(depositTxID1).
-					Return(&deposit.Deposit{RewardOwner: &depositRewardOwner}, nil)
+					Return(&deposits.Deposit{RewardOwner: &depositRewardOwner}, nil)
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
 				return s
 			},
@@ -4117,7 +4509,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 				s.EXPECT().GetTimestamp().Return(timestamp)
 
 				// deposit1
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4126,7 +4518,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
 				return s
@@ -4160,7 +4552,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 
 				// deposit1
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4168,10 +4560,10 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:    &depositRewardOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount + utx.Claimables[0].Amount,
@@ -4183,7 +4575,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 
 				// deposit2
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				deposit2 := &deposit.Deposit{
+				deposit2 := &deposits.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4191,10 +4583,10 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:    &depositRewardOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID2, &deposit.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID2, &deposits.Deposit{
 					DepositOfferID:      deposit2.DepositOfferID,
 					UnlockedAmount:      deposit2.UnlockedAmount,
 					ClaimedRewardAmount: deposit2.ClaimedRewardAmount + utx.Claimables[1].Amount,
@@ -4414,7 +4806,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 
 				// deposit
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID:      depositOfferID,
 					Start:               uint64(timestamp.Unix()) - 365*24*60*60/12*6, // 6 month
 					Duration:            365 * 24 * 60 * 60 / 12 * 14,                 // 14 month
@@ -4423,11 +4815,11 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:         &depositRewardOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
 					NoRewardsPeriodDuration: 365 * 24 * 60 * 60 / 12 * 2, // 2 month
 					InterestRateNominator:   1_000_000,                   // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount + utx.Claimables[0].Amount,
@@ -4472,7 +4864,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 
 				// deposit1
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4480,10 +4872,10 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:    &depositRewardOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount + utx.Claimables[1].Amount,
@@ -4646,7 +5038,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					depositRewardMsigAliasOwner.Addrs[0],
 					depositRewardMsigAliasOwner.Addrs[1],
 				}, []*multisig.AliasWithNonce{depositRewardMsigAlias})
-				deposit1 := &deposit.Deposit{
+				deposit1 := &deposits.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4654,10 +5046,10 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:    depositRewardMsigOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount + utx.Claimables[0].Amount,
@@ -6111,23 +6503,23 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 
 	feeUTXO := generate.UTXO(ids.GenerateTestID(), test.AVAXAssetID, test.TxFee, feeOwner, ids.Empty, ids.Empty, true)
 
-	offer1 := &deposit.Offer{
+	offer1 := &deposits.Offer{
 		UpgradeVersionID:      codec.UpgradeVersion1,
 		Start:                 0,
 		End:                   1,
 		MinDuration:           1,
 		MaxDuration:           1,
-		MinAmount:             deposit.OfferMinDepositAmount,
+		MinAmount:             deposits.OfferMinDepositAmount,
 		InterestRateNominator: 1,
 		TotalMaxRewardAmount:  100,
 	}
-	offerZeroLimits := &deposit.Offer{
+	offerZeroLimits := &deposits.Offer{
 		UpgradeVersionID: codec.UpgradeVersion1,
 		Start:            0,
 		End:              1,
 		MinDuration:      1,
 		MaxDuration:      1,
-		MinAmount:        deposit.OfferMinDepositAmount,
+		MinAmount:        deposits.OfferMinDepositAmount,
 	}
 
 	baseTx := txs.BaseTx{BaseTx: avax.BaseTx{
@@ -6261,7 +6653,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 		"Supply overflow (v1, existing offers)": {
 			state: func(t *testing.T, c *gomock.Controller, utx *txs.AddDepositOfferTx, txID ids.ID, cfg *config.Config) *state.MockDiff {
 				chainTime := test.PhaseTime(t, test.PhaseLast, cfg)
-				existingOffers := []*deposit.Offer{
+				existingOffers := []*deposits.Offer{
 					{ // [0], expired
 						UpgradeVersionID:     1,
 						Start:                uint64(chainTime.Add(-2 * time.Second).Unix()),
@@ -6274,7 +6666,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 						End:                   uint64(chainTime.Add(2 * time.Second).Unix()),
 						MaxDuration:           100,
 						TotalMaxAmount:        102,
-						InterestRateNominator: deposit.InterestRateDenominator / 2,
+						InterestRateNominator: deposits.InterestRateDenominator / 2,
 					},
 					{ // [2], not started yet with TotalMaxRewardAmount
 						UpgradeVersionID:     1,
@@ -6286,7 +6678,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 						UpgradeVersionID:     1,
 						Start:                uint64(chainTime.Unix()),
 						End:                  uint64(chainTime.Add(1 * time.Second).Unix()),
-						Flags:                deposit.OfferFlagLocked,
+						Flags:                deposits.OfferFlagLocked,
 						TotalMaxRewardAmount: 104,
 					},
 					{ // [4] active // shouldn't be possible, cause offers must always have one of the limits
@@ -8369,30 +8761,30 @@ func TestCaminoStandardTxExecutorUnlockExpiredDepositTx(t *testing.T) {
 		ExpiredDepositReward: 4,
 	}
 
-	depositOffer1 := &deposit.Offer{
+	depositOffer1 := &deposits.Offer{
 		ID: ids.ID{1},
 	}
-	depositOffer2 := &deposit.Offer{
+	depositOffer2 := &deposits.Offer{
 		ID:                    ids.ID{2},
-		InterestRateNominator: deposit.InterestRateDenominator,
+		InterestRateNominator: deposits.InterestRateDenominator,
 	}
-	depositOffer3 := &deposit.Offer{
+	depositOffer3 := &deposits.Offer{
 		ID:                    ids.ID{3},
-		InterestRateNominator: deposit.InterestRateDenominator,
+		InterestRateNominator: deposits.InterestRateDenominator,
 	}
-	deposit1 := &deposit.Deposit{
+	deposit1 := &deposits.Deposit{
 		DepositOfferID: depositOffer1.ID,
 		Duration:       1,
 		Amount:         7 + 17 + 19, // depositedUTXO1 + depositedBondedUTXO1 + depositedBondedUTXO2
 	}
-	deposit2 := &deposit.Deposit{
+	deposit2 := &deposits.Deposit{
 		DepositOfferID:      depositOffer2.ID,
 		Duration:            100,
 		ClaimedRewardAmount: 29,
 		Amount:              11 + 23, // depositedUTXO2 + depositedBondedUTXO3
 		RewardOwner:         &rewardOwner1,
 	}
-	deposit3 := &deposit.Deposit{
+	deposit3 := &deposits.Deposit{
 		DepositOfferID:      depositOffer3.ID,
 		Duration:            100,
 		ClaimedRewardAmount: 31,
@@ -8460,7 +8852,7 @@ func TestCaminoStandardTxExecutorUnlockExpiredDepositTx(t *testing.T) {
 				s := state.NewMockDiff(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				s.EXPECT().GetTimestamp().Return(chainTime)
-				s.EXPECT().GetDeposit(depositTxID1).Return(&deposit.Deposit{
+				s.EXPECT().GetDeposit(depositTxID1).Return(&deposits.Deposit{
 					Start: uint64(chainTime.Unix()), Duration: 1,
 				}, nil)
 				return s

--- a/vms/platformvm/txs/executor/camino_tx_executor_test.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
 	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
-	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
+	"github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
 	"github.com/ava-labs/avalanchego/vms/platformvm/reward"
 	"github.com/ava-labs/avalanchego/vms/platformvm/state"
@@ -2400,7 +2400,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 	offerOwnerKey, offerOwnerAddr := test.Keys[3], test.Keys[3].Address()
 	depositCreatorKey, depositCreatorAddr := test.Keys[4], test.Keys[4].Address()
 
-	offer := &deposits.Offer{
+	offer := &deposit.Offer{
 		ID:          ids.ID{0, 0, 1},
 		End:         100,
 		MinAmount:   2,
@@ -2408,7 +2408,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		MaxDuration: 20,
 	}
 
-	offerWithMaxAmount := &deposits.Offer{
+	offerWithMaxAmount := &deposit.Offer{
 		ID:              ids.ID{0, 0, 2},
 		End:             100,
 		MinAmount:       2,
@@ -2418,7 +2418,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		DepositedAmount: 100,
 	}
 
-	offerWithMaxRewardAmount := &deposits.Offer{
+	offerWithMaxRewardAmount := &deposit.Offer{
 		ID:                    ids.ID{0, 0, 3},
 		End:                   100,
 		MinAmount:             2,
@@ -2429,7 +2429,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 		RewardedAmount:        1000000,
 	}
 
-	offerWithOwner := &deposits.Offer{
+	offerWithOwner := &deposit.Offer{
 		ID:           ids.ID{0, 0, 4},
 		End:          100,
 		MinAmount:    2,
@@ -2552,7 +2552,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 			state: func(t *testing.T, c *gomock.Controller, utx *txs.DepositTx, txID ids.ID, cfg *config.Config, phaseIndex int) *state.MockDiff {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
-				s.EXPECT().GetDepositOffer(utx.DepositOfferID).Return(&deposits.Offer{Flags: deposits.OfferFlagLocked}, nil)
+				s.EXPECT().GetDepositOffer(utx.DepositOfferID).Return(&deposit.Offer{Flags: deposit.OfferFlagLocked}, nil)
 				s.EXPECT().GetTimestamp().Return(offer.StartTime())
 				return s
 			},
@@ -3043,7 +3043,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3089,7 +3089,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3138,7 +3138,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						newUTXOOwnerAddr, utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3188,7 +3188,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3237,7 +3237,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3288,7 +3288,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						newUTXOOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3337,7 +3337,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 						utxoOwnerAddr, // produced
 					}, nil)
 
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: utx.DepositOfferID,
 					Duration:       utx.DepositDuration,
 					Amount:         utx.DepositAmount(),
@@ -3391,7 +3391,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 							utxoOwnerAddr, // produced
 						}, nil)
 
-					deposit1 := &deposits.Deposit{
+					deposit1 := &deposit.Deposit{
 						DepositOfferID: utx.DepositOfferID,
 						Duration:       utx.DepositDuration,
 						Amount:         utx.DepositAmount(),
@@ -3449,7 +3449,7 @@ func TestCaminoStandardTxExecutorDepositTx(t *testing.T) {
 							utxoOwnerAddr, // produced
 						}, nil)
 
-					deposit1 := &deposits.Deposit{
+					deposit1 := &deposit.Deposit{
 						DepositOfferID: utx.DepositOfferID,
 						Duration:       utx.DepositDuration,
 						Amount:         utx.DepositAmount(),
@@ -3553,14 +3553,14 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 	depositWithRewardTxID1 := ids.ID{2}
 	depositTxID2 := ids.ID{3}
 
-	offer := &deposits.Offer{
+	offer := &deposit.Offer{
 		ID:                   ids.ID{4},
 		MinAmount:            1,
 		MinDuration:          60,
 		MaxDuration:          80,
 		UnlockPeriodDuration: 50,
 	}
-	depositOfferWithReward := &deposits.Offer{
+	depositOfferWithReward := &deposit.Offer{
 		ID:                    ids.ID{5},
 		MinAmount:             1,
 		MinDuration:           60,
@@ -3604,13 +3604,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				s.EXPECT().GetTimestamp().Return(deposit.StartUnlockTime(offer).Add(-time.Second)).Times(2)
+				s.EXPECT().GetTimestamp().Return(deposit1.StartUnlockTime(offer).Add(-time.Second)).Times(2)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{feeUTXO, deposit1UTXO},
@@ -3618,7 +3618,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
 				return s
 			},
@@ -3640,9 +3640,9 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
-				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil)
+				deposit1 := &deposit.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
+				s.EXPECT().GetTimestamp().Return(deposit1.EndTime()).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
 				return s
 			},
 			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
@@ -3658,9 +3658,9 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
-				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil)
+				deposit1 := &deposit.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
+				s.EXPECT().GetTimestamp().Return(deposit1.EndTime()).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
 				return s
 			},
 			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
@@ -3676,8 +3676,8 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit1 := &deposits.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
-				deposit2 := &deposits.Deposit{Duration: offer.MaxDuration, Start: uint64(phaseTime.Unix())}
+				deposit1 := &deposit.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
+				deposit2 := &deposit.Deposit{Duration: offer.MaxDuration, Start: uint64(phaseTime.Unix())}
 				s.EXPECT().GetTimestamp().Return(deposit1.EndTime()).Times(2)
 				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil)
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
@@ -3696,19 +3696,19 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
+				s.EXPECT().GetTimestamp().Return(deposit1.EndTime()).Times(2)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{deposit1UTXO},
 					[]ids.ShortID{
 						owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				return s
 			},
 			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
@@ -3728,13 +3728,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				depositHalfUnlockTime := deposit.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				depositHalfUnlockTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
 				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime).Times(2)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
@@ -3743,7 +3743,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
 				return s
 			},
@@ -3765,9 +3765,9 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
-				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil)
+				deposit1 := &deposit.Deposit{Duration: offer.MinDuration, Start: uint64(phaseTime.Unix())}
+				s.EXPECT().GetTimestamp().Return(deposit1.EndTime()).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
 				return s
 			},
 			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
@@ -3786,13 +3786,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				depositHalfUnlockTime := deposit.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				depositHalfUnlockTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
 				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime).Times(2)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
@@ -3801,7 +3801,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						feeOwnerAddr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				return s
 			},
 			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
@@ -3852,28 +3852,28 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				// checks
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       depositOfferWithReward.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: depositOfferWithReward.ID,
 					RewardOwner:    &owner1,
 				}
-				s.EXPECT().GetTimestamp().Return(deposit.EndTime()).Times(2)
+				s.EXPECT().GetTimestamp().Return(deposit1.EndTime()).Times(2)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{deposit1WithRewardUTXO},
 					[]ids.ShortID{
 						owner1Addr, // produced unlocked
 					}, nil)
 				// state update: deposit
-				s.EXPECT().GetDeposit(depositWithRewardTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDeposit(depositWithRewardTxID1).Return(deposit1, nil).Times(2)
 				s.EXPECT().GetDepositOffer(depositOfferWithReward.ID).Return(depositOfferWithReward, nil)
 				s.EXPECT().GetClaimable(owner1ID).Return(&state.Claimable{Owner: &owner1}, nil)
 				s.EXPECT().SetClaimable(owner1ID, &state.Claimable{
 					Owner:                &owner1,
-					ExpiredDepositReward: deposit.RemainingReward(depositOfferWithReward),
+					ExpiredDepositReward: deposit1.RemainingReward(depositOfferWithReward),
 				})
-				s.EXPECT().RemoveDeposit(depositWithRewardTxID1, deposit)
+				s.EXPECT().RemoveDeposit(depositWithRewardTxID1, deposit1)
 				// state update: ins/outs/utxos
 				expect.ConsumeUTXOs(t, s, utx.Ins)
 				expect.ProduceUTXOs(t, s, utx.Outs, txID, 0)
@@ -3895,13 +3895,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				// checks
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				deposit2 := &deposits.Deposit{
+				deposit2 := &deposit.Deposit{
 					Duration:       offer.MaxDuration,
 					Start:          deposit1.Start,
 					Amount:         depositAmount2,
@@ -3919,7 +3919,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				// state update: deposit1
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount + depositAmount1/2,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount,
@@ -3931,7 +3931,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				// state update: deposit2
 				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil).Times(2)
 				s.EXPECT().GetDepositOffer(deposit2.DepositOfferID).Return(offer, nil)
-				s.EXPECT().ModifyDeposit(depositTxID2, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID2, &deposit.Deposit{
 					DepositOfferID:      deposit2.DepositOfferID,
 					UnlockedAmount:      deposit2.UnlockedAmount + deposit2.UnlockableAmount(offer, uint64(chainTime.Unix())),
 					ClaimedRewardAmount: deposit2.ClaimedRewardAmount,
@@ -3949,13 +3949,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				phaseTime := test.PhaseTime(t, phase, cfg)
 
 				// state deposits
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				deposit2 := &deposits.Deposit{
+				deposit2 := &deposit.Deposit{
 					Duration:       offer.MaxDuration,
 					Start:          deposit1.Start,
 					Amount:         depositAmount2,
@@ -3996,13 +3996,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				s.EXPECT().GetTimestamp().Return(deposit.StartUnlockTime(offer).Add(-time.Second))
+				s.EXPECT().GetTimestamp().Return(deposit1.StartUnlockTime(offer).Add(-time.Second))
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
 					[]*avax.UTXO{feeUTXO, deposit1UTXO},
@@ -4010,7 +4010,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
 				return s
 			},
@@ -4032,13 +4032,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				depositHalfUnlockTime := deposit.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				depositHalfUnlockTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
 				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime).Times(2)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
@@ -4047,7 +4047,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
 				return s
 			},
@@ -4069,13 +4069,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				s := state.NewMockDiff(c)
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				depositHalfUnlockTime := deposit.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
+				depositHalfUnlockTime := deposit1.StartUnlockTime(offer).Add(offer.UnlockPeriodDurationNano() / 2)
 				s.EXPECT().GetTimestamp().Return(depositHalfUnlockTime)
 				s.EXPECT().GetBaseFee().Return(test.TxFee, nil)
 				expect.VerifyUnlockDeposit(t, s, utx.Ins,
@@ -4084,7 +4084,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, feeOwnerAddr, owner1Addr, // consumed (not expired deposit)
 						feeOwnerAddr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(deposit, nil).Times(2)
+				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				return s
 			},
 			utx: func(test.Phase, *config.Config) *txs.UnlockDepositTx {
@@ -4141,7 +4141,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 						feeOwnerAddr, owner1Addr, // consumed
 						feeOwnerAddr, owner1Addr, // produced unlocked
 					}, nil)
-				s.EXPECT().GetDeposit(depositTxID1).Return(&deposits.Deposit{}, nil) // expired deposit
+				s.EXPECT().GetDeposit(depositTxID1).Return(&deposit.Deposit{}, nil) // expired deposit
 				return s
 			},
 			utx: func(p test.Phase, c *config.Config) *txs.UnlockDepositTx {
@@ -4160,13 +4160,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				// checks
 				s.EXPECT().CaminoConfig().Return(&state.CaminoConfig{LockModeBondDeposit: true}, nil)
 				phaseTime := test.PhaseTime(t, phase, cfg)
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				deposit2 := &deposits.Deposit{
+				deposit2 := &deposit.Deposit{
 					Duration:       offer.MaxDuration,
 					Start:          deposit1.Start,
 					Amount:         depositAmount2,
@@ -4184,7 +4184,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				// state update: deposit1
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil).Times(2)
 				s.EXPECT().GetDepositOffer(offer.ID).Return(offer, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount + depositAmount1/2,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount,
@@ -4196,7 +4196,7 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				// state update: deposit2
 				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil).Times(2)
 				s.EXPECT().GetDepositOffer(deposit2.DepositOfferID).Return(offer, nil)
-				s.EXPECT().ModifyDeposit(depositTxID2, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID2, &deposit.Deposit{
 					DepositOfferID:      deposit2.DepositOfferID,
 					UnlockedAmount:      deposit2.UnlockedAmount + deposit2.UnlockableAmount(offer, uint64(chainTime.Unix())),
 					ClaimedRewardAmount: deposit2.ClaimedRewardAmount,
@@ -4214,13 +4214,13 @@ func TestCaminoStandardTxExecutorUnlockDepositTx(t *testing.T) {
 				phaseTime := test.PhaseTime(t, phase, cfg)
 
 				// state deposits
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					Duration:       offer.MinDuration,
 					Start:          uint64(phaseTime.Unix()),
 					Amount:         depositAmount1,
 					DepositOfferID: offer.ID,
 				}
-				deposit2 := &deposits.Deposit{
+				deposit2 := &deposit.Deposit{
 					Duration:       offer.MaxDuration,
 					Start:          deposit1.Start,
 					Amount:         depositAmount2,
@@ -4367,7 +4367,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 				s.EXPECT().GetTimestamp().Return(timestamp)
 				// deposit
 				s.EXPECT().GetDeposit(depositTxID1).
-					Return(&deposits.Deposit{RewardOwner: &depositRewardOwner}, nil)
+					Return(&deposit.Deposit{RewardOwner: &depositRewardOwner}, nil)
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
 				return s
 			},
@@ -4509,7 +4509,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 				s.EXPECT().GetTimestamp().Return(timestamp)
 
 				// deposit1
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4518,7 +4518,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
 				return s
@@ -4552,7 +4552,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 
 				// deposit1
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4560,10 +4560,10 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:    &depositRewardOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount + utx.Claimables[0].Amount,
@@ -4575,7 +4575,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 
 				// deposit2
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				deposit2 := &deposits.Deposit{
+				deposit2 := &deposit.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4583,10 +4583,10 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:    &depositRewardOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID2).Return(deposit2, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID2, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID2, &deposit.Deposit{
 					DepositOfferID:      deposit2.DepositOfferID,
 					UnlockedAmount:      deposit2.UnlockedAmount,
 					ClaimedRewardAmount: deposit2.ClaimedRewardAmount + utx.Claimables[1].Amount,
@@ -4806,7 +4806,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 
 				// deposit
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID:      depositOfferID,
 					Start:               uint64(timestamp.Unix()) - 365*24*60*60/12*6, // 6 month
 					Duration:            365 * 24 * 60 * 60 / 12 * 14,                 // 14 month
@@ -4815,11 +4815,11 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:         &depositRewardOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
 					NoRewardsPeriodDuration: 365 * 24 * 60 * 60 / 12 * 2, // 2 month
 					InterestRateNominator:   1_000_000,                   // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount + utx.Claimables[0].Amount,
@@ -4864,7 +4864,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 
 				// deposit1
 				expect.VerifyMultisigPermission(t, s, depositRewardOwner.Addrs, nil)
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -4872,10 +4872,10 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:    &depositRewardOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount + utx.Claimables[1].Amount,
@@ -5038,7 +5038,7 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					depositRewardMsigAliasOwner.Addrs[0],
 					depositRewardMsigAliasOwner.Addrs[1],
 				}, []*multisig.AliasWithNonce{depositRewardMsigAlias})
-				deposit1 := &deposits.Deposit{
+				deposit1 := &deposit.Deposit{
 					DepositOfferID: depositOfferID,
 					Start:          uint64(timestamp.Unix()) - 365*24*60*60/2, // 0.5 year ago
 					Duration:       365 * 24 * 60 * 60,                        // 1 year
@@ -5046,10 +5046,10 @@ func TestCaminoStandardTxExecutorClaimTx(t *testing.T) {
 					RewardOwner:    depositRewardMsigOwner,
 				}
 				s.EXPECT().GetDeposit(depositTxID1).Return(deposit1, nil)
-				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposits.Offer{
+				s.EXPECT().GetDepositOffer(depositOfferID).Return(&deposit.Offer{
 					InterestRateNominator: 1_000_000, // 100%
 				}, nil)
-				s.EXPECT().ModifyDeposit(depositTxID1, &deposits.Deposit{
+				s.EXPECT().ModifyDeposit(depositTxID1, &deposit.Deposit{
 					DepositOfferID:      deposit1.DepositOfferID,
 					UnlockedAmount:      deposit1.UnlockedAmount,
 					ClaimedRewardAmount: deposit1.ClaimedRewardAmount + utx.Claimables[0].Amount,
@@ -6503,23 +6503,23 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 
 	feeUTXO := generate.UTXO(ids.GenerateTestID(), test.AVAXAssetID, test.TxFee, feeOwner, ids.Empty, ids.Empty, true)
 
-	offer1 := &deposits.Offer{
+	offer1 := &deposit.Offer{
 		UpgradeVersionID:      codec.UpgradeVersion1,
 		Start:                 0,
 		End:                   1,
 		MinDuration:           1,
 		MaxDuration:           1,
-		MinAmount:             deposits.OfferMinDepositAmount,
+		MinAmount:             deposit.OfferMinDepositAmount,
 		InterestRateNominator: 1,
 		TotalMaxRewardAmount:  100,
 	}
-	offerZeroLimits := &deposits.Offer{
+	offerZeroLimits := &deposit.Offer{
 		UpgradeVersionID: codec.UpgradeVersion1,
 		Start:            0,
 		End:              1,
 		MinDuration:      1,
 		MaxDuration:      1,
-		MinAmount:        deposits.OfferMinDepositAmount,
+		MinAmount:        deposit.OfferMinDepositAmount,
 	}
 
 	baseTx := txs.BaseTx{BaseTx: avax.BaseTx{
@@ -6653,7 +6653,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 		"Supply overflow (v1, existing offers)": {
 			state: func(t *testing.T, c *gomock.Controller, utx *txs.AddDepositOfferTx, txID ids.ID, cfg *config.Config) *state.MockDiff {
 				chainTime := test.PhaseTime(t, test.PhaseLast, cfg)
-				existingOffers := []*deposits.Offer{
+				existingOffers := []*deposit.Offer{
 					{ // [0], expired
 						UpgradeVersionID:     1,
 						Start:                uint64(chainTime.Add(-2 * time.Second).Unix()),
@@ -6666,7 +6666,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 						End:                   uint64(chainTime.Add(2 * time.Second).Unix()),
 						MaxDuration:           100,
 						TotalMaxAmount:        102,
-						InterestRateNominator: deposits.InterestRateDenominator / 2,
+						InterestRateNominator: deposit.InterestRateDenominator / 2,
 					},
 					{ // [2], not started yet with TotalMaxRewardAmount
 						UpgradeVersionID:     1,
@@ -6678,7 +6678,7 @@ func TestCaminoStandardTxExecutorAddDepositOfferTx(t *testing.T) {
 						UpgradeVersionID:     1,
 						Start:                uint64(chainTime.Unix()),
 						End:                  uint64(chainTime.Add(1 * time.Second).Unix()),
-						Flags:                deposits.OfferFlagLocked,
+						Flags:                deposit.OfferFlagLocked,
 						TotalMaxRewardAmount: 104,
 					},
 					{ // [4] active // shouldn't be possible, cause offers must always have one of the limits
@@ -8761,30 +8761,30 @@ func TestCaminoStandardTxExecutorUnlockExpiredDepositTx(t *testing.T) {
 		ExpiredDepositReward: 4,
 	}
 
-	depositOffer1 := &deposits.Offer{
+	depositOffer1 := &deposit.Offer{
 		ID: ids.ID{1},
 	}
-	depositOffer2 := &deposits.Offer{
+	depositOffer2 := &deposit.Offer{
 		ID:                    ids.ID{2},
-		InterestRateNominator: deposits.InterestRateDenominator,
+		InterestRateNominator: deposit.InterestRateDenominator,
 	}
-	depositOffer3 := &deposits.Offer{
+	depositOffer3 := &deposit.Offer{
 		ID:                    ids.ID{3},
-		InterestRateNominator: deposits.InterestRateDenominator,
+		InterestRateNominator: deposit.InterestRateDenominator,
 	}
-	deposit1 := &deposits.Deposit{
+	deposit1 := &deposit.Deposit{
 		DepositOfferID: depositOffer1.ID,
 		Duration:       1,
 		Amount:         7 + 17 + 19, // depositedUTXO1 + depositedBondedUTXO1 + depositedBondedUTXO2
 	}
-	deposit2 := &deposits.Deposit{
+	deposit2 := &deposit.Deposit{
 		DepositOfferID:      depositOffer2.ID,
 		Duration:            100,
 		ClaimedRewardAmount: 29,
 		Amount:              11 + 23, // depositedUTXO2 + depositedBondedUTXO3
 		RewardOwner:         &rewardOwner1,
 	}
-	deposit3 := &deposits.Deposit{
+	deposit3 := &deposit.Deposit{
 		DepositOfferID:      depositOffer3.ID,
 		Duration:            100,
 		ClaimedRewardAmount: 31,
@@ -8852,7 +8852,7 @@ func TestCaminoStandardTxExecutorUnlockExpiredDepositTx(t *testing.T) {
 				s := state.NewMockDiff(ctrl)
 				s.EXPECT().CaminoConfig().Return(caminoConfig, nil)
 				s.EXPECT().GetTimestamp().Return(chainTime)
-				s.EXPECT().GetDeposit(depositTxID1).Return(&deposits.Deposit{
+				s.EXPECT().GetDeposit(depositTxID1).Return(&deposit.Deposit{
 					Start: uint64(chainTime.Unix()), Duration: 1,
 				}, nil)
 				return s

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -1388,7 +1388,7 @@ func TestUnlockDeposit(t *testing.T) {
 	}
 }
 
-func TestVerifyUnlockDepositedUTXOs(t *testing.T) {
+func TestVerifyUnlockDepositedUTXOsBeforeCairo(t *testing.T) {
 	tx := &dummyUnsignedTx{txs.BaseTx{}}
 	tx.SetBytes([]byte{0})
 	owner1, cred1 := generateOwnersAndSig(t, test.Keys[0], tx)
@@ -1727,7 +1727,7 @@ func TestVerifyUnlockDepositedUTXOs(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			err := defaultCaminoHandler(t).VerifyUnlockDepositedUTXOs(
+			err := defaultCaminoHandler(t).verifyUnlockDepositedUTXOsBeforeCairo(
 				tt.handlerState(ctrl),
 				tt.args.tx,
 				tt.args.utxos,
@@ -1737,6 +1737,332 @@ func TestVerifyUnlockDepositedUTXOs(t *testing.T) {
 				tt.args.burnedAmount,
 				tt.args.assetID,
 				tt.args.verifyCreds,
+			)
+			require.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestVerifyUnlockDepositedUTXOs(t *testing.T) {
+	tx := &dummyUnsignedTx{txs.BaseTx{}}
+	tx.SetBytes([]byte{0})
+	owner1, cred1 := generateOwnersAndSig(t, test.Keys[0], tx)
+	owner2, cred2 := generateOwnersAndSig(t, test.Keys[1], tx)
+	depositTxID1 := ids.ID{1}
+	depositTxID2 := ids.ID{2}
+	bondTxID1 := ids.ID{3}
+	bondTxID2 := ids.ID{4}
+
+	noMsigState := func(ctrl *gomock.Controller) *state.MockChain {
+		s := state.NewMockChain(ctrl)
+		s.EXPECT().GetMultisigAlias(gomock.Any()).Return(nil, database.ErrNotFound).AnyTimes()
+		return s
+	}
+
+	type args struct {
+		tx           txs.UnsignedTx
+		utxos        []*avax.UTXO
+		ins          []*avax.TransferableInput
+		outs         []*avax.TransferableOutput
+		creds        []verify.Verifiable
+		amountToBurn uint64
+		assetID      ids.ID
+	}
+	tests := map[string]struct {
+		handlerState func(ctrl *gomock.Controller) *state.MockChain
+		args         args
+		expectedErr  error
+	}{
+		"Number of inputs-utxos mismatch": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{{}, {}},
+				ins:   []*avax.TransferableInput{{}},
+			},
+			expectedErr: errInputsUTXOsMismatch,
+		},
+		"Number of inputs-credentials mismatch": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{{}},
+				ins:   []*avax.TransferableInput{{}},
+				creds: []verify.Verifiable{cred1, cred1},
+			},
+			expectedErr: errInputsCredentialsMismatch,
+		},
+		"Bad credential": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{{}},
+				ins:   []*avax.TransferableInput{{}},
+				creds: []verify.Verifiable{(*secp256k1fx.Credential)(nil)},
+			},
+			expectedErr: errBadCredentials,
+		},
+		"UTXO AssetID mismatch": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.OtherAssetID, 1, owner1, depositTxID1, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, depositTxID1, ids.Empty, []uint32{0}),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errAssetIDMismatch,
+		},
+		"Input AssetID mismatch": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 1, owner1, depositTxID1, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.OtherAssetID, 1, depositTxID1, ids.Empty, []uint32{0}),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errAssetIDMismatch,
+		},
+		"UTXO locked, but not deposited (e.g. just bonded)": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 1, owner1, ids.Empty, bondTxID1, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, ids.Empty, bondTxID1, []uint32{0}),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errUnlockingUnlockedUTXO,
+		},
+		"Input and utxo lock IDs mismatch: different depositTxIDs": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{
+					generate.UTXO(depositTxID1, test.AVAXAssetID, 1, owner1, depositTxID1, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, depositTxID2, ids.Empty, []uint32{0}),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errLockIDsMismatch,
+		},
+		"Input and utxo lock IDs mismatch: different bondTxIDs": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{
+					generate.UTXO(depositTxID1, test.AVAXAssetID, 1, owner1, depositTxID1, bondTxID1, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, depositTxID1, bondTxID2, []uint32{0}),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errLockIDsMismatch,
+		},
+		"Input and utxo lock IDs mismatch: utxo is locked, but input isn't locked": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 1, owner1, depositTxID1, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{0}),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errLockedFundsNotMarkedAsLocked,
+		},
+		"Input and utxo lock IDs mismatch: utxo isn't locked, but input is locked": {
+			handlerState: noMsigState,
+			args: args{
+				utxos: []*avax.UTXO{
+					generate.UTXO(depositTxID1, test.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, depositTxID1, ids.Empty, []uint32{0}),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errLockIDsMismatch,
+		},
+		"Wrong credential": {
+			handlerState: noMsigState,
+			args: args{
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 5, owner1, depositTxID1, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 5, depositTxID1, ids.Empty, []uint32{0}),
+				},
+				outs: []*avax.TransferableOutput{
+					generate.Out(test.AVAXAssetID, 5, owner1, ids.Empty, ids.Empty),
+				},
+				creds:   []verify.Verifiable{cred2},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errCantSpend,
+		},
+		"Not burned enough": {
+			handlerState: noMsigState,
+			args: args{
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 1, owner1, ids.Empty, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, ids.Empty, ids.Empty, []uint32{0}),
+				},
+				amountToBurn: 2,
+				creds:        []verify.Verifiable{cred1},
+				assetID:      test.AVAXAssetID,
+			},
+			expectedErr: errNotBurnedEnough,
+		},
+		"Produced unlocked more, than consumed deposited or unlocked": {
+			handlerState: noMsigState,
+			args: args{
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 1, owner1, depositTxID1, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, depositTxID1, ids.Empty, []uint32{0}),
+				},
+				outs: []*avax.TransferableOutput{
+					generate.Out(test.AVAXAssetID, 2, owner1, ids.Empty, ids.Empty),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errWrongProducedAmount,
+		},
+		"Consumed-produced amount mismatch (per lockIDs)": {
+			handlerState: noMsigState,
+			args: args{
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 1, owner1, depositTxID1, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, depositTxID1, ids.Empty, []uint32{0}),
+				},
+				outs: []*avax.TransferableOutput{
+					generate.Out(test.AVAXAssetID, 1, owner1, ids.Empty, bondTxID1),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errWrongProducedAmount,
+		},
+		"Consumed-produced amount mismatch (per ownerID, e.g. produced locked for different owner)": {
+			handlerState: noMsigState,
+			args: args{
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 1, owner1, depositTxID1, bondTxID1, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 1, depositTxID1, bondTxID1, []uint32{0}),
+				},
+				outs: []*avax.TransferableOutput{
+					generate.Out(test.AVAXAssetID, 1, owner2, ids.Empty, bondTxID1),
+				},
+				creds:   []verify.Verifiable{cred1},
+				assetID: test.AVAXAssetID,
+			},
+			expectedErr: errWrongProducedAmount,
+		},
+		"OK": {
+			handlerState: noMsigState,
+			args: args{
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 5, owner1, depositTxID1, ids.Empty, true),
+					generate.UTXO(ids.ID{101}, test.AVAXAssetID, 11, owner1, depositTxID1, bondTxID1, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 5, depositTxID1, ids.Empty, []uint32{0}),
+					generate.In(test.AVAXAssetID, 11, depositTxID1, bondTxID1, []uint32{0}),
+				},
+				outs: []*avax.TransferableOutput{
+					generate.Out(test.AVAXAssetID, 5, owner1, ids.Empty, ids.Empty),
+					generate.Out(test.AVAXAssetID, 11, owner1, ids.Empty, bondTxID1),
+				},
+				creds:   []verify.Verifiable{cred1, cred1},
+				assetID: test.AVAXAssetID,
+			},
+		},
+		"OK: with burn": {
+			handlerState: noMsigState,
+			args: args{
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 2, owner1, ids.Empty, ids.Empty, true),
+					generate.UTXO(ids.ID{102}, test.AVAXAssetID, 5, owner1, depositTxID1, ids.Empty, true),
+					generate.UTXO(ids.ID{103}, test.AVAXAssetID, 11, owner1, depositTxID1, bondTxID1, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 2, ids.Empty, ids.Empty, []uint32{0}),
+					generate.In(test.AVAXAssetID, 5, depositTxID1, ids.Empty, []uint32{0}),
+					generate.In(test.AVAXAssetID, 11, depositTxID1, bondTxID1, []uint32{0}),
+				},
+				outs: []*avax.TransferableOutput{
+					generate.Out(test.AVAXAssetID, 6, owner1, ids.Empty, ids.Empty),
+					generate.Out(test.AVAXAssetID, 11, owner1, ids.Empty, bondTxID1),
+				},
+				amountToBurn: 1,
+				creds:        []verify.Verifiable{cred1, cred1, cred1},
+				assetID:      test.AVAXAssetID,
+			},
+		},
+		"OK: with burn, partial unlock, no bond": {
+			handlerState: noMsigState,
+			args: args{
+				tx: tx,
+				utxos: []*avax.UTXO{
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 100, owner1, ids.Empty, ids.Empty, true), // TODO@ refactor to be able to call without bool
+					generate.UTXO(ids.ID{101}, test.AVAXAssetID, 50, owner1, depositTxID1, ids.Empty, true),
+				},
+				ins: []*avax.TransferableInput{
+					generate.In(test.AVAXAssetID, 100, ids.Empty, ids.Empty, []uint32{0}),
+					generate.In(test.AVAXAssetID, 50, depositTxID1, ids.Empty, []uint32{0}),
+				},
+				outs: []*avax.TransferableOutput{
+					generate.Out(test.AVAXAssetID, 10, owner1, ids.Empty, ids.Empty),
+					generate.Out(test.AVAXAssetID, 99, owner1, ids.Empty, ids.Empty),
+					generate.Out(test.AVAXAssetID, 40, owner1, depositTxID1, ids.Empty),
+				},
+				creds:        []verify.Verifiable{cred1, cred1},
+				amountToBurn: 1,
+				assetID:      test.AVAXAssetID,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			err := defaultCaminoHandler(t).verifyUnlockDepositedUTXOs(
+				tt.handlerState(ctrl),
+				tt.args.tx,
+				tt.args.utxos,
+				tt.args.ins,
+				tt.args.outs,
+				tt.args.creds,
+				tt.args.amountToBurn,
+				tt.args.assetID,
 			)
 			require.ErrorIs(t, err, tt.expectedErr)
 		})
@@ -1876,5 +2202,59 @@ func TestSortUTXOs(t *testing.T) {
 			// }
 			require.Equal(t, tt.expectedUTXOs(originalUTXOs), utxos)
 		})
+	}
+}
+
+// TODO@ move to api PR?
+// VerifyUnlockDepositedUTXOs requires outputs to be sorted exactly, that unlocked outs will go first
+func TestAVAXSortTransferableOutputsUnlockedFirst(t *testing.T) {
+	owner1 := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{{1}},
+	}
+	owner2 := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{{2}},
+	}
+	owner1And2 := secp256k1fx.OutputOwners{
+		Locktime:  0,
+		Threshold: 1,
+		Addrs:     []ids.ShortID{{1}, {2}},
+	}
+	depositTxID1 := ids.ID{3}
+	bondTxID1 := ids.ID{4}
+	depositTxID2 := ids.ID{5}
+	bondTxID2 := ids.ID{6}
+
+	outsWithLockIDs := func(depositTxID, bondTxID ids.ID) []*avax.TransferableOutput {
+		return []*avax.TransferableOutput{
+			generate.Out(test.AVAXAssetID, 1, owner1, depositTxID, bondTxID),
+			generate.Out(test.AVAXAssetID, 2, owner1, depositTxID, bondTxID),
+			generate.Out(test.AVAXAssetID, 1, owner2, depositTxID, bondTxID),
+			generate.Out(test.AVAXAssetID, 2, owner2, depositTxID, bondTxID),
+			generate.Out(test.AVAXAssetID, 1, owner1And2, depositTxID, bondTxID),
+			generate.Out(test.AVAXAssetID, 2, owner1And2, depositTxID, bondTxID),
+		}
+	}
+
+	outs := outsWithLockIDs(ids.Empty, ids.Empty)
+	outs = append(outs, outsWithLockIDs(depositTxID1, ids.Empty)...)
+	outs = append(outs, outsWithLockIDs(depositTxID2, ids.Empty)...)
+	outs = append(outs, outsWithLockIDs(ids.Empty, bondTxID1)...)
+	outs = append(outs, outsWithLockIDs(ids.Empty, bondTxID2)...)
+	outs = append(outs, outsWithLockIDs(depositTxID1, bondTxID1)...)
+	outs = append(outs, outsWithLockIDs(depositTxID1, bondTxID2)...)
+	outs = append(outs, outsWithLockIDs(depositTxID2, bondTxID1)...)
+	outs = append(outs, outsWithLockIDs(depositTxID2, bondTxID2)...)
+
+	avax.SortTransferableOutputs(outs, txs.Codec)
+
+	doneWithUnlockedOuts := false
+	for i, out := range outs {
+		_, isLocked := out.Out.(*locked.Out)
+		require.Truef(t, isLocked || !doneWithUnlockedOuts, "outs[%d] is locked, but there are unlocked outs after it", i-1)
+		doneWithUnlockedOuts = isLocked
 	}
 }

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -2205,7 +2205,6 @@ func TestSortUTXOs(t *testing.T) {
 	}
 }
 
-// TODO@ move to api PR?
 // VerifyUnlockDepositedUTXOs requires outputs to be sorted exactly, that unlocked outs will go first
 func TestAVAXSortTransferableOutputsUnlockedFirst(t *testing.T) {
 	owner1 := secp256k1fx.OutputOwners{

--- a/vms/platformvm/utxo/mock_verifier.go
+++ b/vms/platformvm/utxo/mock_verifier.go
@@ -101,15 +101,30 @@ func (mr *MockVerifierMockRecorder) VerifySpendUTXOs(arg0, arg1, arg2, arg3, arg
 }
 
 // VerifyUnlockDeposit mocks base method.
-func (m *MockVerifier) VerifyUnlockDeposit(arg0 avax.UTXOGetter, arg1 txs.UnsignedTx, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID, arg7 bool) error {
+func (m *MockVerifier) VerifyUnlockDeposit(arg0 avax.UTXOGetter, arg1 txs.UnsignedTx, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyUnlockDeposit", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "VerifyUnlockDeposit", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // VerifyUnlockDeposit indicates an expected call of VerifyUnlockDeposit.
-func (mr *MockVerifierMockRecorder) VerifyUnlockDeposit(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+func (mr *MockVerifierMockRecorder) VerifyUnlockDeposit(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUnlockDeposit", reflect.TypeOf((*MockVerifier)(nil).VerifyUnlockDeposit), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUnlockDeposit", reflect.TypeOf((*MockVerifier)(nil).VerifyUnlockDeposit), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+}
+
+
+// VerifyUnlockDepositBeforeCairo mocks base method.
+func (m *MockVerifier) VerifyUnlockDepositBeforeCairo(arg0 avax.UTXOGetter, arg1 txs.UnsignedTx, arg2 []*avax.TransferableInput, arg3 []*avax.TransferableOutput, arg4 []verify.Verifiable, arg5 uint64, arg6 ids.ID, arg7 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyUnlockDepositBeforeCairo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyUnlockDepositBeforeCairo indicates an expected call of VerifyUnlockDepositBeforeCairo.
+func (mr *MockVerifierMockRecorder) VerifyUnlockDepositBeforeCairo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyUnlockDepositBeforeCairo", reflect.TypeOf((*MockVerifier)(nil).VerifyUnlockDepositBeforeCairo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }


### PR DESCRIPTION
Introduces cleaner logic for verifying unlock deposited utxos flow.
New logic includes fix for valid UnlockDepositTxs that were failing because of bad utxos flow verification.  
Branches old logic with CairoPhase check.