### PR TITLE
Fix general proposal AddVote missing fields and add phase logic

### DIFF
--- a/vms/platformvm/dac/allowed_voters.go
+++ b/vms/platformvm/dac/allowed_voters.go
@@ -1,0 +1,24 @@
+package dac
+
+import (
+	"bytes"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"golang.org/x/exp/slices"
+)
+
+func excludeFromAllowedVoters(allowedVoters []ids.ShortID, voterAddress ids.ShortID) ([]ids.ShortID, error) {
+	voterAddrPos, allowedToVote := slices.BinarySearchFunc(allowedVoters, voterAddress, func(id, other ids.ShortID) int {
+		return bytes.Compare(id[:], other[:])
+	})
+	if !allowedToVote {
+		return nil, ErrNotAllowedToVoteOnProposal
+	}
+
+	// we can't use the same slice, cause we need to change its elements
+	updatedAllowedVoters := make([]ids.ShortID, len(allowedVoters)-1)
+	copy(updatedAllowedVoters, allowedVoters[:voterAddrPos])
+	updatedAllowedVoters = append(updatedAllowedVoters[:voterAddrPos], allowedVoters[voterAddrPos+1:]...)
+
+	return updatedAllowedVoters, nil
+}

--- a/vms/platformvm/dac/camino_add_member_proposal.go
+++ b/vms/platformvm/dac/camino_add_member_proposal.go
@@ -133,7 +133,7 @@ func (p *AddMemberProposalState) Result() (bool, uint32, bool) {
 }
 
 // Will return modified proposal with added vote, original proposal will not be modified!
-func (p *AddMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote) (ProposalState, error) {
+func (p *AddMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote

--- a/vms/platformvm/dac/camino_add_member_proposal.go
+++ b/vms/platformvm/dac/camino_add_member_proposal.go
@@ -4,13 +4,11 @@
 package dac
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
-	"golang.org/x/exp/slices"
 )
 
 const AddMemberProposalDuration = uint64(time.Hour * 24 * 30 * 2 / time.Second) // 2 month
@@ -134,54 +132,36 @@ func (p *AddMemberProposalState) Result() (bool, uint32, bool) {
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *AddMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	updatedProposal, err := p.addVote(voteIntf, isCairoPhase)
 	if err != nil {
 		return nil, err
 	}
-
-	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
-		return bytes.Compare(id[:], other[:])
-	})
-	if !allowedToVote {
-		return nil, ErrNotAllowedToVoteOnProposal
+	updatedProposal.AllowedVoters, err = excludeFromAllowedVoters(p.AllowedVoters, voterAddress)
+	if err != nil {
+		return nil, err
 	}
-
-	// we can't use the same slice, cause we need to change its elements
-	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
-	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
 func (p *AddMemberProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+	return p.addVote(voteIntf, isCairoPhase)
 }
 
-func (p *AddMemberProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*AddMemberProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+func (p *AddMemberProposalState) addVote(voteIntf Vote, _ bool) (*AddMemberProposalState, error) {
+	simpleVoteOptions, err := p.AddWeight(voteIntf)
+	if err != nil {
+		return nil, err
 	}
 
-	updatedProposal := &AddMemberProposalState{
-		ApplicantAddress: p.ApplicantAddress,
-		Start:            p.Start,
-		End:              p.End,
-		AllowedVoters:    allowedVoters,
-		SimpleVoteOptions: SimpleVoteOptions[bool]{
-			Options: make([]SimpleVoteOption[bool], len(p.Options)),
-		},
+	return &AddMemberProposalState{
+		ApplicantAddress:   p.ApplicantAddress,
+		Start:              p.Start,
+		End:                p.End,
+		AllowedVoters:      p.AllowedVoters,
+		SimpleVoteOptions:  *simpleVoteOptions,
 		TotalAllowedVoters: p.TotalAllowedVoters,
-	}
-
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
-	return updatedProposal, nil
+	}, nil
 }
 
 func (p *AddMemberProposalState) ExecuteWith(executor Executor) error {

--- a/vms/platformvm/dac/camino_add_member_proposal.go
+++ b/vms/platformvm/dac/camino_add_member_proposal.go
@@ -134,12 +134,9 @@ func (p *AddMemberProposalState) Result() (bool, uint32, bool) {
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *AddMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	if err != nil {
+		return nil, err
 	}
 
 	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
@@ -149,27 +146,19 @@ func (p *AddMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote
 		return nil, ErrNotAllowedToVoteOnProposal
 	}
 
-	updatedProposal := &AddMemberProposalState{
-		ApplicantAddress: p.ApplicantAddress,
-		Start:            p.Start,
-		End:              p.End,
-		AllowedVoters:    make([]ids.ShortID, len(p.AllowedVoters)-1),
-		SimpleVoteOptions: SimpleVoteOptions[bool]{
-			Options: make([]SimpleVoteOption[bool], len(p.Options)),
-		},
-		TotalAllowedVoters: p.TotalAllowedVoters,
-	}
 	// we can't use the same slice, cause we need to change its elements
 	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
 	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
+
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
-func (p *AddMemberProposalState) ForceAddVote(voteIntf Vote) (ProposalState, error) {
+func (p *AddMemberProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
+	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+}
+
+func (p *AddMemberProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*AddMemberProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote
@@ -182,12 +171,13 @@ func (p *AddMemberProposalState) ForceAddVote(voteIntf Vote) (ProposalState, err
 		ApplicantAddress: p.ApplicantAddress,
 		Start:            p.Start,
 		End:              p.End,
-		AllowedVoters:    p.AllowedVoters,
+		AllowedVoters:    allowedVoters,
 		SimpleVoteOptions: SimpleVoteOptions[bool]{
 			Options: make([]SimpleVoteOption[bool], len(p.Options)),
 		},
 		TotalAllowedVoters: p.TotalAllowedVoters,
 	}
+
 	// we can't use the same slice, cause we need to change its element
 	copy(updatedProposal.Options, p.Options)
 	updatedProposal.Options[vote.OptionIndex].Weight++

--- a/vms/platformvm/dac/camino_add_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_add_member_proposal_test.go
@@ -368,7 +368,7 @@ func TestAddMemberProposalStateAddVote(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote)
+			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote, true)
 			require.ErrorIs(t, err, tt.expectedErr)
 			require.Equal(t, tt.expectedUpdatedProposal, updatedProposal)
 			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)

--- a/vms/platformvm/dac/camino_allowed_voters.go
+++ b/vms/platformvm/dac/camino_allowed_voters.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2025, Chain4Travel AG. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package dac
 
 import (

--- a/vms/platformvm/dac/camino_base_fee_proposal.go
+++ b/vms/platformvm/dac/camino_base_fee_proposal.go
@@ -153,7 +153,7 @@ func (p *BaseFeeProposalState) Result() (uint64, uint32, bool) {
 }
 
 // Will return modified proposal with added vote, original proposal will not be modified!
-func (p *BaseFeeProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote) (ProposalState, error) {
+func (p *BaseFeeProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote

--- a/vms/platformvm/dac/camino_base_fee_proposal.go
+++ b/vms/platformvm/dac/camino_base_fee_proposal.go
@@ -4,7 +4,6 @@
 package dac
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"time"
@@ -12,7 +11,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
 	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
-	"golang.org/x/exp/slices"
 )
 
 const baseFeeProposalMaxOptionsCount = 3
@@ -154,53 +152,35 @@ func (p *BaseFeeProposalState) Result() (uint64, uint32, bool) {
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *BaseFeeProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	updatedProposal, err := p.addVote(voteIntf, isCairoPhase)
 	if err != nil {
 		return nil, err
 	}
-
-	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
-		return bytes.Compare(id[:], other[:])
-	})
-	if !allowedToVote {
-		return nil, ErrNotAllowedToVoteOnProposal
+	updatedProposal.AllowedVoters, err = excludeFromAllowedVoters(p.AllowedVoters, voterAddress)
+	if err != nil {
+		return nil, err
 	}
-
-	// we can't use the same slice, cause we need to change its elements
-	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
-	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
 func (p *BaseFeeProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+	return p.addVote(voteIntf, isCairoPhase)
 }
 
-func (p *BaseFeeProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*BaseFeeProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+func (p *BaseFeeProposalState) addVote(voteIntf Vote, _ bool) (*BaseFeeProposalState, error) {
+	simpleVoteOptions, err := p.AddWeight(voteIntf)
+	if err != nil {
+		return nil, err
 	}
 
-	updatedProposal := &BaseFeeProposalState{
-		Start:         p.Start,
-		End:           p.End,
-		AllowedVoters: allowedVoters,
-		SimpleVoteOptions: SimpleVoteOptions[uint64]{
-			Options: make([]SimpleVoteOption[uint64], len(p.Options)),
-		},
+	return &BaseFeeProposalState{
+		Start:              p.Start,
+		End:                p.End,
+		AllowedVoters:      p.AllowedVoters,
+		SimpleVoteOptions:  *simpleVoteOptions,
 		TotalAllowedVoters: p.TotalAllowedVoters,
-	}
-
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
-	return updatedProposal, nil
+	}, nil
 }
 
 func (p *BaseFeeProposalState) ExecuteWith(executor Executor) error {

--- a/vms/platformvm/dac/camino_base_fee_proposal.go
+++ b/vms/platformvm/dac/camino_base_fee_proposal.go
@@ -154,12 +154,9 @@ func (p *BaseFeeProposalState) Result() (uint64, uint32, bool) {
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *BaseFeeProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	if err != nil {
+		return nil, err
 	}
 
 	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
@@ -169,26 +166,19 @@ func (p *BaseFeeProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, 
 		return nil, ErrNotAllowedToVoteOnProposal
 	}
 
-	updatedProposal := &BaseFeeProposalState{
-		Start:         p.Start,
-		End:           p.End,
-		AllowedVoters: make([]ids.ShortID, len(p.AllowedVoters)-1),
-		SimpleVoteOptions: SimpleVoteOptions[uint64]{
-			Options: make([]SimpleVoteOption[uint64], len(p.Options)),
-		},
-		TotalAllowedVoters: p.TotalAllowedVoters,
-	}
 	// we can't use the same slice, cause we need to change its elements
 	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
 	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
+
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
-func (p *BaseFeeProposalState) ForceAddVote(voteIntf Vote) (ProposalState, error) {
+func (p *BaseFeeProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
+	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+}
+
+func (p *BaseFeeProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*BaseFeeProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote
@@ -200,12 +190,13 @@ func (p *BaseFeeProposalState) ForceAddVote(voteIntf Vote) (ProposalState, error
 	updatedProposal := &BaseFeeProposalState{
 		Start:         p.Start,
 		End:           p.End,
-		AllowedVoters: p.AllowedVoters,
+		AllowedVoters: allowedVoters,
 		SimpleVoteOptions: SimpleVoteOptions[uint64]{
 			Options: make([]SimpleVoteOption[uint64], len(p.Options)),
 		},
 		TotalAllowedVoters: p.TotalAllowedVoters,
 	}
+
 	// we can't use the same slice, cause we need to change its element
 	copy(updatedProposal.Options, p.Options)
 	updatedProposal.Options[vote.OptionIndex].Weight++

--- a/vms/platformvm/dac/camino_base_fee_proposal_test.go
+++ b/vms/platformvm/dac/camino_base_fee_proposal_test.go
@@ -432,7 +432,7 @@ func TestBaseFeeProposalStateAddVote(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote)
+			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote, true)
 			require.ErrorIs(t, err, tt.expectedErr)
 			require.Equal(t, tt.expectedUpdatedProposal, updatedProposal)
 			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)

--- a/vms/platformvm/dac/camino_exclude_member_proposal.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal.go
@@ -142,7 +142,7 @@ func (p *ExcludeMemberProposalState) Result() (bool, uint32, bool) {
 }
 
 // Will return modified proposal with added vote, original proposal will not be modified!
-func (p *ExcludeMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote) (ProposalState, error) {
+func (p *ExcludeMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote

--- a/vms/platformvm/dac/camino_exclude_member_proposal.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal.go
@@ -143,12 +143,9 @@ func (p *ExcludeMemberProposalState) Result() (bool, uint32, bool) {
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *ExcludeMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	if err != nil {
+		return nil, err
 	}
 
 	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
@@ -158,27 +155,19 @@ func (p *ExcludeMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf 
 		return nil, ErrNotAllowedToVoteOnProposal
 	}
 
-	updatedProposal := &ExcludeMemberProposalState{
-		MemberAddress: p.MemberAddress,
-		Start:         p.Start,
-		End:           p.End,
-		AllowedVoters: make([]ids.ShortID, len(p.AllowedVoters)-1),
-		SimpleVoteOptions: SimpleVoteOptions[bool]{
-			Options: make([]SimpleVoteOption[bool], len(p.Options)),
-		},
-		TotalAllowedVoters: p.TotalAllowedVoters,
-	}
 	// we can't use the same slice, cause we need to change its elements
 	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
 	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
+
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
-func (p *ExcludeMemberProposalState) ForceAddVote(voteIntf Vote) (ProposalState, error) {
+func (p *ExcludeMemberProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
+	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+}
+
+func (p *ExcludeMemberProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*ExcludeMemberProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote
@@ -191,12 +180,13 @@ func (p *ExcludeMemberProposalState) ForceAddVote(voteIntf Vote) (ProposalState,
 		MemberAddress: p.MemberAddress,
 		Start:         p.Start,
 		End:           p.End,
-		AllowedVoters: p.AllowedVoters,
+		AllowedVoters: allowedVoters,
 		SimpleVoteOptions: SimpleVoteOptions[bool]{
 			Options: make([]SimpleVoteOption[bool], len(p.Options)),
 		},
 		TotalAllowedVoters: p.TotalAllowedVoters,
 	}
+
 	// we can't use the same slice, cause we need to change its element
 	copy(updatedProposal.Options, p.Options)
 	updatedProposal.Options[vote.OptionIndex].Weight++

--- a/vms/platformvm/dac/camino_exclude_member_proposal.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal.go
@@ -4,13 +4,11 @@
 package dac
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
-	"golang.org/x/exp/slices"
 )
 
 const (
@@ -143,54 +141,36 @@ func (p *ExcludeMemberProposalState) Result() (bool, uint32, bool) {
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *ExcludeMemberProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	updatedProposal, err := p.addVote(voteIntf, isCairoPhase)
 	if err != nil {
 		return nil, err
 	}
-
-	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
-		return bytes.Compare(id[:], other[:])
-	})
-	if !allowedToVote {
-		return nil, ErrNotAllowedToVoteOnProposal
+	updatedProposal.AllowedVoters, err = excludeFromAllowedVoters(p.AllowedVoters, voterAddress)
+	if err != nil {
+		return nil, err
 	}
-
-	// we can't use the same slice, cause we need to change its elements
-	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
-	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
 func (p *ExcludeMemberProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+	return p.addVote(voteIntf, isCairoPhase)
 }
 
-func (p *ExcludeMemberProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*ExcludeMemberProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+func (p *ExcludeMemberProposalState) addVote(voteIntf Vote, _ bool) (*ExcludeMemberProposalState, error) {
+	simpleVoteOptions, err := p.AddWeight(voteIntf)
+	if err != nil {
+		return nil, err
 	}
 
-	updatedProposal := &ExcludeMemberProposalState{
-		MemberAddress: p.MemberAddress,
-		Start:         p.Start,
-		End:           p.End,
-		AllowedVoters: allowedVoters,
-		SimpleVoteOptions: SimpleVoteOptions[bool]{
-			Options: make([]SimpleVoteOption[bool], len(p.Options)),
-		},
+	return &ExcludeMemberProposalState{
+		MemberAddress:      p.MemberAddress,
+		Start:              p.Start,
+		End:                p.End,
+		AllowedVoters:      p.AllowedVoters,
+		SimpleVoteOptions:  *simpleVoteOptions,
 		TotalAllowedVoters: p.TotalAllowedVoters,
-	}
-
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
-	return updatedProposal, nil
+	}, nil
 }
 
 func (p *ExcludeMemberProposalState) ExecuteWith(executor Executor) error {

--- a/vms/platformvm/dac/camino_exclude_member_proposal_test.go
+++ b/vms/platformvm/dac/camino_exclude_member_proposal_test.go
@@ -378,7 +378,7 @@ func TestExcludeMemberProposalStateAddVote(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote)
+			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote, true)
 			require.ErrorIs(t, err, tt.expectedErr)
 			require.Equal(t, tt.expectedUpdatedProposal, updatedProposal)
 			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)

--- a/vms/platformvm/dac/camino_fee_distribution_proposal.go
+++ b/vms/platformvm/dac/camino_fee_distribution_proposal.go
@@ -166,7 +166,7 @@ func (p *FeeDistributionProposalState) Result() ([FeeDistributionFractionsCount]
 }
 
 // Will return modified proposal with added vote, original proposal will not be modified!
-func (p *FeeDistributionProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote) (ProposalState, error) {
+func (p *FeeDistributionProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote

--- a/vms/platformvm/dac/camino_fee_distribution_proposal.go
+++ b/vms/platformvm/dac/camino_fee_distribution_proposal.go
@@ -167,12 +167,9 @@ func (p *FeeDistributionProposalState) Result() ([FeeDistributionFractionsCount]
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *FeeDistributionProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	if err != nil {
+		return nil, err
 	}
 
 	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
@@ -182,26 +179,19 @@ func (p *FeeDistributionProposalState) AddVote(voterAddress ids.ShortID, voteInt
 		return nil, ErrNotAllowedToVoteOnProposal
 	}
 
-	updatedProposal := &FeeDistributionProposalState{
-		Start:         p.Start,
-		End:           p.End,
-		AllowedVoters: make([]ids.ShortID, len(p.AllowedVoters)-1),
-		SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
-			Options: make([]SimpleVoteOption[[FeeDistributionFractionsCount]uint64], len(p.Options)),
-		},
-		TotalAllowedVoters: p.TotalAllowedVoters,
-	}
 	// we can't use the same slice, cause we need to change its elements
 	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
 	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
+
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
-func (p *FeeDistributionProposalState) ForceAddVote(voteIntf Vote) (ProposalState, error) {
+func (p *FeeDistributionProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
+	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+}
+
+func (p *FeeDistributionProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*FeeDistributionProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote
@@ -213,12 +203,13 @@ func (p *FeeDistributionProposalState) ForceAddVote(voteIntf Vote) (ProposalStat
 	updatedProposal := &FeeDistributionProposalState{
 		Start:         p.Start,
 		End:           p.End,
-		AllowedVoters: p.AllowedVoters,
+		AllowedVoters: allowedVoters,
 		SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
 			Options: make([]SimpleVoteOption[[FeeDistributionFractionsCount]uint64], len(p.Options)),
 		},
 		TotalAllowedVoters: p.TotalAllowedVoters,
 	}
+
 	// we can't use the same slice, cause we need to change its element
 	copy(updatedProposal.Options, p.Options)
 	updatedProposal.Options[vote.OptionIndex].Weight++

--- a/vms/platformvm/dac/camino_fee_distribution_proposal.go
+++ b/vms/platformvm/dac/camino_fee_distribution_proposal.go
@@ -4,7 +4,6 @@
 package dac
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/set"
 	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
-	"golang.org/x/exp/slices"
 )
 
 const (
@@ -167,53 +165,35 @@ func (p *FeeDistributionProposalState) Result() ([FeeDistributionFractionsCount]
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *FeeDistributionProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	updatedProposal, err := p.addVote(voteIntf, isCairoPhase)
 	if err != nil {
 		return nil, err
 	}
-
-	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
-		return bytes.Compare(id[:], other[:])
-	})
-	if !allowedToVote {
-		return nil, ErrNotAllowedToVoteOnProposal
+	updatedProposal.AllowedVoters, err = excludeFromAllowedVoters(p.AllowedVoters, voterAddress)
+	if err != nil {
+		return nil, err
 	}
-
-	// we can't use the same slice, cause we need to change its elements
-	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
-	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
 func (p *FeeDistributionProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+	return p.addVote(voteIntf, isCairoPhase)
 }
 
-func (p *FeeDistributionProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*FeeDistributionProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+func (p *FeeDistributionProposalState) addVote(voteIntf Vote, _ bool) (*FeeDistributionProposalState, error) {
+	simpleVoteOptions, err := p.AddWeight(voteIntf)
+	if err != nil {
+		return nil, err
 	}
 
-	updatedProposal := &FeeDistributionProposalState{
-		Start:         p.Start,
-		End:           p.End,
-		AllowedVoters: allowedVoters,
-		SimpleVoteOptions: SimpleVoteOptions[[FeeDistributionFractionsCount]uint64]{
-			Options: make([]SimpleVoteOption[[FeeDistributionFractionsCount]uint64], len(p.Options)),
-		},
+	return &FeeDistributionProposalState{
+		Start:              p.Start,
+		End:                p.End,
+		AllowedVoters:      p.AllowedVoters,
+		SimpleVoteOptions:  *simpleVoteOptions,
 		TotalAllowedVoters: p.TotalAllowedVoters,
-	}
-
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
-	return updatedProposal, nil
+	}, nil
 }
 
 func (p *FeeDistributionProposalState) ExecuteWith(executor Executor) error {

--- a/vms/platformvm/dac/camino_fee_distribution_proposal_test.go
+++ b/vms/platformvm/dac/camino_fee_distribution_proposal_test.go
@@ -445,7 +445,7 @@ func TestFeeDistributionProposalStateAddVote(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote)
+			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote, true)
 			require.ErrorIs(t, err, tt.expectedErr)
 			require.Equal(t, tt.expectedUpdatedProposal, updatedProposal)
 			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)

--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -230,12 +230,9 @@ func (p *GeneralProposalState) Result() (types.JSONByteSlice, uint32, bool) {
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *GeneralProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	if err != nil {
+		return nil, err
 	}
 
 	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
@@ -245,43 +242,19 @@ func (p *GeneralProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, 
 		return nil, ErrNotAllowedToVoteOnProposal
 	}
 
-	var updatedProposal *GeneralProposalState
-	if isCairoPhase {
-		updatedProposal = &GeneralProposalState{
-			Start:         p.Start,
-			End:           p.End,
-			AllowedVoters: make([]ids.ShortID, len(p.AllowedVoters)-1),
-			SimpleVoteOptions: SimpleVoteOptions[[]byte]{
-				Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
-			},
-			TotalAllowedVoters:          p.TotalAllowedVoters,
-			AllowEarlyFinish:            p.AllowEarlyFinish,
-			TotalVotedThreshold:         p.TotalVotedThreshold,
-			MostVotedThresholdNominator: p.MostVotedThresholdNominator,
-		}
-	} else {
-		updatedProposal = &GeneralProposalState{
-			Start:         p.Start,
-			End:           p.End,
-			AllowedVoters: make([]ids.ShortID, len(p.AllowedVoters)-1),
-			SimpleVoteOptions: SimpleVoteOptions[[]byte]{
-				Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
-			},
-			TotalAllowedVoters: p.TotalAllowedVoters,
-		}
-	}
-
 	// we can't use the same slice, cause we need to change its elements
 	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
 	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
+
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
-func (p *GeneralProposalState) ForceAddVote(voteIntf Vote) (ProposalState, error) {
+func (p *GeneralProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
+	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+}
+
+func (p *GeneralProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*GeneralProposalState, error) {
 	vote, ok := voteIntf.(*SimpleVote)
 	if !ok {
 		return nil, ErrWrongVote
@@ -293,14 +266,16 @@ func (p *GeneralProposalState) ForceAddVote(voteIntf Vote) (ProposalState, error
 	updatedProposal := &GeneralProposalState{
 		Start:         p.Start,
 		End:           p.End,
-		AllowedVoters: p.AllowedVoters,
+		AllowedVoters: allowedVoters,
 		SimpleVoteOptions: SimpleVoteOptions[[]byte]{
 			Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
 		},
-		TotalAllowedVoters:          p.TotalAllowedVoters,
-		AllowEarlyFinish:            p.AllowEarlyFinish,
-		TotalVotedThreshold:         p.TotalVotedThreshold,
-		MostVotedThresholdNominator: p.MostVotedThresholdNominator,
+		TotalAllowedVoters: p.TotalAllowedVoters,
+	}
+	if isCairoPhase {
+		updatedProposal.AllowEarlyFinish = p.AllowEarlyFinish
+		updatedProposal.TotalVotedThreshold = p.TotalVotedThreshold
+		updatedProposal.MostVotedThresholdNominator = p.MostVotedThresholdNominator
 	}
 	// we can't use the same slice, cause we need to change its element
 	copy(updatedProposal.Options, p.Options)

--- a/vms/platformvm/dac/camino_general_proposal.go
+++ b/vms/platformvm/dac/camino_general_proposal.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
 	"github.com/ava-labs/avalanchego/vms/types"
-	"golang.org/x/exp/slices"
 )
 
 const (
@@ -230,46 +229,33 @@ func (p *GeneralProposalState) Result() (types.JSONByteSlice, uint32, bool) {
 
 // Will return modified proposal with added vote, original proposal will not be modified!
 func (p *GeneralProposalState) AddVote(voterAddress ids.ShortID, voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	updatedProposal, err := p.verifyVoteAndClone(voteIntf, make([]ids.ShortID, len(p.AllowedVoters)-1), isCairoPhase)
+	updatedProposal, err := p.addVote(voteIntf, isCairoPhase)
 	if err != nil {
 		return nil, err
 	}
-
-	voterAddrPos, allowedToVote := slices.BinarySearchFunc(p.AllowedVoters, voterAddress, func(id, other ids.ShortID) int {
-		return bytes.Compare(id[:], other[:])
-	})
-	if !allowedToVote {
-		return nil, ErrNotAllowedToVoteOnProposal
+	updatedProposal.AllowedVoters, err = excludeFromAllowedVoters(p.AllowedVoters, voterAddress)
+	if err != nil {
+		return nil, err
 	}
-
-	// we can't use the same slice, cause we need to change its elements
-	copy(updatedProposal.AllowedVoters, p.AllowedVoters[:voterAddrPos])
-	updatedProposal.AllowedVoters = append(updatedProposal.AllowedVoters[:voterAddrPos], p.AllowedVoters[voterAddrPos+1:]...)
-
 	return updatedProposal, nil
 }
 
 // Will return modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
 func (p *GeneralProposalState) ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error) {
-	return p.verifyVoteAndClone(voteIntf, p.AllowedVoters, isCairoPhase)
+	return p.addVote(voteIntf, isCairoPhase)
 }
 
-func (p *GeneralProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters []ids.ShortID, isCairoPhase bool) (*GeneralProposalState, error) {
-	vote, ok := voteIntf.(*SimpleVote)
-	if !ok {
-		return nil, ErrWrongVote
-	}
-	if int(vote.OptionIndex) >= len(p.Options) {
-		return nil, ErrWrongVote
+func (p *GeneralProposalState) addVote(voteIntf Vote, isCairoPhase bool) (*GeneralProposalState, error) {
+	simpleVoteOptions, err := p.AddWeight(voteIntf)
+	if err != nil {
+		return nil, err
 	}
 
 	updatedProposal := &GeneralProposalState{
-		Start:         p.Start,
-		End:           p.End,
-		AllowedVoters: allowedVoters,
-		SimpleVoteOptions: SimpleVoteOptions[[]byte]{
-			Options: make([]SimpleVoteOption[[]byte], len(p.Options)),
-		},
+		Start:              p.Start,
+		End:                p.End,
+		AllowedVoters:      p.AllowedVoters,
+		SimpleVoteOptions:  *simpleVoteOptions,
 		TotalAllowedVoters: p.TotalAllowedVoters,
 	}
 	if isCairoPhase {
@@ -277,9 +263,7 @@ func (p *GeneralProposalState) verifyVoteAndClone(voteIntf Vote, allowedVoters [
 		updatedProposal.TotalVotedThreshold = p.TotalVotedThreshold
 		updatedProposal.MostVotedThresholdNominator = p.MostVotedThresholdNominator
 	}
-	// we can't use the same slice, cause we need to change its element
-	copy(updatedProposal.Options, p.Options)
-	updatedProposal.Options[vote.OptionIndex].Weight++
+
 	return updatedProposal, nil
 }
 

--- a/vms/platformvm/dac/camino_general_proposal_test.go
+++ b/vms/platformvm/dac/camino_general_proposal_test.go
@@ -266,6 +266,7 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 		proposal                 *GeneralProposalState
 		voterAddr                ids.ShortID
 		vote                     Vote
+		isCairoPhase             bool
 		expectedUpdatedProposal  ProposalState
 		expectedOriginalProposal *GeneralProposalState
 		expectedErr              error
@@ -286,6 +287,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 					mostVotedOptionIndex: 0,
 					unambiguous:          true,
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			voterAddr: voterAddr1,
 			vote:      &DummyVote{}, // not *SimpleVote
@@ -304,6 +308,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 					mostVotedOptionIndex: 0,
 					unambiguous:          true,
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			expectedErr: ErrWrongVote,
 		},
@@ -323,6 +330,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 					mostVotedOptionIndex: 0,
 					unambiguous:          true,
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			voterAddr: ids.ShortID{3},
 			vote:      &SimpleVote{OptionIndex: 3},
@@ -341,6 +351,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 					mostVotedOptionIndex: 0,
 					unambiguous:          true,
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			expectedErr: ErrWrongVote,
 		},
@@ -350,6 +363,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
 					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			voterAddr: ids.ShortID{3},
 			vote:      &SimpleVote{OptionIndex: 0},
@@ -358,6 +374,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
 					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			expectedErr: ErrNotAllowedToVoteOnProposal,
 		},
@@ -377,6 +396,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 					mostVotedOptionIndex: 0,
 					unambiguous:          true,
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			voterAddr: voterAddr1,
 			vote:      &SimpleVote{OptionIndex: 1},
@@ -392,6 +414,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 						{Value: []byte{3}, Weight: 1}, // 2
 					},
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			expectedOriginalProposal: &GeneralProposalState{
 				Start:              100,
@@ -408,6 +433,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 					mostVotedOptionIndex: 0,
 					unambiguous:          true,
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 		},
 		"OK: adding vote to already voted option": {
@@ -426,6 +454,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 					mostVotedOptionIndex: 0,
 					unambiguous:          true,
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			voterAddr: voterAddr1,
 			vote:      &SimpleVote{OptionIndex: 2},
@@ -441,6 +472,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 						{Value: []byte{3}, Weight: 2}, // 2
 					},
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			expectedOriginalProposal: &GeneralProposalState{
 				Start:              100,
@@ -457,6 +491,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 					mostVotedOptionIndex: 0,
 					unambiguous:          true,
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 		},
 		"OK: voter addr in the middle of allowedVoters array": {
@@ -468,6 +505,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
 					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			voterAddr: voterAddr2,
 			vote:      &SimpleVote{OptionIndex: 0},
@@ -479,6 +519,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
 					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}, Weight: 1}},
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 			expectedOriginalProposal: &GeneralProposalState{
 				Start:              100,
@@ -488,12 +531,15 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
 					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
 				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
 			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote)
+			updatedProposal, err := tt.proposal.AddVote(tt.voterAddr, tt.vote, tt.isCairoPhase)
 			require.ErrorIs(t, err, tt.expectedErr)
 			require.Equal(t, tt.expectedUpdatedProposal, updatedProposal)
 			require.Equal(t, tt.expectedOriginalProposal, tt.proposal)

--- a/vms/platformvm/dac/camino_general_proposal_test.go
+++ b/vms/platformvm/dac/camino_general_proposal_test.go
@@ -291,8 +291,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				MostVotedThresholdNominator: 2,
 				AllowEarlyFinish:            true,
 			},
-			voterAddr: voterAddr1,
-			vote:      &DummyVote{}, // not *SimpleVote
+			voterAddr:    voterAddr1,
+			vote:         &DummyVote{}, // not *SimpleVote
+			isCairoPhase: true,
 			expectedOriginalProposal: &GeneralProposalState{
 				Start:              100,
 				End:                101,
@@ -334,8 +335,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				MostVotedThresholdNominator: 2,
 				AllowEarlyFinish:            true,
 			},
-			voterAddr: ids.ShortID{3},
-			vote:      &SimpleVote{OptionIndex: 3},
+			voterAddr:    ids.ShortID{3},
+			vote:         &SimpleVote{OptionIndex: 3},
+			isCairoPhase: true,
 			expectedOriginalProposal: &GeneralProposalState{
 				Start:              100,
 				End:                101,
@@ -367,8 +369,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				MostVotedThresholdNominator: 2,
 				AllowEarlyFinish:            true,
 			},
-			voterAddr: ids.ShortID{3},
-			vote:      &SimpleVote{OptionIndex: 0},
+			voterAddr:    ids.ShortID{3},
+			vote:         &SimpleVote{OptionIndex: 0},
+			isCairoPhase: true,
 			expectedOriginalProposal: &GeneralProposalState{
 				AllowedVoters: []ids.ShortID{{1}, {2}},
 				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
@@ -400,8 +403,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				MostVotedThresholdNominator: 2,
 				AllowEarlyFinish:            true,
 			},
-			voterAddr: voterAddr1,
-			vote:      &SimpleVote{OptionIndex: 1},
+			voterAddr:    voterAddr1,
+			vote:         &SimpleVote{OptionIndex: 1},
+			isCairoPhase: true,
 			expectedUpdatedProposal: &GeneralProposalState{
 				Start:              100,
 				End:                101,
@@ -458,8 +462,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				MostVotedThresholdNominator: 2,
 				AllowEarlyFinish:            true,
 			},
-			voterAddr: voterAddr1,
-			vote:      &SimpleVote{OptionIndex: 2},
+			voterAddr:    voterAddr1,
+			vote:         &SimpleVote{OptionIndex: 2},
+			isCairoPhase: true,
 			expectedUpdatedProposal: &GeneralProposalState{
 				Start:              100,
 				End:                101,
@@ -509,8 +514,9 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				MostVotedThresholdNominator: 2,
 				AllowEarlyFinish:            true,
 			},
-			voterAddr: voterAddr2,
-			vote:      &SimpleVote{OptionIndex: 0},
+			voterAddr:    voterAddr2,
+			vote:         &SimpleVote{OptionIndex: 0},
+			isCairoPhase: true,
 			expectedUpdatedProposal: &GeneralProposalState{
 				Start:              100,
 				End:                101,
@@ -530,6 +536,62 @@ func TestGeneralProposalStateAddVote(t *testing.T) {
 				AllowedVoters:      []ids.ShortID{voterAddr1, voterAddr2, voterAddr3},
 				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
 					Options: []SimpleVoteOption[[]byte]{{Value: []byte{1}}},
+				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
+			},
+		},
+		"OK: adding vote before CairoPhase": {
+			proposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
+				},
+				TotalVotedThreshold:         1,
+				MostVotedThresholdNominator: 2,
+				AllowEarlyFinish:            true,
+			},
+			voterAddr:    voterAddr1,
+			vote:         &SimpleVote{OptionIndex: 1},
+			isCairoPhase: false,
+			expectedUpdatedProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 1}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+				},
+			},
+			expectedOriginalProposal: &GeneralProposalState{
+				Start:              100,
+				End:                101,
+				TotalAllowedVoters: 555,
+				AllowedVoters:      []ids.ShortID{voterAddr1},
+				SimpleVoteOptions: SimpleVoteOptions[[]byte]{
+					Options: []SimpleVoteOption[[]byte]{
+						{Value: []byte{1}, Weight: 2}, // 0
+						{Value: []byte{2}, Weight: 0}, // 1
+						{Value: []byte{3}, Weight: 1}, // 2
+					},
+					mostVotedWeight:      2,
+					mostVotedOptionIndex: 0,
+					unambiguous:          true,
 				},
 				TotalVotedThreshold:         1,
 				MostVotedThresholdNominator: 2,

--- a/vms/platformvm/dac/camino_proposal.go
+++ b/vms/platformvm/dac/camino_proposal.go
@@ -87,7 +87,7 @@ type ProposalState interface {
 	// Visits getter and returns additional lock tx ids, that should be unbonded when this proposal is successfully finished.
 	GetBondTxIDsWith(BondTxIDsGetter) ([]ids.ID, error)
 	// Will return modified ProposalState with added vote, original ProposalState will not be modified!
-	AddVote(voterAddress ids.ShortID, vote Vote) (ProposalState, error)
+	AddVote(voterAddress ids.ShortID, vote Vote, isCairoPhase bool) (ProposalState, error)
 
 	// Returns modified proposal with added vote ignoring allowed voters, original proposal will not be modified!
 	// (used in magellan)

--- a/vms/platformvm/dac/camino_proposal.go
+++ b/vms/platformvm/dac/camino_proposal.go
@@ -95,7 +95,7 @@ type ProposalState interface {
 	// We want to keep it in caminogo even if its used only in magellan,
 	// cause it contains internal proposal logic that affects success state.
 	// We don't want to care about that in magellan.
-	ForceAddVote(voteIntf Vote) (ProposalState, error)
+	ForceAddVote(voteIntf Vote, isCairoPhase bool) (ProposalState, error)
 }
 
 type AdminProposal struct {

--- a/vms/platformvm/dac/camino_simple_vote.go
+++ b/vms/platformvm/dac/camino_simple_vote.go
@@ -29,20 +29,20 @@ type SimpleVoteOptions[T any] struct {
 	unambiguous          bool                  // True, if there is an option with weight > then other options weight
 }
 
-func (p SimpleVoteOptions[T]) GetMostVoted() (
+func (vo SimpleVoteOptions[T]) GetMostVoted() (
 	mostVotedWeight uint32,
 	mostVotedIndex uint32,
 	unambiguous bool,
 ) {
-	if p.mostVotedWeight != 0 {
-		return p.mostVotedWeight, p.mostVotedOptionIndex, p.unambiguous
+	if vo.mostVotedWeight != 0 {
+		return vo.mostVotedWeight, vo.mostVotedOptionIndex, vo.unambiguous
 	}
 
 	unambiguous = true
 	mostVotedIndexInt := 0
-	weights := make([]int, len(p.Options))
-	for optionIndex := range p.Options {
-		weights[optionIndex] += int(p.Options[optionIndex].Weight)
+	weights := make([]int, len(vo.Options))
+	for optionIndex := range vo.Options {
+		weights[optionIndex] += int(vo.Options[optionIndex].Weight)
 		if optionIndex != mostVotedIndexInt && weights[optionIndex] == weights[mostVotedIndexInt] {
 			unambiguous = false
 		} else if weights[optionIndex] > weights[mostVotedIndexInt] {
@@ -51,17 +51,38 @@ func (p SimpleVoteOptions[T]) GetMostVoted() (
 		}
 	}
 
-	p.mostVotedWeight = uint32(weights[mostVotedIndexInt])
-	p.mostVotedOptionIndex = uint32(mostVotedIndexInt)
-	p.unambiguous = unambiguous && p.mostVotedWeight > 0
+	vo.mostVotedWeight = uint32(weights[mostVotedIndexInt])
+	vo.mostVotedOptionIndex = uint32(mostVotedIndexInt)
+	vo.unambiguous = unambiguous && vo.mostVotedWeight > 0
 
-	return p.mostVotedWeight, p.mostVotedOptionIndex, p.unambiguous
+	return vo.mostVotedWeight, vo.mostVotedOptionIndex, vo.unambiguous
 }
 
-func (p SimpleVoteOptions[T]) Voted() uint32 {
+func (vo SimpleVoteOptions[T]) Voted() uint32 {
 	voted := uint32(0)
-	for i := range p.Options {
-		voted += p.Options[i].Weight
+	for i := range vo.Options {
+		voted += vo.Options[i].Weight
 	}
 	return voted
+}
+
+// Will not modify original simple vote options
+func (vo SimpleVoteOptions[T]) AddWeight(voteIntf Vote) (*SimpleVoteOptions[T], error) {
+	vote, ok := voteIntf.(*SimpleVote)
+	if !ok {
+		return nil, ErrWrongVote
+	}
+	if int(vote.OptionIndex) >= len(vo.Options) {
+		return nil, ErrWrongVote
+	}
+
+	updatedSimpleVoteOptions := &SimpleVoteOptions[T]{
+		Options: make([]SimpleVoteOption[T], len(vo.Options)),
+	}
+
+	// we can't use the same slice, because we need to change its element
+	copy(updatedSimpleVoteOptions.Options, vo.Options)
+	updatedSimpleVoteOptions.Options[vote.OptionIndex].Weight++
+
+	return updatedSimpleVoteOptions, nil
 }

--- a/vms/platformvm/test/camino_defaults.go
+++ b/vms/platformvm/test/camino_defaults.go
@@ -85,6 +85,7 @@ func Config(t *testing.T, phase Phase) *config.Config {
 
 	activePhases := []Phase{}
 
+	// collect all active phases in reverse order from last to first
 	switch phase {
 	case PhaseD:
 		activePhases = append(activePhases, PhaseD)
@@ -108,6 +109,7 @@ func Config(t *testing.T, phase Phase) *config.Config {
 		require.FailNowf(t, "", "unknown phase %d (%s)", phase)
 	}
 
+	// set phaseTime to phases from first to last in order to introduce time gaps between them.
 	for i := len(activePhases) - 1; i >= 0; i-- {
 		switch activePhases[i] {
 		case PhaseApricot5:

--- a/vms/platformvm/txs/builder/camino_builder_test.go
+++ b/vms/platformvm/txs/builder/camino_builder_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/vms/components/avax"
-	as "github.com/ava-labs/avalanchego/vms/platformvm/addrstate"
 	"github.com/ava-labs/avalanchego/vms/platformvm/api"
-	"github.com/ava-labs/avalanchego/vms/platformvm/config"
 	"github.com/ava-labs/avalanchego/vms/platformvm/dac"
 	"github.com/ava-labs/avalanchego/vms/platformvm/fx"
 	"github.com/ava-labs/avalanchego/vms/platformvm/locked"
@@ -34,117 +32,6 @@ import (
 
 	deposits "github.com/ava-labs/avalanchego/vms/platformvm/deposit"
 )
-
-// only tests pre-berlin upgrade version 0
-func TestNewAddressStateTx(t *testing.T) {
-	ctx := test.Context(t)
-
-	fundsKey := test.FundedKeys[0]
-	fundsAddr := fundsKey.Address()
-	fundsOwner := secp256k1fx.OutputOwners{Threshold: 1, Addrs: []ids.ShortID{fundsAddr}}
-
-	otherAddr := ids.ShortID{1, 1}
-
-	feeUTXO := generate.UTXO(ids.ID{1}, ctx.AVAXAssetID, test.TxFee, fundsOwner, ids.Empty, ids.Empty, false)
-
-	baseTx := txs.BaseTx{BaseTx: avax.BaseTx{
-		NetworkID:    ctx.NetworkID,
-		BlockchainID: ctx.ChainID,
-		Ins: []*avax.TransferableInput{
-			generate.InFromUTXO(t, feeUTXO, []uint32{0}, false),
-		},
-		Outs: []*avax.TransferableOutput{},
-	}}
-
-	tests := map[string]struct {
-		state       func(*gomock.Controller, *config.Config) state.State
-		targetAddr  ids.ShortID
-		remove      bool
-		stateBit    as.AddressStateBit
-		executor    ids.ShortID
-		keys        []*secp256k1.PrivateKey
-		change      *secp256k1fx.OutputOwners
-		utx         *txs.AddressStateTx
-		signers     [][]*secp256k1.PrivateKey
-		expectedErr error
-	}{
-		"Empty address": {
-			state: func(ctrl *gomock.Controller, cfg *config.Config) state.State {
-				s := state.NewMockState(ctrl)
-				expect.Lock(t, s, map[ids.ShortID][]*avax.UTXO{fundsAddr: {feeUTXO}})
-				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, test.PhaseLast, cfg))
-				return s
-			},
-			stateBit:    as.AddressStateBitKYCVerified,
-			keys:        []*secp256k1.PrivateKey{fundsKey},
-			signers:     [][]*secp256k1.PrivateKey{{fundsKey}},
-			expectedErr: errEmptyAddress,
-		},
-		"OK": {
-			state: func(ctrl *gomock.Controller, cfg *config.Config) state.State {
-				s := state.NewMockState(ctrl)
-				expect.Lock(t, s, map[ids.ShortID][]*avax.UTXO{fundsAddr: {feeUTXO}})
-				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, test.PhaseLast, cfg))
-				return s
-			},
-			targetAddr: otherAddr,
-			stateBit:   as.AddressStateBitKYCVerified,
-			keys:       []*secp256k1.PrivateKey{fundsKey},
-			utx: &txs.AddressStateTx{
-				BaseTx:   baseTx,
-				Address:  otherAddr,
-				StateBit: as.AddressStateBitKYCVerified,
-			},
-			signers: [][]*secp256k1.PrivateKey{{fundsKey}},
-		},
-		"OK: remove": {
-			state: func(ctrl *gomock.Controller, cfg *config.Config) state.State {
-				s := state.NewMockState(ctrl)
-				expect.Lock(t, s, map[ids.ShortID][]*avax.UTXO{fundsAddr: {feeUTXO}})
-				s.EXPECT().GetTimestamp().Return(test.PhaseTime(t, test.PhaseLast, cfg))
-				return s
-			},
-			targetAddr: otherAddr,
-			remove:     true,
-			stateBit:   as.AddressStateBitKYCVerified,
-			keys:       []*secp256k1.PrivateKey{fundsKey},
-			utx: &txs.AddressStateTx{
-				BaseTx:   baseTx,
-				Address:  otherAddr,
-				StateBit: as.AddressStateBitKYCVerified,
-				Remove:   true,
-			},
-			signers: [][]*secp256k1.PrivateKey{{fundsKey}},
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			require := require.New(t)
-			ctrl := gomock.NewController(t)
-			// only tests pre-berlin upgrade version 0
-
-			b := newCaminoBuilder(t, tt.state(ctrl, test.Config(t, test.PhaseLast)), nil, test.PhaseAthens)
-
-			tx, err := b.NewAddressStateTx(
-				tt.targetAddr,
-				tt.remove,
-				tt.stateBit,
-				tt.executor,
-				tt.keys,
-				tt.change,
-			)
-			require.ErrorIs(err, tt.expectedErr)
-			if err != nil {
-				require.Nil(tx)
-				return
-			}
-			expectedTx, err := txs.NewSigned(tt.utx, txs.Codec, tt.signers)
-			require.NoError(err)
-			require.NoError(expectedTx.SyntacticVerify(b.ctx))
-			require.Equal(expectedTx, tx)
-		})
-	}
-}
 
 func TestNewAddSubnetValidatorTx(t *testing.T) {
 	ctx := test.Context(t)

--- a/vms/platformvm/txs/builder/camino_helpers_test.go
+++ b/vms/platformvm/txs/builder/camino_helpers_test.go
@@ -22,7 +22,7 @@ func newCaminoBuilder(
 	t *testing.T,
 	state state.State,
 	sharedMemory atomic.SharedMemory,
-	phase test.Phase,
+	phase test.Phase, //nolint:unparam
 ) *caminoBuilder {
 	t.Helper()
 

--- a/vms/platformvm/txs/executor/camino_tx_executor.go
+++ b/vms/platformvm/txs/executor/camino_tx_executor.go
@@ -2221,7 +2221,7 @@ func (e *CaminoStandardTxExecutor) AddVoteTx(tx *txs.AddVoteTx) error {
 		return err
 	}
 
-	updatedProposal, err := proposal.AddVote(tx.VoterAddress, vote)
+	updatedProposal, err := proposal.AddVote(tx.VoterAddress, vote, e.Config.IsCairoPhaseActivated(chainTime))
 	if err != nil {
 		return err
 	}

--- a/vms/platformvm/utxo/camino_locked_test.go
+++ b/vms/platformvm/utxo/camino_locked_test.go
@@ -2033,7 +2033,7 @@ func TestVerifyUnlockDepositedUTXOs(t *testing.T) {
 			args: args{
 				tx: tx,
 				utxos: []*avax.UTXO{
-					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 100, owner1, ids.Empty, ids.Empty, true), // TODO@ refactor to be able to call without bool
+					generate.UTXO(ids.ID{100}, test.AVAXAssetID, 100, owner1, ids.Empty, ids.Empty, true),
 					generate.UTXO(ids.ID{101}, test.AVAXAssetID, 50, owner1, depositTxID1, ids.Empty, true),
 				},
 				ins: []*avax.TransferableInput{


### PR DESCRIPTION
## Why this should be merged
Initial implementation of general proposal had a bug, where some fields of proposal state were lost during voting.
https://github.com/chain4travel/caminogo/pull/406 fixed one of fields.
This (413) PR fixes remaining fields, adds tests to confirm fix and refactors proposals code to reduce code duplication.
PR also wraps those fixes into phase.

## How this works
Transport all missing fields, add isCairoPhase arg, to branch logic if true, transport fields, if not - do not.
Refactoring moves duplicated code to new func and simpleVoteOptions method.
Platforvm test package phase time is updated, so phases will have some time gap between them - that is required by some of the test cases and just makes more sense. 

## How this was tested
Unit-tests.